### PR TITLE
 Simplify Media Permissions and Photo Selection in Expo Application

### DIFF
--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from "react";
 import {
   ActivityIndicator,
   Dimensions,
+  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -67,7 +68,7 @@ const PhotoGrid = React.memo(
     onDescribePress: () => void;
     onMorePhotos: () => void;
   }) => {
-    if (!hasMediaPermission || recentPhotos.length === 0) {
+    if (!hasMediaPermission) {
       const windowWidth = Dimensions.get("window").width;
       const padding = 32;
       const spacing = 2;
@@ -129,47 +130,56 @@ const PhotoGrid = React.memo(
         </View>
 
         <View className="flex-1 bg-transparent">
-          <FlashList
-            data={recentPhotos}
-            renderItem={({ item }) => (
-              <Pressable
-                onPress={() => onPhotoSelect(item.uri)}
-                style={{
-                  width: imageSize,
-                  height: imageSize,
-                  margin: spacing / 2,
-                }}
-              >
-                <ExpoImage
-                  source={{ uri: item.uri }}
+          <FlatList
+            data={[{ id: "plus-button", uri: "" }, ...recentPhotos]}
+            renderItem={({ item }) => {
+              if (item.id === "plus-button") {
+                return (
+                  <Pressable
+                    onPress={onMorePhotos}
+                    style={{
+                      width: imageSize,
+                      height: imageSize,
+                      margin: spacing / 2,
+                    }}
+                    className="items-center justify-center rounded-md bg-white"
+                  >
+                    <Plus size={20} color="#5A32FB" />
+                  </Pressable>
+                );
+              }
+
+              return (
+                <Pressable
+                  onPress={() => onPhotoSelect(item.uri)}
                   style={{
-                    width: "100%",
-                    height: "100%",
-                    borderRadius: 4,
+                    width: imageSize,
+                    height: imageSize,
+                    margin: spacing / 2,
                   }}
-                  contentFit="cover"
-                  contentPosition="center"
-                  transition={100}
-                  cachePolicy="memory"
-                />
-              </Pressable>
-            )}
+                >
+                  <ExpoImage
+                    source={{ uri: item.uri }}
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      borderRadius: 4,
+                    }}
+                    contentFit="cover"
+                    contentPosition="center"
+                    transition={100}
+                    cachePolicy="memory"
+                  />
+                </Pressable>
+              );
+            }}
             numColumns={4}
-            estimatedItemSize={imageSize}
             showsVerticalScrollIndicator={false}
             contentContainerStyle={{
               padding: spacing / 2,
             }}
-            estimatedListSize={{
-              height: imageSize * 3 + spacing * 2,
-              width: windowWidth - padding,
-            }}
             keyExtractor={(item) => item.id}
             horizontal={false}
-            overrideItemLayout={(layout, _item) => {
-              layout.size = imageSize;
-              layout.span = 1;
-            }}
           />
         </View>
       </View>
@@ -436,7 +446,7 @@ export default function NewEventModal() {
   const loadRecentPhotos = useCallback(async () => {
     try {
       const { assets } = await MediaLibrary.getAssetsAsync({
-        first: 16,
+        first: 15,
         sortBy: MediaLibrary.SortBy.creationTime,
         mediaType: [MediaLibrary.MediaType.photo],
       });

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -20,7 +20,6 @@ import * as MediaLibrary from "expo-media-library";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 import { useFocusEffect } from "@react-navigation/native";
-import { FlashList } from "@shopify/flash-list";
 import {
   Camera,
   ChevronRight,
@@ -55,7 +54,6 @@ const styles = StyleSheet.create({
 
 const PhotoGrid = React.memo(
   ({
-    hasMediaPermission,
     recentPhotos,
     onPhotoSelect,
     onCameraPress,

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -23,6 +23,7 @@ import {
   Camera,
   ChevronRight,
   Link as LinkIcon,
+  Plus,
   Sparkles,
   Type,
   X,
@@ -74,37 +75,21 @@ const PhotoGrid = React.memo(
       const availableWidth = windowWidth - padding;
       const imageSize = (availableWidth - (columns - 1) * spacing) / columns;
 
-      async function handleGrantAccess() {
-        try {
-          const { status } = await MediaLibrary.requestPermissionsAsync();
-          useAppStore.setState({
-            hasMediaPermission:
-              status === MediaLibrary.PermissionStatus.GRANTED,
-          });
-          if (status === MediaLibrary.PermissionStatus.GRANTED) {
-            await onMorePhotos();
-          }
-        } catch (err) {
-          toast.error("Unable to request access to photos.");
-          console.error(err);
-        }
-      }
-
       return (
         <View
           className="flex-row flex-wrap"
           style={{ height: imageSize * 3 + spacing * 2 }}
         >
           <Pressable
-            onPress={handleGrantAccess}
+            onPress={onMorePhotos}
             style={{
               width: imageSize,
               height: imageSize,
               margin: spacing / 2,
             }}
-            className="items-center justify-center rounded-md bg-interactive-3"
+            className="items-center justify-center rounded-md bg-white"
           >
-            <Text className="text-sm font-medium text-white">Grant Access</Text>
+            <Plus size={20} color="#5A32FB" />
           </Pressable>
         </View>
       );

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -67,7 +67,7 @@ const PhotoGrid = React.memo(
     onDescribePress: () => void;
     onMorePhotos: () => void;
   }) => {
-    if (!hasMediaPermission) {
+    if (!hasMediaPermission || recentPhotos.length === 0) {
       const windowWidth = Dimensions.get("window").width;
       const padding = 32;
       const spacing = 2;
@@ -94,8 +94,6 @@ const PhotoGrid = React.memo(
         </View>
       );
     }
-
-    if (!hasMediaPermission || recentPhotos.length === 0) return null;
 
     const windowWidth = Dimensions.get("window").width;
     const padding = 32;
@@ -460,6 +458,7 @@ export default function NewEventModal() {
 
   useEffect(() => {
     if (shouldRefreshMediaLibrary) {
+      clearPreview();
       void loadRecentPhotos();
       setShouldRefreshMediaLibrary(false);
     }
@@ -467,6 +466,7 @@ export default function NewEventModal() {
     shouldRefreshMediaLibrary,
     loadRecentPhotos,
     setShouldRefreshMediaLibrary,
+    clearPreview,
   ]);
 
   useEffect(() => {
@@ -526,14 +526,19 @@ export default function NewEventModal() {
 
   useFocusEffect(
     useCallback(() => {
-      // Re-check permissions on focus in case user changed them in Settings
       void (async () => {
         const { status } = await MediaLibrary.getPermissionsAsync();
+        const isGranted = status === MediaLibrary.PermissionStatus.GRANTED;
+
+        if (!isGranted) {
+          clearPreview();
+        }
+
         useAppStore.setState({
-          hasMediaPermission: status === MediaLibrary.PermissionStatus.GRANTED,
+          hasMediaPermission: isGranted,
         });
       })();
-    }, []),
+    }, [clearPreview]),
   );
 
   return (

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -4,6 +4,7 @@ import {
   Dimensions,
   FlatList,
   KeyboardAvoidingView,
+  Linking,
   Platform,
   Pressable,
   StyleSheet,
@@ -52,6 +53,32 @@ const styles = StyleSheet.create({
   },
 });
 
+function PermissionPromptCard() {
+  const handleOpenSettings = useCallback(() => {
+    void Linking.openSettings();
+  }, []);
+
+  return (
+    <View className="rounded-2xl bg-accent-yellow p-4">
+      <Text className="mb-1 text-lg font-semibold text-neutral-1">
+        Grant photo access
+      </Text>
+      <Text className="mb-3 text-base text-neutral-2">
+        Enable photo access to select from your library, or use the Share menu
+        from your photos app.
+      </Text>
+      <Pressable
+        onPress={handleOpenSettings}
+        className="self-start rounded-md bg-white px-4 py-2"
+      >
+        <Text className="text-sm font-medium text-neutral-1">
+          Open Settings
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
 const PhotoGrid = React.memo(
   ({
     hasMediaPermission,
@@ -68,34 +95,6 @@ const PhotoGrid = React.memo(
     onDescribePress: () => void;
     onMorePhotos: () => void;
   }) => {
-    if (!hasMediaPermission) {
-      const windowWidth = Dimensions.get("window").width;
-      const padding = 32;
-      const spacing = 2;
-      const columns = 4;
-      const availableWidth = windowWidth - padding;
-      const imageSize = (availableWidth - (columns - 1) * spacing) / columns;
-
-      return (
-        <View
-          className="flex-row flex-wrap"
-          style={{ height: imageSize * 3 + spacing * 2 }}
-        >
-          <Pressable
-            onPress={onMorePhotos}
-            style={{
-              width: imageSize,
-              height: imageSize,
-              margin: spacing / 2,
-            }}
-            className="items-center justify-center rounded-md bg-white"
-          >
-            <Plus size={20} color="#5A32FB" />
-          </Pressable>
-        </View>
-      );
-    }
-
     const windowWidth = Dimensions.get("window").width;
     const padding = 32;
     const spacing = 2;
@@ -105,6 +104,11 @@ const PhotoGrid = React.memo(
 
     return (
       <View className="" style={{ height: imageSize * 3 + spacing * 2 }}>
+        {!hasMediaPermission && (
+          <View className="mb-4">
+            <PermissionPromptCard />
+          </View>
+        )}
         <View className="mb-2 flex-row items-center justify-between">
           <Pressable
             onPress={onMorePhotos}

--- a/apps/expo/src/components/AddEventButton.tsx
+++ b/apps/expo/src/components/AddEventButton.tsx
@@ -5,15 +5,11 @@ import { LinearGradient } from "expo-linear-gradient";
 import * as MediaLibrary from "expo-media-library";
 import { useRouter } from "expo-router";
 import { Plus } from "lucide-react-native";
-import { toast } from "sonner-native";
 
 import { useAppStore } from "~/store";
 
 export default function AddEventButton() {
   const router = useRouter();
-  const { hasMediaPermission } = useAppStore((state) => ({
-    hasMediaPermission: state.hasMediaPermission,
-  }));
 
   const handlePress = useCallback(async () => {
     try {

--- a/apps/expo/src/components/AddEventButton.tsx
+++ b/apps/expo/src/components/AddEventButton.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { BlurView } from "expo-blur";
 import { LinearGradient } from "expo-linear-gradient";
+import * as MediaLibrary from "expo-media-library";
 import { useRouter } from "expo-router";
 import { Plus } from "lucide-react-native";
 import { toast } from "sonner-native";
@@ -14,14 +15,19 @@ export default function AddEventButton() {
     hasMediaPermission: state.hasMediaPermission,
   }));
 
-  const handlePress = useCallback(() => {
-    if (!hasMediaPermission) {
-      toast.error("Photo access is needed to add photos to events");
-      router.push("/new");
-      return;
+  const handlePress = useCallback(async () => {
+    try {
+      // Request photo permissions on-demand
+      const { status } = await MediaLibrary.requestPermissionsAsync();
+      useAppStore.setState({
+        hasMediaPermission: status === MediaLibrary.PermissionStatus.GRANTED,
+      });
+    } catch (error) {
+      console.error("Error requesting media permissions:", error);
     }
+    // Navigate to /new whether granted or not
     router.push("/new");
-  }, [hasMediaPermission, router]);
+  }, [router]);
 
   return (
     <View className="absolute bottom-0 left-0 right-0">

--- a/apps/expo/src/hooks/useMediaPermissions.ts
+++ b/apps/expo/src/hooks/useMediaPermissions.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import * as MediaLibrary from "expo-media-library";
-import { toast } from "sonner-native";
 
 import { useAppStore } from "~/store";
 


### PR DESCRIPTION
- **♻️ refactor: improve media permissions handling and user experience**
- **✨ feat(PhotoGrid): simplify photo access UI by replacing grant access button with plus icon**
- **🐛 fix: handle media permission edge cases and clear preview when needed**
- **♻️ refactor: replace FlashList with FlatList and add plus button to photo grid**
- **✨ feat: add permission prompt card for photo library access**
- **♻️ refactor: replace permission prompt card with toast notification system**
- **♻️ remove unused imports and props to clean up codebase**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "plus" button in the photo selection interface for adding more photos.
	- Simplified media permissions handling with a new notification system for permission requests.

- **Bug Fixes**
	- Removed unnecessary error handling for media permissions, streamlining user experience.

- **Refactor**
	- Updated the logic for fetching recent photos and managing media permissions, enhancing overall performance and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->