### PR TITLE
 Add react-native-screens dependency to package.json

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -86,6 +86,7 @@
     "react-native-qrcode-svg": "^6.3.0",
     "react-native-reanimated": "~3.16.6",
     "react-native-safe-area-context": "~4.12.0",
+    "react-native-screens": "~4.4.0",
     "react-native-svg": "15.8.0",
     "sonner-native": "^0.16.2",
     "superjson": "2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       react-native-safe-area-context:
         specifier: ~4.12.0
         version: 4.12.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.24.4(@babel/core@7.26.0))(@react-native-community/cli-server-api@12.3.6(encoding@0.1.13))(@types/react@18.3.18)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+      react-native-screens:
+        specifier: ~4.4.0
+        version: 4.4.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.24.4(@babel/core@7.26.0))(@react-native-community/cli-server-api@12.3.6(encoding@0.1.13))(@types/react@18.3.18)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       react-native-svg:
         specifier: 15.8.0
         version: 15.8.0(react-native@0.76.5(@babel/core@7.26.0)(@babel/preset-env@7.24.4(@babel/core@7.26.0))(@react-native-community/cli-server-api@12.3.6(encoding@0.1.13))(@types/react@18.3.18)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
this fixes a boo boo where this was removed because it doesn't show up as a direct dependency but is still needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added `react-native-screens` package to project dependencies
	- Updated project dependency configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->