### PR TITLE
fix: Feed query performance with hasEnded field (v3)

### DIFF
--- a/packages/backend/convex/planetscaleSync.ts
+++ b/packages/backend/convex/planetscaleSync.ts
@@ -556,6 +556,7 @@ export const upsertEvent = internalMutation({
           userId: args.userId,
           visibility: args.visibility,
           startDateTime: args.startDateTime,
+          endDateTime: args.endDateTime,
         });
       }
     } else {
@@ -568,6 +569,7 @@ export const upsertEvent = internalMutation({
         userId: args.userId,
         visibility: args.visibility,
         startDateTime: args.startDateTime,
+        endDateTime: args.endDateTime,
       });
     }
     return null;

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -182,13 +182,17 @@ export default defineSchema({
     eventStartTime: v.number(), // For chronological ordering (timestamp)
     eventEndTime: v.number(), // For filtering ongoing/past events (timestamp)
     addedAt: v.number(), // When added to feed (timestamp)
-    hasEnded: v.boolean(), // Pre-computed field: true if event has ended, false if ongoing/upcoming
+    hasEnded: v.optional(v.boolean()), // Pre-computed field: true if event has ended, false if ongoing/upcoming
   })
     .index("by_feed_time", ["feedId", "eventStartTime"])
     .index("by_feed_event", ["feedId", "eventId"]) // For deduplication checks
     .index("by_event", ["eventId"]) // For event removal across all feeds
     .index("by_feed_endTime", ["feedId", "eventEndTime"]) // For efficient time-based queries
-    .index("by_feed_hasEnded_startTime", ["feedId", "hasEnded", "eventStartTime"]), // For efficient filtering and sorting
+    .index("by_feed_hasEnded_startTime", [
+      "feedId",
+      "hasEnded",
+      "eventStartTime",
+    ]), // For efficient filtering and sorting
 
   guestOnboardingData: defineTable({
     ownerToken: v.string(), // Guest user ID

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -180,12 +180,15 @@ export default defineSchema({
     feedId: v.string(), // Feed identifier (user_${userId}, discover, curated_${topic}, etc.)
     eventId: v.string(), // Event in the feed
     eventStartTime: v.number(), // For chronological ordering (timestamp)
-    eventEndTime: v.optional(v.number()), // For filtering ongoing/past events (timestamp) - optional during migration
+    eventEndTime: v.number(), // For filtering ongoing/past events (timestamp)
     addedAt: v.number(), // When added to feed (timestamp)
+    hasEnded: v.boolean(), // Pre-computed field: true if event has ended, false if ongoing/upcoming
   })
     .index("by_feed_time", ["feedId", "eventStartTime"])
     .index("by_feed_event", ["feedId", "eventId"]) // For deduplication checks
-    .index("by_event", ["eventId"]), // For event removal across all feeds
+    .index("by_event", ["eventId"]) // For event removal across all feeds
+    .index("by_feed_endTime", ["feedId", "eventEndTime"]) // For efficient time-based queries
+    .index("by_feed_hasEnded_startTime", ["feedId", "hasEnded", "eventStartTime"]), // For efficient filtering and sorting
 
   guestOnboardingData: defineTable({
     ownerToken: v.string(), // Guest user ID


### PR DESCRIPTION
## Summary

This is a fresh PR with all the fixes from the review feedback on #641. This PR adds the `hasEnded` field as **optional** and implements efficient database-level filtering for feed queries.

## Changes Made

### 🔧 Fixed Critical Issues from Review
1. **Fixed infinite loop bug** in `updateHasEndedFlags` - now uses proper pagination with cursor tracking
2. **Removed unused `beforeThisDateTime` parameter** from all feed queries (backend and frontend)
3. **Improved type safety** in migration code

### 📊 Performance Improvements
- Database-level filtering using new `by_feed_hasEnded_startTime` index
- Eliminates post-fetch filtering overhead
- Consistent pagination behavior (fixes "2 items vs 10 items" issue)
- Maintains sort order by `eventStartTime`

### 🔄 Migration Strategy
- `hasEnded` field is **optional** in schema (will be made required in a follow-up PR)
- Migration handles backfilling for existing records
- 10-minute cron job keeps `hasEnded` flags up-to-date
- Client-side safety filters provide additional protection

## Prerequisites
- PR #640 must be deployed first (adds optional `eventEndTime` field)
- Migration must run to populate all `hasEnded` values

## Testing
- All lint, format, and typecheck pass
- Backward compatibility maintained
- No breaking API changes

Closes #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events in feeds now display both start and end times.
  * Events are marked as ended or ongoing/upcoming based on their end time.
* **Improvements**
  * Event feeds are updated more accurately when event times or visibility change, ensuring up-to-date information.
  * Enhanced performance for event feed queries, especially for filtering and sorting by event status and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->