### PR TITLE
 Add Expo iOS associatedDomains, update apple-app-site-association

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -152,6 +152,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         },
       ],
     },
+    associatedDomains: ["applinks:soonlist.com", "applinks:www.soonlist.com"],
   },
   android: {
     package: getUniqueIdentifier(),

--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -152,7 +152,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         },
       ],
     },
-    associatedDomains: ["applinks:soonlist.com", "applinks:www.soonlist.com"],
+    associatedDomains: ["applinks:www.soonlist.com"],
   },
   android: {
     package: getUniqueIdentifier(),

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -5,7 +5,12 @@
         "appIDs": [
           "GQ59Z4XZHZ.com.soonlist.app"
         ],
-        "components": []
+        "components": [
+          {
+            "/": "/event/*",
+            "comment": "Matches event routes"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced universal linking support for iOS, enabling the app to associate with specific domains.
  - Improved web link handling by incorporating event route matching for seamless redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->