### PR TITLE
fix: resolve Expo app authentication disconnection issues

### DIFF
--- a/apps/expo/src/components/OnboardingRedirect.tsx
+++ b/apps/expo/src/components/OnboardingRedirect.tsx
@@ -18,7 +18,7 @@ export function OnboardingRedirect() {
   // Use "skip" pattern when user is not available or not authenticated
   const userData = useQuery(
     api.users.getById,
-    isAuthenticated && user?.id ? { id: user.id } : "skip"
+    isAuthenticated && user?.id ? { id: user.id } : "skip",
   );
 
   useEffect(() => {

--- a/apps/expo/src/components/OnboardingRedirect.tsx
+++ b/apps/expo/src/components/OnboardingRedirect.tsx
@@ -15,7 +15,11 @@ export function OnboardingRedirect() {
   const { hasCompletedOnboarding } = useAppStore();
 
   // Get user data from our database
-  const userData = useQuery(api.users.getById, { id: user?.id ?? "" });
+  // Use "skip" pattern when user is not available or not authenticated
+  const userData = useQuery(
+    api.users.getById,
+    isAuthenticated && user?.id ? { id: user.id } : "skip"
+  );
 
   useEffect(() => {
     // Only proceed if user data is loaded and user is authenticated

--- a/apps/expo/src/hooks/useTokenRefresh.ts
+++ b/apps/expo/src/hooks/useTokenRefresh.ts
@@ -1,5 +1,6 @@
+import type { AppStateStatus } from "react-native";
 import { useEffect, useRef } from "react";
-import { AppState, AppStateStatus } from "react-native";
+import { AppState } from "react-native";
 import { useAuth } from "@clerk/clerk-expo";
 
 import { logError, logMessage } from "~/utils/errorLogging";
@@ -48,7 +49,7 @@ export function useTokenRefresh() {
     // Handle app state changes (foreground/background)
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       if (
-        appStateRef.current.match(/inactive|background/) &&
+        /inactive|background/.exec(appStateRef.current) &&
         nextAppState === "active"
       ) {
         // App has come to foreground - refresh token
@@ -64,9 +65,12 @@ export function useTokenRefresh() {
     );
 
     // Set up periodic token refresh (every 5 minutes)
-    const intervalId = setInterval(() => {
-      void refreshToken();
-    }, 5 * 60 * 1000);
+    const intervalId = setInterval(
+      () => {
+        void refreshToken();
+      },
+      5 * 60 * 1000,
+    );
 
     // Initial token fetch
     void refreshToken();

--- a/apps/expo/src/hooks/useTokenRefresh.ts
+++ b/apps/expo/src/hooks/useTokenRefresh.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from "react";
+import { AppState, AppStateStatus } from "react-native";
+import { useAuth } from "@clerk/clerk-expo";
+
+import { logError, logMessage } from "~/utils/errorLogging";
+
+/**
+ * Hook to monitor and refresh Clerk tokens for Convex
+ * - Refreshes token when app comes to foreground
+ * - Periodically checks token validity
+ * - Ensures fresh tokens for WebSocket connections
+ */
+export function useTokenRefresh() {
+  const { getToken, isSignedIn } = useAuth();
+  const lastRefreshRef = useRef<Date>(new Date());
+  const appStateRef = useRef(AppState.currentState);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+
+    // Function to refresh token
+    const refreshToken = async () => {
+      try {
+        const now = new Date();
+        const timeSinceLastRefresh =
+          now.getTime() - lastRefreshRef.current.getTime();
+
+        // Only refresh if it's been more than 30 seconds since last refresh
+        if (timeSinceLastRefresh < 30000) {
+          return;
+        }
+
+        const token = await getToken({ template: "convex" });
+        if (token) {
+          lastRefreshRef.current = now;
+          logMessage("Token refreshed successfully", {}, { type: "info" });
+        } else {
+          logError(
+            "Failed to refresh token",
+            new Error("Token refresh returned null"),
+          );
+        }
+      } catch (error) {
+        logError("Error refreshing token", error);
+      }
+    };
+
+    // Handle app state changes (foreground/background)
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (
+        appStateRef.current.match(/inactive|background/) &&
+        nextAppState === "active"
+      ) {
+        // App has come to foreground - refresh token
+        void refreshToken();
+      }
+      appStateRef.current = nextAppState;
+    };
+
+    // Set up app state listener
+    const subscription = AppState.addEventListener(
+      "change",
+      handleAppStateChange,
+    );
+
+    // Set up periodic token refresh (every 5 minutes)
+    const intervalId = setInterval(() => {
+      void refreshToken();
+    }, 5 * 60 * 1000);
+
+    // Initial token fetch
+    void refreshToken();
+
+    return () => {
+      subscription.remove();
+      clearInterval(intervalId);
+    };
+  }, [getToken, isSignedIn]);
+}


### PR DESCRIPTION
## Summary

This PR addresses authentication disconnection issues in the Expo app that started occurring after the Convex migration. The fixes ensure proper token management and prevent queries from running before authentication completes.

## Problem

Users were experiencing random authentication disconnections in the Expo app, particularly:
- After the app was backgrounded and resumed
- During normal usage when tokens expired
- When queries ran before authentication completed

## Solution

### 1. Fixed Clerk JWT Token Template
- Changed `getToken()` to `getToken({ template: "convex" })` as required by Convex documentation
- Added null check before saving tokens to SecureStore
- Added sessionId monitoring to detect auth state changes

### 2. Implemented Skip Pattern for Queries
- Fixed `OnboardingRedirect` to use the "skip" pattern when user is not authenticated
- Prevents `ctx.auth.getUserIdentity()` from returning null due to premature queries

### 3. Added Proactive Token Refresh
- Created `useTokenRefresh` hook that:
  - Refreshes tokens when app returns to foreground
  - Performs periodic refresh every 5 minutes
  - Prevents stale tokens in WebSocket connections

## Testing

- [x] Lint, format, and typecheck all pass
- [ ] Test app backgrounding and foregrounding
- [ ] Verify authentication persists after extended periods
- [ ] Confirm no disconnections during normal usage

## Related Documentation
- [Convex Clerk Integration](https://docs.convex.dev/auth/clerk)
- [Debugging Convex Auth](https://docs.convex.dev/auth/debug)

🤖 Generated with [Claude Code](https://claude.ai/code)