### PR TITLE
 Add auth and plan logic for discover page and nav, update plan schema

### DIFF
--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import { View } from "react-native";
+import { Redirect } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 
 import type { RouterOutputs } from "~/utils/api";
@@ -8,6 +9,7 @@ import LoadingSpinner from "~/components/LoadingSpinner";
 import SaveButton from "~/components/SaveButton";
 import UserEventsList from "~/components/UserEventsList";
 import { api } from "~/utils/api";
+import { getPlanStatusFromUser } from "~/utils/plan";
 
 export default function Page() {
   const { user } = useUser();
@@ -33,8 +35,18 @@ export default function Page() {
 
   const events = eventsQuery.data?.pages.flatMap((page) => page.events) ?? [];
 
+  if (!user) {
+    return <Redirect href="/sign-in" />;
+  }
+
+  const { showDiscover } = getPlanStatusFromUser(user);
+
+  if (!showDiscover) {
+    return <Redirect href="/feed" />;
+  }
+
   const savedEventIdsQuery = api.event.getSavedIdsForUser.useQuery({
-    userName: user?.username ?? "",
+    userName: user.username ?? "",
   });
 
   const savedEventIds = new Set(

--- a/apps/expo/src/components/NavigationMenu.tsx
+++ b/apps/expo/src/components/NavigationMenu.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { router } from "expo-router";
+import { useUser } from "@clerk/clerk-expo";
 import { Check, ChevronDown } from "lucide-react-native";
 
+import { getPlanStatusFromUser } from "~/utils/plan";
 import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -18,7 +20,7 @@ interface NavigationMenuProps {
   active?: RouteType;
 }
 
-const routes = [
+const baseRoutes = [
   { label: "Upcoming", path: "/feed" },
   { label: "Past", path: "/past" },
   { label: "Discover", path: "/discover" },
@@ -31,6 +33,11 @@ function isRouteActive(routePath: string, active?: RouteType) {
 
 export function NavigationMenu({ active }: NavigationMenuProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const { user } = useUser();
+
+  const showDiscover = user ? getPlanStatusFromUser(user).showDiscover : false;
+  console.log("showDiscover", showDiscover);
+  const routes = showDiscover ? baseRoutes : baseRoutes.slice(0, 2);
 
   const currentRoute =
     routes.find((r) => isRouteActive(r.path, active))?.label ?? "Upcoming";

--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -8,19 +8,20 @@ import { useAppStore } from "~/store";
 import { api } from "~/utils/api";
 import { deleteAuthData } from "./useAuthSync";
 
+interface SignOutOptions {
+  shouldDeleteAccount?: boolean;
+}
+
 export const useSignOut = () => {
   const utils = api.useUtils();
   const { signOut, userId } = useAuth();
   const resetStore = useAppStore((state) => state.resetStore);
   const { logout: revenueCatLogout } = useRevenueCat();
   const { expoPushToken } = useNotification();
-  const { mutateAsync: deleteToken } = api.pushToken.deleteToken.useMutation({
-    onError: (error) => {
-      console.error("Failed to delete push token:", error);
-    },
-  });
+  const { mutateAsync: deleteToken } = api.pushToken.deleteToken.useMutation();
+  const { mutateAsync: deleteAccount } = api.user.deleteAccount.useMutation();
 
-  return async () => {
+  return async (options?: SignOutOptions) => {
     if (!userId) return;
 
     // First cancel all ongoing queries and prevent refetching
@@ -35,6 +36,7 @@ export const useSignOut = () => {
       revenueCatLogout(),
       deleteAuthData(),
       deleteToken({ userId, expoPushToken }),
+      options?.shouldDeleteAccount ? deleteAccount() : undefined,
       signOut(),
     ]);
 

--- a/apps/expo/src/utils/plan.ts
+++ b/apps/expo/src/utils/plan.ts
@@ -1,7 +1,18 @@
-import type { User, UserPublicMetadata } from "@soonlist/db/types";
+import type { UserResource } from "@clerk/types";
 
-export const getPlanStatusFromUser = (user: User) => {
-  const publicMetadata = user.publicMetadata as UserPublicMetadata | null;
+export const getPlanStatusFromUser = (user: UserResource) => {
+  const publicMetadata = user.publicMetadata as {
+    stripe?: {
+      customerId?: string;
+    };
+    plan?: {
+      name?: string; //"free" | "personal" | "pro";
+      productId?: string;
+      status?: string;
+      id?: string;
+    };
+    showDiscover?: boolean;
+  } | null;
   const name = publicMetadata?.plan?.name || "";
   const currentPlanStatus = publicMetadata?.plan?.status || "";
   const active =

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -57,11 +57,12 @@ export interface UserPublicMetadata {
     customerId?: string;
   };
   plan?: {
-    name?: "free" | "personal" | "pro";
+    name?: string; // "free" | "personal" | "pro";
     productId?: string;
     status?: string;
     id?: string;
   };
+  showDiscover?: boolean;
 }
 
 export interface OnboardingData {


### PR DESCRIPTION
The commit adds a feature flag system to control access to the discover feature
based on user's plan status, including new plan utilities and route protection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced access control: Users are now automatically redirected to appropriate pages (sign-in or feed) based on their authentication status and subscription plan.
	- Dynamic navigation: The app’s menu now adjusts available sections in real time according to a user’s current plan.
	- Account deletion: Users can now delete their accounts with confirmation and feedback.
	- Expanded plan configuration: Subscription details now support a broader range of options, offering a more personalized user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->