### PR TITLE
Fix timestamp refresh to avoid render errors

### DIFF
--- a/apps/expo/src/hooks/useEventActions.ts
+++ b/apps/expo/src/hooks/useEventActions.ts
@@ -12,7 +12,7 @@ import { toast } from "sonner-native";
 import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useAppStore } from "~/store";
+import { useStableTimestamp } from "~/store";
 import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { getPlanStatusFromUser } from "~/utils/plan";
@@ -35,7 +35,7 @@ export function useEventActions({
   const { user } = useUser();
   const isOwner = demoMode || (event && user?.id === event.user?.id);
   const showDiscover = user ? getPlanStatusFromUser(user).showDiscover : false;
-  const stableTimestamp = useAppStore((state) => state.getStableTimestamp());
+  const stableTimestamp = useStableTimestamp();
 
   const deleteEventMutation = useMutation(api.events.deleteEvent);
   const unfollowEventMutation = useMutation(api.events.unfollow);

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -1,6 +1,6 @@
-import React from "react";
 import type { FunctionReturnType } from "convex/server";
 import type * as Calendar from "expo-calendar";
+import React from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -440,15 +440,12 @@ export const useUserTimezone = () => useAppStore((state) => state.userTimezone);
 
 // Stable timestamp selectors
 export const useStableTimestamp = () => {
-  const {
-    stableTimestamp,
-    lastTimestampUpdate,
-    refreshStableTimestamp,
-  } = useAppStore((state) => ({
-    stableTimestamp: state.stableTimestamp,
-    lastTimestampUpdate: state.lastTimestampUpdate,
-    refreshStableTimestamp: state.refreshStableTimestamp,
-  }));
+  const { stableTimestamp, lastTimestampUpdate, refreshStableTimestamp } =
+    useAppStore((state) => ({
+      stableTimestamp: state.stableTimestamp,
+      lastTimestampUpdate: state.lastTimestampUpdate,
+      refreshStableTimestamp: state.refreshStableTimestamp,
+    }));
 
   React.useEffect(() => {
     const now = Date.now();


### PR DESCRIPTION
## Summary
- avoid updating store state during render by removing side effects from `getStableTimestamp`
- refresh the stable timestamp via effect in `useStableTimestamp`
- use the new hook in `useEventActions`

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683a4bb3e800832ab7ccc1a9f4394ce2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of timestamp updates by ensuring they refresh automatically if more than 15 minutes have passed.
- **Chores**
	- Updated internal logic to enhance timestamp management for better app consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->