### PR TITLE
Move close button from EventPreview to header of /new in share extension

### DIFF
--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { View } from "react-native";
+import { Pressable, View } from "react-native";
 import Animated from "react-native-reanimated";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
+import { X } from "lucide-react-native";
 import { toast } from "sonner-native";
 
 import { CaptureEventButton } from "~/components/CaptureEventButton";
@@ -33,7 +34,6 @@ export default function NewShareScreen() {
   const {
     newEventState: { input, imagePreview, linkPreview, isImageLoading },
     setInput,
-    setImagePreview,
     setLinkPreview,
     resetNewEventState,
   } = useAppStore();
@@ -71,16 +71,6 @@ export default function NewShareScreen() {
     },
     [setInput, setLinkPreview],
   );
-
-  /**
-   * Clear the preview state
-   */
-  const handleClearPreview = useCallback(() => {
-    setImagePreview(null, "new");
-    setLinkPreview(null, "new");
-    setInput("", "new");
-    resetNewEventState();
-  }, [setImagePreview, setLinkPreview, setInput, resetNewEventState]);
 
   /**
    * Actually create the event
@@ -155,6 +145,14 @@ export default function NewShareScreen() {
               handleDescribePress={() => setActiveInput("describe")}
             />
           ),
+          headerRight: () => (
+            <Pressable
+              onPress={() => router.back()}
+              className="rounded-full bg-transparent py-4"
+            >
+              <X size={24} color="#fff" />
+            </Pressable>
+          ),
         }}
       />
 
@@ -166,8 +164,6 @@ export default function NewShareScreen() {
             linkPreview={linkPreview}
             input={input}
             handleTextChange={handleTextChange}
-            clearPreview={handleClearPreview}
-            clearText={() => setInput("", "new")}
             activeInput={activeInput}
             isImageLoading={isImageLoading}
             handleMorePhotos={() => null}

--- a/apps/expo/src/components/EventPreview.tsx
+++ b/apps/expo/src/components/EventPreview.tsx
@@ -18,8 +18,8 @@ interface EventPreviewProps {
   linkPreview: string | null;
   input: string;
   handleTextChange: (text: string) => void;
-  clearPreview: () => void;
-  clearText: () => void;
+  clearPreview?: () => void;
+  clearText?: () => void;
   activeInput: string | null;
   isImageLoading: boolean;
   handleMorePhotos: () => void;
@@ -71,12 +71,14 @@ export function EventPreview({
             placeholderContentFit="contain"
             className="bg-muted/10"
           />
-          <Pressable
-            onPress={clearPreview}
-            className="absolute right-2 top-2 rounded-full bg-interactive-3 p-1"
-          >
-            <X size={20} color="#5A32FB" />
-          </Pressable>
+          {clearPreview && (
+            <Pressable
+              onPress={clearPreview}
+              className="absolute right-2 top-2 rounded-full bg-interactive-3 p-1"
+            >
+              <X size={20} color="#5A32FB" />
+            </Pressable>
+          )}
           {isImageLoading && (
             <View className="absolute bottom-2 right-2">
               <ActivityIndicator size="small" color="#DCE0E8" />
@@ -97,12 +99,14 @@ export function EventPreview({
               {linkPreview}
             </Text>
           </View>
-          <Pressable
-            onPress={clearPreview}
-            className="absolute right-2 top-2 rounded-full bg-white p-1"
-          >
-            <X size={16} color="black" />
-          </Pressable>
+          {clearPreview && (
+            <Pressable
+              onPress={clearPreview}
+              className="absolute right-2 top-2 rounded-full bg-white p-1"
+            >
+              <X size={16} color="black" />
+            </Pressable>
+          )}
         </View>
       )}
 
@@ -124,7 +128,7 @@ export function EventPreview({
             className="h-full text-lg"
           />
 
-          {input.length > 0 && (
+          {input.length > 0 && clearText && (
             <Pressable
               onPress={clearText}
               className="absolute right-2 top-2 rounded-full bg-neutral-200 p-2"


### PR DESCRIPTION
The commit adds a close button (X icon) to the header of the new event screen,
allowing users to dismiss the screen. Also makes the clear preview and clear text
buttons optional in the EventPreview component for better reusability.
