### PR TITLE
check if image before check if url in share extension

### DIFF
--- a/apps/expo/targets/share/ShareViewController.swift
+++ b/apps/expo/targets/share/ShareViewController.swift
@@ -19,10 +19,10 @@ class ShareViewController: UIViewController {
     Task {
       if firstAttachment.hasItemConformingToTypeIdentifier("public.text") {
         await self.handleText(item: firstAttachment)
-      } else if firstAttachment.hasItemConformingToTypeIdentifier("public.url") {
-        await self.handleUrl(item: firstAttachment)
       } else if firstAttachment.hasItemConformingToTypeIdentifier("public.image") {
         await self.handleImage(item: firstAttachment)
+      } else if firstAttachment.hasItemConformingToTypeIdentifier("public.url") {
+        await self.handleUrl(item: firstAttachment)
       } else {
         self.completeRequest()
       }


### PR DESCRIPTION
this fixes a bug where for some images would show up as links by checking if something is a url _last_ so that if something can be both a link and an image it is used as an image.

for example, open a photo in an imessage thread and then share to soonlist. this bug was present in the in the bluesky code that was adapted for the share extension.

