### PR TITLE
fix: handle share extension deep links when app is closed

### DIFF
--- a/apps/expo/src/hooks/useIntentHandler.ts
+++ b/apps/expo/src/hooks/useIntentHandler.ts
@@ -63,7 +63,9 @@ export function useIntentHandler() {
           return;
         }
 
-        const route = parsedUrl.pathname.replace(/^\/+/, "");
+        // For custom scheme URLs like soonlist.dev://new?params
+        // the "new" part is parsed as hostname, not pathname
+        const route = parsedUrl.hostname || parsedUrl.pathname.replace(/^\/+/, "");
         const params = parsedUrl.searchParams;
 
         logDebug("Route", {

--- a/apps/expo/src/hooks/useIntentHandler.ts
+++ b/apps/expo/src/hooks/useIntentHandler.ts
@@ -65,7 +65,8 @@ export function useIntentHandler() {
 
         // For custom scheme URLs like soonlist.dev://new?params
         // the "new" part is parsed as hostname, not pathname
-        const route = parsedUrl.hostname || parsedUrl.pathname.replace(/^\/+/, "");
+        const route =
+          parsedUrl.hostname || parsedUrl.pathname.replace(/^\/+/, "");
         const params = parsedUrl.searchParams;
 
         logDebug("Route", {


### PR DESCRIPTION
## Summary
- Fixed deep link routing when app is launched from closed state via share extension
- The issue was that custom scheme URLs parse the route as hostname instead of pathname

## Test plan
- [x] Close the app completely
- [x] Share an image to Soonlist via share extension
- [x] Verify the app opens to the new event screen with the image

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom scheme URLs to ensure routes are correctly extracted, enhancing navigation reliability for various URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->