### PR TITLE
 Remove beforeThisDateTime parameter from event feed API queries

### DIFF
--- a/apps/web/app/(base)/[userName]/upcoming/page.tsx
+++ b/apps/web/app/(base)/[userName]/upcoming/page.tsx
@@ -66,14 +66,12 @@ export default function Page({ params }: Props) {
   // For viewing another user's feed, only show their created events
   const myFeedArgs = {
     filter: "upcoming" as const,
-    beforeThisDateTime: stableNow.toISOString(),
   };
 
   const userCreatedArgs = targetUser
     ? {
         userId: targetUser.id,
         filter: "upcoming" as const,
-        beforeThisDateTime: stableNow.toISOString(),
       }
     : "skip";
 


### PR DESCRIPTION
- Eliminated the beforeThisDateTime parameter from the myFeedArgs and userCreatedArgs objects in the upcoming page to enhance code clarity and streamline data fetching.
- This change aligns with recent updates to the feed handling logic, ensuring consistency across the application.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upcoming events feed by adjusting date filtering for event queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->