### PR TITLE
docs: Placeholder for making eventEndTime required

### DIFF
--- a/packages/backend/convex/migrations/makeEventEndTimeRequired.ts
+++ b/packages/backend/convex/migrations/makeEventEndTimeRequired.ts
@@ -1,0 +1,21 @@
+// NOTE: This file documents the future schema change to make eventEndTime required
+// After the addEventEndTimeToFeeds migration completes successfully,
+// update the schema.ts file to change:
+//   eventEndTime: v.optional(v.number())
+// to:
+//   eventEndTime: v.number()
+//
+// Also update all places where userFeeds entries are created to ensure
+// eventEndTime is always provided (it should already be after the first PR).
+
+export const makeEventEndTimeRequired = `
+After migration completes, update schema.ts:
+
+userFeeds: defineTable({
+  feedId: v.string(),
+  eventId: v.string(),
+  eventStartTime: v.number(),
+  eventEndTime: v.number(), // Remove v.optional()
+  addedAt: v.number(),
+})
+`;


### PR DESCRIPTION
## Summary
This PR adds a documentation file that outlines the schema change to be made after the migration in PR #636 completes.

## Details
After the `addEventEndTimeToFeeds` migration successfully populates all existing feed entries with `eventEndTime`, we need to:
1. Change the schema to make `eventEndTime` required (remove `v.optional()`)
2. Ensure all code paths that create userFeeds entries include eventEndTime (should already be done)

## Important
**DO NOT MERGE** this PR until:
1. PR #636 is merged and deployed
2. The migration has completed successfully in production
3. All existing userFeeds entries have been populated with eventEndTime

Once those conditions are met, this PR can be updated to actually implement the schema change.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration instructions for making the event end time field required in user feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->