### PR TITLE
Fix logout redirect issues and navigation loops

### DIFF
--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -225,8 +225,7 @@ export default function EditProfileScreen() {
                 await signOut({ shouldDeleteAccount: true });
                 toast.dismiss(loadingToastId);
                 toast.success("Account deleted successfully");
-                // Navigate to onboarding welcome after sign out
-                router.replace("/(onboarding)/onboarding");
+                // No manual navigation needed - Convex auth components will handle the transition
               } catch (error) {
                 logError("Error deleting account", error);
                 toast.dismiss(loadingToastId);

--- a/apps/expo/src/components/AuthAndTokenSync.tsx
+++ b/apps/expo/src/components/AuthAndTokenSync.tsx
@@ -102,7 +102,13 @@ export default function AuthAndTokenSync() {
         }
       } catch (error) {
         if (!cancelled) {
-          logError("Auth sync error", error);
+          // Ignore "You are signed out" errors as these are expected during logout
+          if (
+            error instanceof Error &&
+            !error.message?.includes("You are signed out")
+          ) {
+            logError("Auth sync error", error);
+          }
         }
       }
     };

--- a/apps/expo/src/components/ProfileMenu.tsx
+++ b/apps/expo/src/components/ProfileMenu.tsx
@@ -24,25 +24,21 @@ export function ProfileMenu() {
   const { user } = useUser();
   const { isAuthenticated } = useConvexAuth();
   const signOut = useSignOut();
-  const { setHasSeenOnboarding, setHasCompletedOnboarding } = useAppStore();
+  const { resetOnboarding } = useAppStore();
 
   const handleSignOut = () => {
-    signOut()
-      .catch((error) => {
-        // Ignore "You are signed out" errors as these are expected
-        // when third-party services try to logout after Clerk has already signed out
-        if (
-          error instanceof Error &&
-          !error.message?.includes("You are signed out")
-        ) {
-          logError("Error during sign out process", error);
-          toast.error("Failed to sign out. Please try again.");
-        }
-      })
-      .finally(() => {
-        // Navigate to onboarding welcome after sign out attempt (success or expected error)
-        router.replace("/(onboarding)/onboarding");
-      });
+    signOut().catch((error) => {
+      // Ignore "You are signed out" errors as these are expected
+      // when third-party services try to logout after Clerk has already signed out
+      if (
+        error instanceof Error &&
+        !error.message?.includes("You are signed out")
+      ) {
+        logError("Error during sign out process", error);
+        toast.error("Failed to sign out. Please try again.");
+      }
+    });
+    // No manual navigation needed - Convex auth components will handle the transition
   };
 
   const handleEditProfile = () => {
@@ -67,9 +63,8 @@ export function ProfileMenu() {
   };
 
   const handleResetOnboarding = () => {
-    // Reset onboarding state
-    setHasSeenOnboarding(false);
-    setHasCompletedOnboarding(false);
+    // Reset onboarding state using the resetOnboarding function
+    resetOnboarding();
 
     // Navigate to onboarding
     router.replace("/(onboarding)/onboarding");

--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -16,6 +16,7 @@ interface SignOutOptions {
 export const useSignOut = () => {
   const { signOut, userId } = useAuth();
   const resetStore = useAppStore((state) => state.resetStore);
+  const resetForLogout = useAppStore((state) => state.resetForLogout);
   const setHasCompletedOnboarding = useAppStore(
     (state) => state.setHasCompletedOnboarding,
   );
@@ -85,7 +86,12 @@ export const useSignOut = () => {
     });
 
     // Step 4: Reset local app state AFTER successful sign out.
-    resetStore();
+    // Use full reset for account deletion, partial reset for regular logout
+    if (options?.shouldDeleteAccount) {
+      resetStore();
+    } else {
+      resetForLogout();
+    }
     setHasCompletedOnboarding(false);
   };
 };

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -142,6 +142,7 @@ interface AppState {
   hasSeenOnboarding: boolean;
   setHasSeenOnboarding: (seen: boolean) => void;
   resetStore: () => void;
+  resetForLogout: () => void;
 
   // Media-related state & actions
   recentPhotos: RecentPhoto[];
@@ -405,6 +406,53 @@ export const useAppStore = create<AppState>()(
           currentOnboardingStep: null,
           workflowIds: [],
         }),
+
+      // Reset for logout - preserves onboarding state
+      resetForLogout: () =>
+        set((state) => ({
+          filter: "upcoming",
+          intentParams: null,
+          isCalendarModalVisible: false,
+          showAllCalendars: false,
+          addEventState: {
+            input: "",
+            imagePreview: null,
+            linkPreview: null,
+            isPublic: false,
+            isImageLoading: false,
+            isImageUploading: false,
+            uploadedImageUrl: null,
+            isOptionSelected: false,
+            activeInput: null,
+          },
+          newEventState: {
+            input: "",
+            imagePreview: null,
+            linkPreview: null,
+            isPublic: false,
+            isImageLoading: false,
+            isImageUploading: false,
+            uploadedImageUrl: null,
+          },
+          defaultCalendarId: null,
+          availableCalendars: [],
+          selectedEvent: null,
+          calendarUsage: {},
+          recentPhotos: [],
+          hasMediaPermission: false,
+          hasFullPhotoAccess: false,
+          userPriority: null,
+          userTimezone: getUserTimeZone(),
+          hasShownTimezoneAlert: false,
+          stableTimestamp: createStableTimestamp(),
+          lastTimestampUpdate: Date.now(),
+          // Preserve onboarding state for logout
+          hasCompletedOnboarding: false,
+          hasSeenOnboarding: state.hasSeenOnboarding, // Keep this value
+          onboardingData: {},
+          currentOnboardingStep: null,
+          workflowIds: [],
+        })),
 
       // Stable timestamp for query filtering
       stableTimestamp: createStableTimestamp(),


### PR DESCRIPTION
## Summary
This PR fixes multiple issues with the logout flow that were causing redirect loops and double navigation pushes.

## Changes
- Added `resetForLogout` function to preserve `hasSeenOnboarding` state during regular logout
- Updated `useSignOut` hook to use appropriate reset function based on logout type
- Removed manual navigation after logout to let Convex auth components handle transitions
- Fixed error handling to ignore expected "You are signed out" errors

## Issues Fixed
- ✅ Multiple redirects between sign-up and onboarding screens after logout
- ✅ Double navigation push causing visual glitches
- ✅ Users being incorrectly treated as new users after logout
- ✅ Race conditions between auth state updates and navigation

## Test Plan
1. Log in as an authenticated user
2. Log out using the profile menu
3. Verify smooth transition to sign-in page without multiple redirects
4. Verify you stay on sign-in page (not redirected to onboarding)
5. Test account deletion flow to ensure full reset still works

🤖 Generated with [Claude Code](https://claude.ai/code)