### PR TITLE
Increase event loading in app screens

### DIFF
--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -42,7 +42,7 @@ function DiscoverContent() {
       beforeThisDateTime: stableTimestamp,
     },
     {
-      initialNumItems: 20,
+      initialNumItems: 50,
     },
   );
 
@@ -59,7 +59,7 @@ function DiscoverContent() {
 
   const handleLoadMore = useCallback(() => {
     if (status === "CanLoadMore") {
-      loadMore(20);
+      loadMore(25);
     }
   }, [status, loadMore]);
 

--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -34,12 +34,12 @@ function MyFeedContent() {
     status,
     loadMore,
   } = useStablePaginatedQuery(api.feeds.getMyFeed, queryArgs, {
-    initialNumItems: 20,
+    initialNumItems: 50,
   });
 
   const handleLoadMore = useCallback(() => {
     if (status === "CanLoadMore") {
-      loadMore(20);
+      loadMore(25);
     }
   }, [status, loadMore]);
 

--- a/apps/expo/src/app/(tabs)/past.tsx
+++ b/apps/expo/src/app/(tabs)/past.tsx
@@ -35,12 +35,12 @@ function PastEventsContent() {
     loadMore,
     isLoading,
   } = useStablePaginatedQuery(api.feeds.getMyFeed, queryArgs, {
-    initialNumItems: 20,
+    initialNumItems: 50,
   });
 
   const handleLoadMore = useCallback(() => {
     if (status === "CanLoadMore") {
-      loadMore(20);
+      loadMore(25);
     }
   }, [status, loadMore]);
 


### PR DESCRIPTION
Increase initial event load to 50 and subsequent loads to 25 for feed, past, and discover screens to improve content density.