### PR TITLE
Fix upcoming events filter to include in-progress events

### DIFF
--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -60,14 +60,15 @@ async function queryFeed(
       if (!event) return null;
 
       // Only include events that match our filter criteria
-      if (beforeThisDateTime) {
-        const eventStartTime = new Date(event.startDateTime).getTime();
-        const referenceTime = new Date(beforeThisDateTime).getTime();
+      const eventEndTime = new Date(event.endDateTime).getTime();
+      const eventStartTime = new Date(event.startDateTime).getTime();
+      const referenceTime = beforeThisDateTime 
+        ? new Date(beforeThisDateTime).getTime() 
+        : Date.now();
 
-        if (filter === "upcoming" && eventStartTime < referenceTime)
-          return null;
-        if (filter === "past" && eventStartTime >= referenceTime) return null;
-      }
+      if (filter === "upcoming" && eventEndTime < referenceTime)
+        return null;
+      if (filter === "past" && eventStartTime >= referenceTime) return null;
 
       // Fetch the user who created the event
       const user = await ctx.db

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -142,7 +142,7 @@ export async function getUpcomingEventsForUser(
   ctx: QueryCtx,
   userName: string,
 ) {
-  const now = new Date(new Date().getTime() - 24 * 60 * 60 * 1000); // 24 hours ago
+  const now = new Date();
 
   const user = await ctx.db
     .query("users")
@@ -157,7 +157,7 @@ export async function getUpcomingEventsForUser(
   const createdEvents = await ctx.db
     .query("events")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
-    .filter((q) => q.gte(q.field("startDateTime"), now.toISOString()))
+    .filter((q) => q.gte(q.field("endDateTime"), now.toISOString()))
     .collect();
 
   // Get saved events
@@ -173,7 +173,7 @@ export async function getUpcomingEventsForUser(
       .withIndex("by_custom_id", (q) => q.eq("id", follow.eventId))
       .unique();
 
-    if (event && new Date(event.startDateTime) > now) {
+    if (event && new Date(event.endDateTime) >= now) {
       savedEvents.push(event);
     }
   }


### PR DESCRIPTION
## Summary
- Fixed the upcoming events view to correctly show events that are currently in progress
- Changed filtering logic from using `startDateTime` to `endDateTime` for upcoming events
- Removed the 24-hour offset that was causing past events to appear in upcoming view

## Changes Made
1. **feeds.ts**: Updated event filtering to use `endDateTime` for upcoming events filter
2. **events.ts**: Already correctly used `endDateTime` for filtering
3. **model/events.ts**: 
   - Removed 24-hour offset from `getUpcomingEventsForUser`
   - Changed filter from `startDateTime` to `endDateTime` for both created and saved events

## Test Plan
- [ ] Verify that events currently in progress appear in the upcoming events view
- [ ] Confirm that past events (where endDateTime has passed) do not appear in upcoming view
- [ ] Check that future events still appear correctly
- [ ] Test pagination to ensure filtering works correctly with beforeThisDateTime parameter

🤖 Generated with [Claude Code](https://claude.ai/code)