### PR TITLE
 Enable AddEventButton during isCapturing state by removing disable logic

### DIFF
--- a/apps/expo/src/components/AddEventButton.tsx
+++ b/apps/expo/src/components/AddEventButton.tsx
@@ -103,7 +103,6 @@ export default function AddEventButton({
         <TouchableOpacity
           onPress={triggerAddEventFlow}
           className="absolute bottom-8 self-center"
-          disabled={isCapturing}
         >
           {hasUnlimited ? (
             <View className="relative">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Add Event button can now be pressed even while capturing is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->