### PR TITLE
Enable no-floating-promises ESLint rule

### DIFF
--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -60,6 +60,7 @@ export default tseslint.config(
         2,
         { checksVoidReturn: { attributes: false } },
       ],
+      "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-unnecessary-condition": [
         // "error",
         "warn",


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-floating-promises` in base ESLint config

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting rules to enforce proper handling of promises in TypeScript code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->