### PR TITLE
 Update iOS photo library permission configuration in Expo app

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -24,6 +24,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       {
         ios: {
           deploymentTarget: "15.0",
+          infoPlist: {
+            PHPhotoLibraryPreventAutomaticLimitedAccessAlert: true,
+          },
         },
       },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced photo library permission handling on iOS to prevent automatic limited access alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->