### PR TITLE
Add DB table export script

### DIFF
--- a/packages/db/eslint.config.js
+++ b/packages/db/eslint.config.js
@@ -3,7 +3,7 @@ import baseConfig from "@soonlist/eslint-config/base";
 /** @type {import('typescript-eslint').Config} */
 export default [
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "scripts/**"],
   },
   ...baseConfig,
 ];

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,6 +32,7 @@
     "studio": "pnpm with-env drizzle-kit studio --config src/config.ts",
     "studio:prod": "pnpm with-env:production drizzle-kit studio --config src/config.ts",
     "dr": "pscale dr create timetime dev",
+    "export:tables": "pnpm with-env node ./scripts/export-tables.js",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "with-env": "dotenv -e ../../.env.local --",
     "with-env:production": "dotenv -e ../../.env.production --"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -33,6 +33,7 @@
     "studio:prod": "pnpm with-env:production drizzle-kit studio --config src/config.ts",
     "dr": "pscale dr create timetime dev",
     "export:tables": "pnpm with-env node ./scripts/export-tables.js",
+    "format:events": "node ./scripts/format-events.js",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "with-env": "dotenv -e ../../.env.local --",
     "with-env:production": "dotenv -e ../../.env.production --"

--- a/packages/db/scripts/export-tables.js
+++ b/packages/db/scripts/export-tables.js
@@ -1,25 +1,25 @@
-import { createConnection } from 'mysql2/promise';
-import fs from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { createConnection } from "mysql2/promise";
 
 const DATABASE_URL = process.env.DATABASE_URL;
 if (!DATABASE_URL) {
-  console.error('DATABASE_URL environment variable is not set');
+  console.error("DATABASE_URL environment variable is not set");
   process.exit(1);
 }
 
 async function main() {
   const connection = await createConnection(DATABASE_URL);
-  const [tables] = await connection.query('SHOW TABLES');
+  const [tables] = await connection.query("SHOW TABLES");
   if (!Array.isArray(tables) || tables.length === 0) {
-    console.error('No tables found');
+    console.error("No tables found");
     await connection.end();
     return;
   }
   const tableKey = Object.keys(tables[0])[0];
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const exportDir = path.resolve(__dirname, '../../exports');
+  const exportDir = path.resolve(__dirname, "../../exports");
   await fs.mkdir(exportDir, { recursive: true });
 
   for (const row of tables) {

--- a/packages/db/scripts/export-tables.js
+++ b/packages/db/scripts/export-tables.js
@@ -1,0 +1,39 @@
+import { createConnection } from 'mysql2/promise';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL environment variable is not set');
+  process.exit(1);
+}
+
+async function main() {
+  const connection = await createConnection(DATABASE_URL);
+  const [tables] = await connection.query('SHOW TABLES');
+  if (!Array.isArray(tables) || tables.length === 0) {
+    console.error('No tables found');
+    await connection.end();
+    return;
+  }
+  const tableKey = Object.keys(tables[0])[0];
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const exportDir = path.resolve(__dirname, '../../exports');
+  await fs.mkdir(exportDir, { recursive: true });
+
+  for (const row of tables) {
+    const tableName = row[tableKey];
+    const [rows] = await connection.query(`SELECT * FROM \`${tableName}\``);
+    const filePath = path.join(exportDir, `${tableName}.json`);
+    await fs.writeFile(filePath, JSON.stringify(rows, null, 2));
+    console.log(`Exported ${tableName} to ${filePath}`);
+  }
+
+  await connection.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/db/scripts/format-events.js
+++ b/packages/db/scripts/format-events.js
@@ -16,7 +16,7 @@ async function formatEvents() {
 
     if (!fsSync.existsSync(eventsPath)) {
       console.error("Events.json file not found at:", eventsPath);
-      return;
+      process.exit(1);
     }
 
     const eventsData = JSON.parse(await fs.readFile(eventsPath, "utf8"));

--- a/packages/db/scripts/format-events.js
+++ b/packages/db/scripts/format-events.js
@@ -1,0 +1,95 @@
+import fsSync from "fs";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function formatEvents() {
+  try {
+    // Read the Events.json file
+    const eventsPath = path.join(__dirname, "../../exports/Events.json");
+    const outputPath = path.join(
+      __dirname,
+      "../../exports/Events-formatted.json",
+    );
+
+    if (!fsSync.existsSync(eventsPath)) {
+      console.error("Events.json file not found at:", eventsPath);
+      return;
+    }
+
+    const eventsData = JSON.parse(await fs.readFile(eventsPath, "utf8"));
+
+    console.log(`Processing ${eventsData.length} events...`);
+
+    // Transform each event
+    const formattedEvents = eventsData
+      .map((eventItem, index) => {
+        try {
+          const { event, eventMetadata, ...topLevelProps } = eventItem;
+
+          // Extract the required keys from the nested event object
+          const {
+            name,
+            images = [],
+            endDate,
+            endTime,
+            location,
+            timeZone,
+            startDate,
+            startTime,
+            description,
+            ...otherEventProps
+          } = event || {};
+
+          // Get the first image or null if no images
+          const image = images && images.length > 0 ? images[0] : null;
+
+          // Create the formatted event object
+          const formattedEvent = {
+            ...topLevelProps, // Keep existing top-level properties (id, userId, userName, created_at, updatedAt)
+            name,
+            image,
+            endDate,
+            endTime,
+            location,
+            timeZone,
+            startDate,
+            startTime,
+            description,
+            // Keep the specified top-level DateTime and visibility properties
+            endDateTime: eventItem.endDateTime,
+            startDateTime: eventItem.startDateTime,
+            visibility: eventItem.visibility,
+          };
+
+          return formattedEvent;
+        } catch (error) {
+          console.error(`Error processing event at index ${index}:`, error);
+          return null;
+        }
+      })
+      .filter((event) => event !== null); // Remove any null entries from failed processing
+
+    // Write the formatted events to a new file
+    await fs.writeFile(outputPath, JSON.stringify(formattedEvents, null, 2));
+
+    console.log(`✅ Successfully formatted ${formattedEvents.length} events`);
+    console.log(`📁 Output saved to: ${outputPath}`);
+
+    // Show a sample of the transformation
+    if (formattedEvents.length > 0) {
+      console.log("\n📋 Sample formatted event:");
+      console.log(JSON.stringify(formattedEvents[0], null, 2));
+    }
+  } catch (error) {
+    console.error("❌ Error formatting events:", error);
+  }
+}
+
+// Run the formatting function
+formatEvents().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a script to export each db table into JSON
- expose script via `pnpm export:tables`

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to export all database tables to JSON files.
  - Introduced a tool to reformat and clean up event data from JSON files for easier use.
- **Chores**
  - Updated available commands to include new data export and formatting tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->