### PR TITLE
fix: improve OneSignal environment detection in Convex

### DIFF
--- a/packages/backend/convex/README_NOTIFICATIONS.md
+++ b/packages/backend/convex/README_NOTIFICATIONS.md
@@ -128,6 +128,9 @@ The system includes automated cron jobs defined in `convex/crons.ts`:
 Make sure these environment variables are configured in your Convex deployment:
 
 ```bash
+# Environment Configuration
+CONVEX_ENV=development|production  # Explicitly set the environment (defaults to production)
+
 # OneSignal Configuration
 ONE_SIGNAL_REST_API_KEY_DEV=your-dev-key
 ONE_SIGNAL_REST_API_KEY_PROD=your-prod-key
@@ -144,6 +147,14 @@ ANTHROPIC_API_KEY=your-anthropic-key
 # Security
 CRON_SECRET=your-cron-secret
 ```
+
+### Environment Detection
+
+The notification system uses the `CONVEX_ENV` environment variable to determine which OneSignal credentials to use:
+
+- Set `CONVEX_ENV=development` for development environments
+- Set `CONVEX_ENV=production` for production environments
+- If not set, it falls back to `NODE_ENV`, then defaults to `production`
 
 ## Key Features
 

--- a/packages/backend/convex/model/oneSignal.ts
+++ b/packages/backend/convex/model/oneSignal.ts
@@ -3,7 +3,17 @@
 // OneSignal REST API base URL
 const ONE_SIGNAL_API_URL = "https://onesignal.com/api/v1";
 
-const IS_DEV = process.env.NODE_ENV === "development";
+// Use CONVEX_ENV for explicit environment detection, fallback to NODE_ENV
+const ENV = process.env.CONVEX_ENV || process.env.NODE_ENV || "production";
+const IS_DEV = ENV === "development";
+
+// Log environment detection for debugging
+console.log("OneSignal Environment Detection:", {
+  CONVEX_ENV: process.env.CONVEX_ENV,
+  NODE_ENV: process.env.NODE_ENV,
+  ENV,
+  IS_DEV,
+});
 
 // OneSignal API key from environment variables
 const ONE_SIGNAL_REST_API_KEY = IS_DEV
@@ -18,6 +28,11 @@ const EXPO_PUBLIC_ONE_SIGNAL_APP_ID = IS_DEV
 if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
   console.warn(
     "OneSignal API key or App ID not configured. Notifications will not be sent.",
+    {
+      hasApiKey: !!ONE_SIGNAL_REST_API_KEY,
+      hasAppId: !!EXPO_PUBLIC_ONE_SIGNAL_APP_ID,
+      environment: IS_DEV ? "development" : "production",
+    },
   );
 }
 
@@ -71,7 +86,13 @@ export async function sendNotification({
 }> {
   // If OneSignal is not configured, log and return early
   if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
-    console.error("OneSignal API key or App ID not configured");
+    console.error("OneSignal API key or App ID not configured", {
+      userId,
+      title,
+      environment: IS_DEV ? "development" : "production",
+      hasApiKey: !!ONE_SIGNAL_REST_API_KEY,
+      hasAppId: !!EXPO_PUBLIC_ONE_SIGNAL_APP_ID,
+    });
     return {
       success: false,
       error: "OneSignal API key or App ID not configured",
@@ -121,6 +142,13 @@ export async function sendNotification({
       );
     }
 
+    console.log("OneSignal notification sent successfully", {
+      userId,
+      title,
+      oneSignalId: "id" in result ? result.id : undefined,
+      environment: IS_DEV ? "development" : "production",
+    });
+
     return {
       success: true,
       id: "id" in result ? result.id : undefined,
@@ -158,7 +186,13 @@ export async function sendBatchNotifications({
 }> {
   // If OneSignal is not configured, log and return early
   if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
-    console.error("OneSignal API key or App ID not configured");
+    console.error("OneSignal API key or App ID not configured", {
+      userIds: userIds.length,
+      title,
+      environment: IS_DEV ? "development" : "production",
+      hasApiKey: !!ONE_SIGNAL_REST_API_KEY,
+      hasAppId: !!EXPO_PUBLIC_ONE_SIGNAL_APP_ID,
+    });
     return {
       success: false,
       error: "OneSignal API key or App ID not configured",


### PR DESCRIPTION
## Summary
- Add CONVEX_ENV environment variable support for explicit environment control
- Fix notification issues in TestFlight where incorrect OneSignal credentials might be used
- Add comprehensive logging to help diagnose notification delivery issues

## Problem
Push notifications were not being received when testing in TestFlight. After investigation, the issue appears to be related to environment detection in the Convex backend, which determines whether to use development or production OneSignal credentials.

## Solution
1. **Explicit Environment Control**: Added support for `CONVEX_ENV` environment variable that takes precedence over `NODE_ENV`
2. **Improved Detection Logic**: Environment detection now follows: `CONVEX_ENV` → `NODE_ENV` → default to "production"
3. **Enhanced Logging**: Added detailed logging to track which environment is detected and which credentials are being used

## Changes
- Updated `packages/backend/convex/model/oneSignal.ts` to use CONVEX_ENV for environment detection
- Added logging for debugging notification issues
- Updated documentation in `README_NOTIFICATIONS.md` with CONVEX_ENV configuration instructions

## Test plan
- [ ] Set `CONVEX_ENV=production` in Convex production environment
- [ ] Deploy changes to production
- [ ] Monitor Convex logs for environment detection output
- [ ] Test event creation in TestFlight and verify notifications are received
- [ ] Check logs for any OneSignal API errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated notification system documentation to clarify environment variable usage and fallback behavior.

* **Chores**
  * Enhanced logging for notification-related operations, providing more detailed diagnostic and success information about environment detection and configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->