### PR TITLE
Fix: Remove trailing periods from onboarding copy

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/00-welcome.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/00-welcome.tsx
@@ -44,7 +44,7 @@ export default function WelcomeScreen() {
                 <Text className="text-interactive-1">plans</Text>
               </Text>
               <Text className="mb-4 text-center text-lg text-gray-500">
-                Save events in one tap. All in one place.
+                Save events in one tap. All in one place
               </Text>
             </AnimatedView>
           </View>

--- a/apps/expo/src/app/(onboarding)/onboarding/01-intro.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/01-intro.tsx
@@ -13,7 +13,7 @@ export default function IntroScreen() {
   return (
     <QuestionContainer
       question="Welcome to Soonlist 👋"
-      subtitle="We'll personalize your experience based on a few quick questions."
+      subtitle="We'll customize your experience based on a few quick questions"
       currentStep={2}
       totalSteps={TOTAL_ONBOARDING_STEPS}
     >

--- a/apps/expo/src/app/(onboarding)/onboarding/02-goals.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/02-goals.tsx
@@ -62,7 +62,7 @@ export default function GoalsScreen() {
   return (
     <QuestionContainer
       question="What do you want to use Soonlist for?"
-      subtitle="Pick as many as you like."
+      subtitle="Pick as many as you like"
       currentStep={3}
       totalSteps={TOTAL_ONBOARDING_STEPS}
     >

--- a/apps/expo/src/app/(onboarding)/onboarding/07-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/07-notifications.tsx
@@ -81,7 +81,7 @@ export default function NotificationsScreen() {
   return (
     <QuestionContainer
       question="Let's get started!"
-      subtitle="Turn on notifications to save events, get reminders, and never miss what's coming up."
+      subtitle="Turn on notifications to save events, get reminders, and never miss what's coming up"
       currentStep={7}
       totalSteps={TOTAL_ONBOARDING_STEPS}
     >
@@ -91,11 +91,11 @@ export default function NotificationsScreen() {
             <View className="rounded-2xl bg-white">
               <View className="px-2 pb-3 pt-4">
                 <Text className="mb-2 px-4 text-center text-xl font-semibold leading-6">
-                  Turn on Push Notifications to capture and remember.
+                  Turn on Push Notifications to capture and remember
                 </Text>
                 <Text className="mb-2 px-4 text-center text-sm leading-5">
                   Soonlist notifies you when events are created, and to help you
-                  build a habit of capturing events.
+                  build a habit of capturing events
                 </Text>
               </View>
               <View className="flex-row border-t border-[#3c3c43]/30">


### PR DESCRIPTION
## Summary
- Removed trailing periods from onboarding screen copy for consistency
- Changed "personalize" to "customize" in intro screen text

## Changes
- Welcome screen: "Save events in one tap. All in one place." → "Save events in one tap. All in one place"
- Intro screen: "We'll personalize your experience based on a few quick questions." → "We'll customize your experience based on a few quick questions"
- Goals screen: "Pick as many as you like." → "Pick as many as you like"
- Notifications screen: Removed periods from all three text strings

## Test plan
✅ All linting, formatting, and type checks pass
✅ Visual review of affected onboarding screens

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed trailing periods from various text and subtitle strings throughout the onboarding screens for improved consistency in formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->