### PR TITLE
 Add marketing notification system with Expo push tokens

### DIFF
--- a/apps/web/app/api/cron/marketing-notification/route.ts
+++ b/apps/web/app/api/cron/marketing-notification/route.ts
@@ -1,0 +1,28 @@
+import { appRouter } from "@soonlist/api";
+import { createTRPCContext } from "@soonlist/api/trpc";
+
+export async function GET(req: Request) {
+  try {
+    const caller = appRouter.createCaller(
+      await createTRPCContext({ headers: req.headers }),
+    );
+
+    await caller.notification.sendMarketingNotification({
+      adminSecret: process.env.ADMIN_SECRET || "",
+      title: "📸 Soonlist Just Got Better!",
+      body: "Tap to explore our streamlined capture flow, event stats & more. Not seeing it? Update in TestFlight.",
+      data: {
+        url: "/feed",
+      },
+    });
+
+    return new Response("Marketing notification sent successfully", {
+      status: 200,
+    });
+  } catch (error) {
+    console.error("Error sending marketing notification:", error);
+    return new Response("Error sending marketing notification", {
+      status: 500,
+    });
+  }
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "/api/cron/marketing-notification",
-      "schedule": ""
+      "schedule": "0 0 31 12 *"
     }
   ]
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/weekly-notifications",
       "schedule": "0 16 * * 1"
+    },
+    {
+      "path": "/api/cron/marketing-notification",
+      "schedule": ""
     }
   ]
 }


### PR DESCRIPTION
The commit adds a new marketing notification system that allows sending
broadcast messages to all users with valid push tokens, including analytics
tracking and error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new marketing notification system that allows sending targeted push notifications to users.
	- Implemented a secure, admin-controlled notification mechanism with tracking capabilities.

- **Infrastructure**
	- Configured a new cron job endpoint for marketing notifications, scheduled to run at midnight on December 31st.

- **Security**
	- Added admin secret validation to prevent unauthorized notification sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->