### PR TITLE
 Update useInitializeInput hook to support key-based reinitialization

### DIFF
--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -47,13 +47,17 @@ export default function NewShareScreen() {
 
   /**
    * Use same initialization logic from old new.tsx
+   * Use a key to force re-initialization when text or imageUri changes
    */
-  const { initialized } = useInitializeInput({
-    text,
-    imageUri,
-    recentPhotos: [], // We skip recent photos for share extension
-    route: "new",
-  });
+  const { initialized } = useInitializeInput(
+    {
+      text,
+      imageUri,
+      recentPhotos: [], // We skip recent photos for share extension
+      route: "new",
+    },
+    `${text || ""}-${imageUri || ""}`,
+  );
 
   /**
    * Link detection from typed input (if user modifies text).

--- a/apps/expo/src/hooks/useInitializeInput.ts
+++ b/apps/expo/src/hooks/useInitializeInput.ts
@@ -14,12 +14,10 @@ interface UseInitializeInputParams {
   route: "add" | "new";
 }
 
-export function useInitializeInput({
-  text,
-  imageUri,
-  recentPhotos,
-  route,
-}: UseInitializeInputParams) {
+export function useInitializeInput(
+  { text, imageUri, recentPhotos, route }: UseInitializeInputParams,
+  key?: string,
+) {
   const [initialized, setInitialized] = useState(false);
   const {
     setInput,
@@ -69,6 +67,11 @@ export function useInitializeInput({
     },
     [handleLinkPreview, setInput, setLinkPreview, route],
   );
+
+  useEffect(() => {
+    // Reset initialized state when key changes
+    setInitialized(false);
+  }, [key]);
 
   useEffect(() => {
     if (initialized) return;


### PR DESCRIPTION
* Update useInitializeInput hook to accept an optional key parameter for forcing re-initialization when text or imageUri changes.
* Modify NewShareScreen to utilize the new key feature, improving input handling and state management.

These changes enhance the user experience by ensuring the input state resets appropriately based on user modifications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the share screen’s input handling so that changes to text or image content now trigger an immediate reinitialization, leading to a more responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->