### PR TITLE
 Add 'other' to RootLayout metadata and Apple app site association JSON

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -58,6 +58,9 @@ export const metadata: Metadata = {
     telephone: false,
     date: false,
   },
+  other: {
+    "apple-itunes-app": "app-id=6670222216",
+  },
 };
 
 export const viewport: Viewport = {

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,27 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "GQ59Z4XZHZ.com.soonlist.app"
+        ],
+        "components": [
+          {
+            "/": "*",
+            "comment": "Matches all routes"
+          }
+        ]
+      }
+    ]
+  },
+  "activitycontinuation": {
+    "apps": [
+      "GQ59Z4XZHZ.com.soonlist.app"
+    ]
+  },
+  "webcredentials": {
+    "apps": [
+      "GQ59Z4XZHZ.com.soonlist.app"
+    ]
+  }
+}

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -7,7 +7,7 @@
         ],
         "components": [
           {
-            "/": "*",
+            "/": "/event/*",
             "comment": "Matches all routes"
           }
         ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced website metadata to support Apple iTunes integration.
	- Added a new configuration to enable deep linking, activity continuation, and web credential sharing with Apple services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->