### PR TITLE
 Update animation hooks and RevenueCat initialization in Expo app

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -81,7 +81,7 @@ Expo Specific:
 Expo Animations:
 
 - Use React Native Reanimated for animations. Prefer using Animated components (e.g. Animated.View), powered by shared values.
-- NEVER USE JUST useEffect!!!! Should use useSharedValue!!!
+- Don't just use useEffect! Should also use useSharedValue.
 - Shared values are a driving factor of all animations and we define them using a useSharedValue hook.
 - Shared values are always accessed and modified by their .value property (eg. sv.value = 100;).
 - To create smooth animations modify shared values using a withTiming etc...

--- a/apps/expo/src/app/(onboarding)/onboarding/01-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/01-notifications.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import Animated, {
   Easing,
@@ -20,15 +20,16 @@ export default function NotificationsScreen() {
   const { registerForPushNotifications } = useNotification();
   const translateY = useSharedValue(0);
 
-  // Start the animation immediately
-  translateY.value = withRepeat(
-    withTiming(-12, {
-      duration: 500,
-      easing: Easing.inOut(Easing.sin),
-    }),
-    -1,
-    true,
-  );
+  useEffect(() => {
+    translateY.value = withRepeat(
+      withTiming(-12, {
+        duration: 500,
+        easing: Easing.inOut(Easing.sin),
+      }),
+      -1,
+      true,
+    );
+  }, [translateY]);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {

--- a/apps/expo/src/app/(onboarding)/onboarding/07-photos.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/07-photos.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import Animated, {
   Easing,
@@ -18,15 +18,16 @@ import { TOTAL_ONBOARDING_STEPS } from "../_layout";
 export default function PhotosScreen() {
   const translateX = useSharedValue(0);
 
-  // Start the animation immediately
-  translateX.value = withRepeat(
-    withTiming(-12, {
-      duration: 500,
-      easing: Easing.inOut(Easing.sin),
-    }),
-    -1,
-    true,
-  );
+  useEffect(() => {
+    translateX.value = withRepeat(
+      withTiming(-12, {
+        duration: 500,
+        easing: Easing.inOut(Easing.sin),
+      }),
+      -1,
+      true,
+    );
+  }, [translateX]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     position: "absolute",

--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -1,6 +1,5 @@
 import { Platform } from "react-native";
 import Purchases, { LOG_LEVEL } from "react-native-purchases";
-import * as Device from "expo-device";
 
 interface RevenueCatConfig {
   apiKey: {

--- a/apps/expo/src/lib/revenue-cat.ts
+++ b/apps/expo/src/lib/revenue-cat.ts
@@ -23,21 +23,19 @@ const config: RevenueCatConfig = {
 };
 
 export async function initializeRevenueCat() {
-  if (Device.isDevice) {
-    await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Set to DEBUG in development
+  await Purchases.setLogLevel(LOG_LEVEL.DEBUG); // Set to DEBUG in development
 
-    const apiKey = Platform.select({
-      ios: config.apiKey.ios,
-      android: config.apiKey.android,
-      default: "",
-    });
+  const apiKey = Platform.select({
+    ios: config.apiKey.ios,
+    android: config.apiKey.android,
+    default: "",
+  });
 
-    if (!apiKey) {
-      throw new Error("No API key for platform");
-    }
-
-    Purchases.configure({ apiKey });
+  if (!apiKey) {
+    throw new Error("No API key for platform");
   }
+
+  Purchases.configure({ apiKey });
 }
 
 export async function getCurrentSubscriptionStatus() {


### PR DESCRIPTION
- **♻️ remove redundant Device.isDevice check in RevenueCat initialization**
- **🔧 refactor(revenue-cat): remove unused expo-device import**
- **♻️ refactor: wrap animation initialization in useEffect for better lifecycle control**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced animation management in onboarding screens using `useEffect`

- **Improvements**
	- Refined animation control in notifications and photos screens
	- Simplified RevenueCat initialization process

- **Documentation**
	- Updated guidelines for using shared values and animations in Expo applications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->