### PR TITLE
 Consolidate eventData and move state reset in Expo event creation

### DIFF
--- a/apps/expo/src/app/add.tsx
+++ b/apps/expo/src/app/add.tsx
@@ -1,5 +1,5 @@
 // src/app/add.tsx
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { Linking, View } from "react-native";
 import Animated from "react-native-reanimated";
 import * as ImagePicker from "expo-image-picker";

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -80,20 +80,26 @@ export default function NewShareScreen() {
     if (!input.trim() && !imagePreview && !linkPreview) return;
     if (!user?.id || !user.username) return;
 
+    // Store values needed for event creation before resetting state
+    const eventData = {
+      rawText: input,
+      linkPreview: linkPreview ?? undefined,
+      imageUri: imagePreview ?? undefined,
+      userId: user.id,
+      username: user.username,
+    };
+
     // Immediately navigate away
     router.canGoBack() ? router.back() : router.push("/feed");
     toast.info("Capturing in background. Add another?", {
       duration: 5000,
     });
 
+    // Reset state immediately for better UX
+    resetNewEventState();
+
     try {
-      const eventId = await createEvent({
-        rawText: input,
-        linkPreview: linkPreview ?? undefined,
-        imageUri: imagePreview ?? undefined,
-        userId: user.id,
-        username: user.username,
-      });
+      const eventId = await createEvent(eventData);
 
       if (!hasNotificationPermission && eventId) {
         toast.success("Captured successfully!", {
@@ -109,8 +115,6 @@ export default function NewShareScreen() {
     } catch (error) {
       logError("Error creating event", error);
       toast.error("Failed to create event. Please try again.");
-    } finally {
-      resetNewEventState();
     }
   };
 


### PR DESCRIPTION
* Remove unnecessary useEffect for state reset on unmount to improve performance.
* Store event creation data in a single object for cleaner code and better maintainability.
* Reset event state immediately after capturing input for enhanced user experience.
* Update event creation calls to use the new structured data object.

These changes streamline the event creation process and improve the overall user experience in the Expo app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the event creation experience by consolidating event details into a single object.
  - Inputs now reset immediately after submission, ensuring a more responsive and streamlined workflow for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->