### PR TITLE
 Integrate OneSignal push notifications and update layout and provider

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -1,8 +1,10 @@
 import { Platform, Text, View } from "react-native";
+import { LogLevel, OneSignal } from "react-native-onesignal";
 import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import Constants from "expo-constants";
 import { Stack, useNavigationContainerRef } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { StatusBar } from "expo-status-bar";
@@ -21,7 +23,7 @@ import type { ErrorBoundaryProps } from "expo-router";
 import { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
-import Constants, { AppOwnership } from "expo-constants";
+import { AppOwnership } from "expo-constants";
 import { Toaster } from "sonner-native";
 
 import AuthAndTokenSync from "~/components/AuthAndTokenSync";
@@ -93,6 +95,15 @@ Sentry.init({
     replaysOnErrorSampleRate: 1.0,
   },
 });
+
+// Initialize OneSignal before component rendering
+const oneSignalAppId = Constants.expoConfig?.extra?.oneSignalAppId as string;
+if (oneSignalAppId) {
+  OneSignal.Debug.setLogLevel(LogLevel.Verbose);
+  OneSignal.initialize(oneSignalAppId);
+} else {
+  console.error("OneSignal App ID is not defined in app.config.ts");
+}
 
 function RootLayout() {
   const clerkPublishableKey = Config.clerkPublishableKey;

--- a/apps/expo/src/providers/OneSignalProvider.tsx
+++ b/apps/expo/src/providers/OneSignalProvider.tsx
@@ -4,11 +4,7 @@ import type {
 } from "react-native-onesignal";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { Linking, Platform } from "react-native";
-import {
-  LogLevel,
-  OneSignal,
-  OSNotificationPermission,
-} from "react-native-onesignal";
+import { OneSignal, OSNotificationPermission } from "react-native-onesignal";
 import Constants from "expo-constants";
 import { useAuth } from "@clerk/clerk-expo";
 import { usePostHog } from "posthog-react-native";
@@ -83,24 +79,8 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
     useState(false);
   const posthog = usePostHog();
 
-  // Initialize OneSignal
+  // Check permission and set up notification handlers
   useEffect(() => {
-    const oneSignalAppId = Constants.expoConfig?.extra
-      ?.oneSignalAppId as string;
-
-    if (!oneSignalAppId) {
-      console.error("OneSignal App ID is not defined in app.config.ts");
-      return;
-    }
-
-    // Enable logging for debugging (remove in production)
-    // if (__DEV__) {
-    OneSignal.Debug.setLogLevel(LogLevel.Verbose);
-    // }
-
-    // Initialize the OneSignal SDK
-    OneSignal.initialize(oneSignalAppId);
-
     // Check permission status
     void OneSignal.Notifications.permissionNative()
       .then((permission) => {


### PR DESCRIPTION
The OneSignal SDK initialization is moved from OneSignalProvider to _layout to
ensure proper setup before any component rendering, improving notification
reliability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated enhanced push notification support for more reliable delivery of alerts and updates.
	- Streamlined the notification setup process with improved permission checks and handling for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->