### PR TITLE
 Add paywall to AddEventButton and remove onboarding and Intercom references

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/07-we-got-you.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/07-we-got-you.tsx
@@ -126,7 +126,7 @@ export default function WeGotYouScreen() {
           </View>
         </View>
       </View>
-      <FinishDemoButton text="Start your free trial" variant="light" />
+      <FinishDemoButton text="Get started" variant="light" />
     </QuestionContainer>
   );
 }

--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -96,7 +96,10 @@ function MyFeed() {
             promoCard={{ type: "addEvents" }}
             hasUnlimited={hasUnlimited}
           />
-          <AddEventButton showChevron={noLifetimeCaptures} />
+          <AddEventButton
+            showChevron={noLifetimeCaptures}
+            stats={statsQuery.data}
+          />
         </View>
       )}
     </View>

--- a/apps/expo/src/components/AddEventButton.tsx
+++ b/apps/expo/src/components/AddEventButton.tsx
@@ -9,6 +9,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { BlurView } from "expo-blur";
 import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
 
 import { ChevronDown, PlusIcon, Sparkles } from "~/components/icons";
 import { CircularSpinner } from "~/components/ui/CircularSpinner";
@@ -16,8 +17,16 @@ import { useAddEventFlow } from "~/hooks/useAddEventFlow";
 import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 
+interface EventStats {
+  upcomingEvents: number;
+  allTimeEvents: number;
+  // Other fields from statsQuery.data if needed, but not used in current logic
+  // capturesThisWeek: number;
+  // weeklyGoal: number;
+}
 interface AddEventButtonProps {
   showChevron?: boolean;
+  stats?: EventStats;
 }
 
 /**
@@ -25,17 +34,49 @@ interface AddEventButtonProps {
  * ---------------
  * Opens the native photo picker (up to 10 images) and creates events for each selected photo in parallel.
  * This bypasses the /add screen for a faster multi‑event creation flow.
+ * Paywall logic:
+ * - First event is free.
+ * - If not the first event, and upcoming events > 5, requires "unlimited" entitlement.
  */
 export default function AddEventButton({
   showChevron = true,
+  stats,
 }: AddEventButtonProps) {
   const { isCapturing } = useInFlightEventStore();
+  const router = useRouter();
 
-  const { customerInfo, isLoading } = useRevenueCat();
+  const { customerInfo, isLoading: isRevenueCatLoading } = useRevenueCat();
   const hasUnlimited =
     customerInfo?.entitlements.active.unlimited?.isActive ?? false;
 
   const { triggerAddEventFlow } = useAddEventFlow();
+
+  const upcomingEventsCount = stats?.upcomingEvents ?? 0;
+  const allTimeEventsCount = stats?.allTimeEvents ?? 0;
+
+  let canProceedWithAdd = false;
+  if (allTimeEventsCount === 0) {
+    // First capture is always allowed
+    canProceedWithAdd = true;
+  } else {
+    if (upcomingEventsCount < 5) {
+      // Allowed if 5 or less upcoming events (and not the first capture)
+      canProceedWithAdd = true;
+    } else {
+      // More than 5 upcoming events, and not the first capture: requires unlimited
+      canProceedWithAdd = hasUnlimited;
+    }
+  }
+
+  const promptUserToUpgrade = () => {
+    // Navigate to settings/plans page.
+    // You might want to adjust this path to your specific subscription/plans screen.
+    router.push("/(tabs)/settings");
+  };
+
+  const handlePress = canProceedWithAdd
+    ? triggerAddEventFlow
+    : promptUserToUpgrade;
 
   /**
    * Small bounce for the chevron hint
@@ -99,12 +140,12 @@ export default function AddEventButton({
       </View>
 
       {/* Main action button */}
-      {!isLoading && (
+      {!isRevenueCatLoading && (
         <TouchableOpacity
-          onPress={triggerAddEventFlow}
+          onPress={handlePress}
           className="absolute bottom-8 self-center"
         >
-          {hasUnlimited ? (
+          {canProceedWithAdd ? (
             <View className="relative">
               <View
                 className="relative flex-row items-center justify-center gap-2 rounded-full bg-interactive-1 p-3"
@@ -137,7 +178,7 @@ export default function AddEventButton({
             </View>
           ) : (
             <View
-              className="flex-row items-center justify-center rounded-full bg-interactive-1 px-3 py-3.5"
+              className="flex-row items-center justify-center rounded-full bg-interactive-1 px-5 py-4"
               style={{
                 shadowColor: "#5A32FB",
                 shadowOffset: { width: 0, height: 3 },
@@ -147,7 +188,7 @@ export default function AddEventButton({
               }}
             >
               <Sparkles size={20} color="#FFF" />
-              <Text className="ml-2 text-2xl font-bold text-white">
+              <Text className="ml-2 text-3xl font-bold text-white">
                 Start your free trial
               </Text>
             </View>

--- a/apps/expo/src/components/FinishDemoButton.tsx
+++ b/apps/expo/src/components/FinishDemoButton.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "expo-router";
 import { toast } from "sonner-native";
 
 import { useOnboarding } from "~/hooks/useOnboarding";
-import { useRevenueCat } from "~/providers/RevenueCatProvider";
 
 interface FinishDemoButtonProps {
   text?: string;
@@ -16,7 +15,6 @@ export function FinishDemoButton({
   variant = "dark",
 }: FinishDemoButtonProps) {
   const router = useRouter();
-  const { showProPaywallIfNeeded } = useRevenueCat();
   const { completeOnboarding } = useOnboarding();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -26,7 +24,6 @@ export function FinishDemoButton({
 
     try {
       await completeOnboarding();
-      await showProPaywallIfNeeded();
       // Navigate to feed after paywall is handled
       router.push("/feed");
     } catch (error) {

--- a/apps/expo/src/components/ProfileMenu.tsx
+++ b/apps/expo/src/components/ProfileMenu.tsx
@@ -6,13 +6,7 @@ import { useUser } from "@clerk/clerk-expo";
 import Intercom from "@intercom/intercom-react-native";
 import * as DropdownMenu from "zeego/dropdown-menu";
 
-import {
-  HelpCircle,
-  LogOut,
-  MessageCircle,
-  ShareIcon,
-  User,
-} from "~/components/icons";
+import { LogOut, MessageCircle, ShareIcon, User } from "~/components/icons";
 import { useSignOut } from "~/hooks/useSignOut";
 import { logError } from "../utils/errorLogging";
 import { UserProfileFlair } from "./UserProfileFlair";
@@ -20,10 +14,6 @@ import { UserProfileFlair } from "./UserProfileFlair";
 export function ProfileMenu() {
   const { user } = useUser();
   const signOut = useSignOut();
-
-  const showOnboarding = () => {
-    router.push("/onboarding?demo=true");
-  };
 
   const handleEditProfile = () => {
     router.push("/settings/account");
@@ -86,13 +76,6 @@ export function ProfileMenu() {
             <User />
           </DropdownMenu.ItemIcon>
           <DropdownMenu.ItemTitle>Account</DropdownMenu.ItemTitle>
-        </DropdownMenu.Item>
-
-        <DropdownMenu.Item key="how-to-use" onSelect={showOnboarding}>
-          <DropdownMenu.ItemIcon ios={{ name: "questionmark.circle" }}>
-            <HelpCircle />
-          </DropdownMenu.ItemIcon>
-          <DropdownMenu.ItemTitle>How to use</DropdownMenu.ItemTitle>
         </DropdownMenu.Item>
 
         <DropdownMenu.Item key="support" onSelect={presentIntercom}>

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -13,7 +13,6 @@ import { FlatList } from "react-native-gesture-handler";
 import { Image } from "expo-image";
 import { router } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
-import Intercom from "@intercom/intercom-react-native";
 import { useMutationState, useQueryClient } from "@tanstack/react-query";
 
 import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
@@ -530,7 +529,6 @@ export default function UserEventsList(props: UserEventsListProps) {
     isFetchingNextPage,
     promoCard,
     demoMode,
-    hasUnlimited = false,
     stats,
     hideDiscoverableButton = false,
   } = props;
@@ -558,14 +556,6 @@ export default function UserEventsList(props: UserEventsListProps) {
   );
   const isAddingEvent =
     pendingAIMutations.filter((mutation) => mutation === "pending").length > 0;
-
-  const presentIntercom = async () => {
-    try {
-      await Intercom.present();
-    } catch (error) {
-      logError("Error presenting Intercom", error);
-    }
-  };
 
   const renderEmptyState = () => {
     if ((isAddingEvent || isRefetching) && collapsedEvents.length === 0) {

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -576,38 +576,6 @@ export default function UserEventsList(props: UserEventsListProps) {
       );
     }
 
-    if (!hasUnlimited) {
-      return (
-        <View className="flex-1 items-center justify-center px-6">
-          <Image
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            source={require("../assets/icon.png")}
-            style={{
-              width: 64,
-              height: 64,
-              marginBottom: 16,
-              borderRadius: 8,
-            }}
-            contentFit="contain"
-            cachePolicy="disk"
-            transition={100}
-          />
-          <Text className="mb-2 rounded-lg text-center text-2xl font-bold text-neutral-1">
-            Try free now
-          </Text>
-          <Pressable
-            className="mb-4 text-center text-base text-neutral-2"
-            onPress={presentIntercom}
-          >
-            <Text className="text-neutral-2">
-              Funds an issue?{" "}
-              <Text className="text-interactive-1">Message us</Text>
-            </Text>
-          </Pressable>
-        </View>
-      );
-    }
-
     return (
       <View className="flex-1 items-center justify-center px-6">
         <Image


### PR DESCRIPTION
- **Update button text and enhance AddEventButton functionality**
- **Refactor AddEventButton and UserEventsList for improved functionality and clarity**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event creation button with paywall logic, allowing unlimited events for subscribers and up to 5 upcoming events for non-subscribers.
- **Bug Fixes**
	- Removed obsolete Intercom messaging and subscription prompts from the user events list.
- **Style**
	- Updated button text from "Start your free trial" to "Get started" during onboarding.
- **Chores**
	- Simplified profile menu by removing the onboarding demo and unused icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->