### PR TITLE
 Update RevenueCat initialization to remove device type conditional check

### DIFF
--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -1,6 +1,5 @@
 import { Platform } from "react-native";
 import Purchases, { LOG_LEVEL } from "react-native-purchases";
-import * as Device from "expo-device";
 
 interface RevenueCatConfig {
   apiKey: {

--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -22,7 +22,11 @@ const config: RevenueCatConfig = {
 };
 
 export async function initializeRevenueCat() {
-  await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Set to DEBUG in development
+  await Purchases.setLogLevel(
+    process.env.EXPO_PUBLIC_APP_ENV === "development" 
+      ? LOG_LEVEL.DEBUG 
+      : LOG_LEVEL.INFO
+  );
 
   const apiKey = Platform.select({
     ios: config.apiKey.ios,

--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -23,9 +23,9 @@ const config: RevenueCatConfig = {
 
 export async function initializeRevenueCat() {
   await Purchases.setLogLevel(
-    process.env.EXPO_PUBLIC_APP_ENV === "development" 
-      ? LOG_LEVEL.DEBUG 
-      : LOG_LEVEL.INFO
+    process.env.EXPO_PUBLIC_APP_ENV === "development"
+      ? LOG_LEVEL.DEBUG
+      : LOG_LEVEL.INFO,
   );
 
   const apiKey = Platform.select({

--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -23,21 +23,19 @@ const config: RevenueCatConfig = {
 };
 
 export async function initializeRevenueCat() {
-  if (Device.isDevice) {
-    await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Set to DEBUG in development
+  await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Set to DEBUG in development
 
-    const apiKey = Platform.select({
-      ios: config.apiKey.ios,
-      android: config.apiKey.android,
-      default: "",
-    });
+  const apiKey = Platform.select({
+    ios: config.apiKey.ios,
+    android: config.apiKey.android,
+    default: "",
+  });
 
-    if (!apiKey) {
-      throw new Error("No API key for platform");
-    }
-
-    Purchases.configure({ apiKey });
+  if (!apiKey) {
+    throw new Error("No API key for platform");
   }
+
+  Purchases.configure({ apiKey });
 }
 
 export async function getCurrentSubscriptionStatus() {


### PR DESCRIPTION
- **♻️ remove redundant Device.isDevice check in RevenueCat initialization**
- **🔧 refactor(revenue-cat): remove unused expo-device import**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `login` function with enhanced error handling and initialization checks.
  - Updated `logout` and `showProPaywallIfNeeded` functions to include warnings for uninitialized RevenueCat.

- **Refactor**
  - Simplified RevenueCat initialization process by removing device-specific conditional checks.
  - Updated log level configuration to apply universally across all device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->