### PR TITLE
 Enhance sign-out hook to delete push token with new API mutation

### DIFF
--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -2,6 +2,7 @@ import { router } from "expo-router";
 import { useAuth } from "@clerk/clerk-expo";
 import Intercom from "@intercom/intercom-react-native";
 
+import { useNotification } from "~/providers/NotificationProvider";
 import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import { useAppStore } from "~/store";
 import { api } from "~/utils/api";
@@ -9,11 +10,19 @@ import { deleteAuthData } from "./useAuthSync";
 
 export const useSignOut = () => {
   const utils = api.useUtils();
-  const { signOut } = useAuth();
+  const { signOut, userId } = useAuth();
   const resetStore = useAppStore((state) => state.resetStore);
   const { logout: revenueCatLogout } = useRevenueCat();
+  const { expoPushToken } = useNotification();
+  const { mutateAsync: deleteToken } = api.pushToken.deleteToken.useMutation({
+    onError: (error) => {
+      console.error("Failed to delete push token:", error);
+    },
+  });
 
   return async () => {
+    if (!userId) return;
+
     // First cancel all ongoing queries and prevent refetching
     await utils.invalidate();
 
@@ -25,6 +34,7 @@ export const useSignOut = () => {
       Intercom.logout(),
       revenueCatLogout(),
       deleteAuthData(),
+      deleteToken({ userId, expoPushToken }),
       signOut(),
     ]);
 

--- a/packages/api/src/routers/pushToken.ts
+++ b/packages/api/src/routers/pushToken.ts
@@ -58,4 +58,21 @@ export const pushTokenRouter = createTRPCRouter({
           pushTokens.map((pushToken) => pushToken.expoPushToken),
         );
     }),
+  deleteToken: protectedProcedure
+    .input(
+      z.object({
+        userId: z.string(),
+        expoPushToken: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.db
+        .delete(pushTokens)
+        .where(
+          and(
+            eq(pushTokens.userId, input.userId),
+            eq(pushTokens.expoPushToken, input.expoPushToken),
+          ),
+        );
+    }),
 });


### PR DESCRIPTION
The commit adds functionality to delete user's push notification token when they
sign out, ensuring proper cleanup of notification-related data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The sign-out process now validates user presence before proceeding and automatically removes associated push notification tokens.
  - Enhanced backend functionality to securely delete push tokens linked to a user, promoting a more robust and reliable sign-out experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->