### PR TITLE
ci: update Claude review workflow to skip drafts and allow manual triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,14 +2,14 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]  # Run on initial PR creation and when marked ready
+    types: [opened, ready_for_review] # Run on initial PR creation and when marked ready
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
-  
+
   # Also trigger when someone comments '@claude review' on a PR
   issue_comment:
     types: [created]
@@ -26,18 +26,32 @@ jobs:
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request && 
        contains(github.event.comment.body, '@claude review'))
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
+      - name: Get PR details for issue_comment events
+        if: github.event_name == 'issue_comment'
+        id: pr-details
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$PR_URL")
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # For pull_request events, checkout the PR head
+          # For issue_comment events, checkout the PR head ref from the API call above
+          ref: ${{ github.event_name == 'issue_comment' && steps.pr-details.outputs.head_sha || github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
@@ -45,10 +59,10 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Direct prompt for automated review
           # Note: This review runs automatically on:
           # - New non-draft PRs
@@ -61,9 +75,9 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
-          
+
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -71,18 +85,17 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,30 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, ready_for_review]  # Run on initial PR creation and when marked ready
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  
+  # Also trigger when someone comments '@claude review' on a PR
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run if:
+    # 1. It's a new non-draft PR (opened event), OR
+    # 2. A draft PR is marked as ready for review, OR
+    # 3. It's a comment on a PR that contains '@claude review'
+    if: |
+      (github.event_name == 'pull_request' && 
+       github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request && 
+       contains(github.event.comment.body, '@claude review'))
     
     runs-on: ubuntu-latest
     permissions:
@@ -40,7 +49,11 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
           
-          # Direct prompt for automated review (no @claude mention needed)
+          # Direct prompt for automated review
+          # Note: This review runs automatically on:
+          # - New non-draft PRs
+          # - When draft PRs are marked as ready for review
+          # - When someone comments '@claude review'
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,9 +40,37 @@ jobs:
         id: pr-details
         run: |
           PR_URL="${{ github.event.issue.pull_request.url }}"
-          PR_DATA=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$PR_URL")
-          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
-          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          echo "Fetching PR details from: $PR_URL"
+
+          # Fetch PR data with error handling
+          if ! PR_DATA=$(curl -s -f -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$PR_URL"); then
+            echo "Error: Failed to fetch PR data from GitHub API"
+            exit 1
+          fi
+
+          # Validate the API response contains valid JSON
+          if ! echo "$PR_DATA" | jq empty 2>/dev/null; then
+            echo "Error: Invalid JSON response from GitHub API"
+            echo "Response: $PR_DATA"
+            exit 1
+          fi
+
+          # Extract head ref and sha with validation
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref // empty')
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha // empty')
+
+          # Validate that required fields are not empty
+          if [[ -z "$HEAD_REF" || "$HEAD_REF" == "null" ]]; then
+            echo "Error: Could not extract head.ref from PR data"
+            exit 1
+          fi
+
+          if [[ -z "$HEAD_SHA" || "$HEAD_SHA" == "null" ]]; then
+            echo "Error: Could not extract head.sha from PR data"
+            exit 1
+          fi
+
+          echo "Successfully extracted PR details: ref=$HEAD_REF, sha=$HEAD_SHA"
           echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
 
@@ -51,7 +79,7 @@ jobs:
         with:
           # For pull_request events, checkout the PR head
           # For issue_comment events, checkout the PR head ref from the API call above
-          ref: ${{ github.event_name == 'issue_comment' && steps.pr-details.outputs.head_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || steps.pr-details.outputs.head_sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           # For pull_request events, checkout the PR head
           # For issue_comment events, checkout the PR head ref from the API call above
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || steps.pr-details.outputs.head_sha }}
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || (github.event_name == 'issue_comment' && steps.pr-details.outputs.head_sha) }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary
- Configure Claude Code to only review on initial PR creation (non-draft) and when tagged
- Skip automatic reviews on draft PRs
- Run reviews when draft PRs are marked as ready for review
- Allow manual triggering via '@claude review' comment on any PR

## Changes
- Modified `.github/workflows/claude-code-review.yml`:
  - Changed PR event types from `[opened, synchronize]` to `[opened, ready_for_review]`
  - Added `issue_comment` event trigger for manual reviews
  - Added conditional logic to skip draft PRs
  - Updated documentation comments to reflect new behavior

## Test plan
- [ ] Create a draft PR - Claude should not review automatically
- [ ] Mark the draft PR as ready for review - Claude should review
- [ ] Create a non-draft PR - Claude should review automatically
- [ ] Comment '@claude review' on any PR - Claude should perform a review

🤖 Generated with [Claude Code](https://claude.ai/code)