### PR TITLE
 Update AddEventButton handlePress to trigger media library refresh @coderabbitai

### DIFF
--- a/apps/expo/.maestro/flows/deep_links.yaml
+++ b/apps/expo/.maestro/flows/deep_links.yaml
@@ -61,6 +61,13 @@ name: Deep Links
     - "../assets/design.png"
 
 - tapOn:
+    text: wait2seconds # Any random text that does not exist in the UI
+    optional: true # This should be true so that the test won't fail
+    repeat: 2
+    delay: 2000
+    label: "wait for media refresh"
+
+- tapOn:
     point: 50%,93%
 
 - assertVisible: "Select image"

--- a/apps/expo/.maestro/flows/intent_handler.yaml
+++ b/apps/expo/.maestro/flows/intent_handler.yaml
@@ -19,6 +19,13 @@ name: Intent Handler
     - "../assets/food.png"
 
 - tapOn:
+    text: wait2seconds # Any random text that does not exist in the UI
+    optional: true # This should be true so that the test won't fail
+    repeat: 2
+    delay: 2000
+    label: "wait for media refresh"
+
+- tapOn:
     point: 50%,93%
 
 - assertVisible: "Select image"
@@ -32,6 +39,13 @@ name: Intent Handler
 # Add event media
 - addMedia:
     - "../assets/music.png"
+
+- tapOn:
+    text: wait2seconds # Any random text that does not exist in the UI
+    optional: true # This should be true so that the test won't fail
+    repeat: 2
+    delay: 2000
+    label: "wait for media refresh"
 
 - tapOn:
     point: 50%,93%

--- a/apps/expo/src/hooks/useInitializeInput.ts
+++ b/apps/expo/src/hooks/useInitializeInput.ts
@@ -25,6 +25,7 @@ export function useInitializeInput({
     setActiveInput,
     setIsOptionSelected,
     hasMediaPermission,
+    activeInput,
   } = useAppStore();
 
   const handleImagePreview = useCallback(
@@ -126,6 +127,23 @@ export function useInitializeInput({
     setLinkPreview,
     hasMediaPermission,
     initialized,
+  ]);
+
+  // Add a new effect to handle recentPhotos changes
+  useEffect(() => {
+    if (!initialized) return;
+    if (activeInput === "upload" && hasMediaPermission) {
+      const mostRecentPhoto = recentPhotos[0];
+      if (mostRecentPhoto?.uri) {
+        void handleImagePreview(mostRecentPhoto.uri);
+      }
+    }
+  }, [
+    recentPhotos,
+    activeInput,
+    hasMediaPermission,
+    initialized,
+    handleImagePreview,
   ]);
 
   return { initialized };


### PR DESCRIPTION
- **✨ feat: auto-select most recent photo when upload input is active**
- **✅ add delay after media upload in Maestro tests to ensure proper refresh**
