### PR TITLE
 Remove explicit media library permission checks before image picker launch

### DIFF
--- a/apps/expo/src/app/event/[id]/edit.tsx
+++ b/apps/expo/src/app/event/[id]/edit.tsx
@@ -327,14 +327,6 @@ export default function EditEventScreen() {
 
   const pickImage = async () => {
     try {
-      const { status } =
-        await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-      if (status !== ImagePicker.PermissionStatus.GRANTED) {
-        toast.error("Permission to access media library is required");
-        return;
-      }
-
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: false,

--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -129,14 +129,6 @@ export default function EditProfileScreen() {
   const pickImage = useCallback(async () => {
     const loadingToastId = toast.loading("Updating profile image...");
     try {
-      const permissionResult =
-        await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-      if (!permissionResult.granted) {
-        toast.dismiss(loadingToastId);
-        throw new Error("Permission to access photos was denied");
-      }
-
       const result = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsEditing: true,

--- a/apps/expo/src/hooks/useMediaLibrary.ts
+++ b/apps/expo/src/hooks/useMediaLibrary.ts
@@ -1,3 +1,5 @@
+// Not used anymore, but keeping for reference
+
 import { useEffect } from "react";
 import { Image } from "expo-image";
 import * as MediaLibrary from "expo-media-library";


### PR DESCRIPTION
* Removed media library permission checks from image picker functions in both EditEventScreen and EditProfileScreen to streamline the image selection process.
* Updated useMediaLibrary hook with a comment indicating it's no longer in use, retaining it for reference.

This change enhances the user experience by simplifying the image selection workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined image selection by removing explicit media library permission checks when picking images in event editing and account settings screens.
  - Added a clarifying comment to indicate an unused media library hook is retained for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->