### PR TITLE
 Update FoundingMemberPricing: Use app launch event for expiration

### DIFF
--- a/apps/web/components/FoundingMemberPricing.tsx
+++ b/apps/web/components/FoundingMemberPricing.tsx
@@ -103,7 +103,7 @@ export function FoundingMemberPricing({
         </h1>
         <div className="mt-8 rounded-xl bg-accent-orange p-6 text-center">
           <h2 className="font-heading text-2xl font-bold text-interactive-1">
-            Limited availability - Ends January 31st!
+            Limited availability - Ending soon!
           </h2>
           <p className="mt-2 text-4xl font-bold text-neutral-1">
             Only 💯&nbsp;Founding Member spots&nbsp;🎈
@@ -212,7 +212,7 @@ export function FoundingMemberPricing({
               </ul>
             </div>
             <p className="mt-4 animate-pulse text-lg font-semibold text-interactive-1">
-              {remainingSpots} spots left • Offer ends January 31st
+              {remainingSpots} spots left • Offer ends on app launch
             </p>
             <div className="mt-8">
               {tier.soon && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Founding Member Pricing messaging to enhance urgency by changing "Limited availability - Ends January 31st!" to "Limited availability - Ending soon!"
  - Revised the offer expiration text to indicate it ends on app launch instead of a specific date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->