### PR TITLE
 @coderabbitai

### DIFF
--- a/packages/backend/convex/migrations/userFeedsMigration.ts
+++ b/packages/backend/convex/migrations/userFeedsMigration.ts
@@ -210,3 +210,31 @@ export const runCleanupOrphanedFeedEntries = migrations.runner(
 // export const runPopulateHasEndedField = migrations.runner(
 //   internal.migrations.userFeedsMigration.populateHasEndedField,
 // );
+
+// Migration to set beforeThisDateTime to undefined for all userFeeds records
+export const unsetBeforeThisDateTime = migrations.define({
+  table: "userFeeds",
+  batchSize: 100,
+  migrateOne: async (ctx, feedEntry) => {
+    try {
+      // Only update if beforeThisDateTime is set
+      if (
+        "beforeThisDateTime" in feedEntry &&
+        feedEntry.beforeThisDateTime !== undefined
+      ) {
+        await ctx.db.patch(feedEntry._id, { beforeThisDateTime: undefined });
+        console.log(`Unset beforeThisDateTime for feed entry ${feedEntry._id}`);
+      }
+    } catch (error) {
+      console.error(
+        `Failed to unset beforeThisDateTime for feed entry ${feedEntry._id}:`,
+        error,
+      );
+      throw error;
+    }
+  },
+});
+
+export const runUnsetBeforeThisDateTime = migrations.runner(
+  internal.migrations.userFeedsMigration.unsetBeforeThisDateTime,
+);

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -185,6 +185,7 @@ export default defineSchema({
     eventEndTime: v.number(), // For filtering ongoing/past events (timestamp)
     addedAt: v.number(), // When added to feed (timestamp)
     hasEnded: v.boolean(), // Pre-computed field: true if event has ended, false if ongoing/upcoming (now required)
+    beforeThisDateTime: v.optional(v.string()), // Optional ISO date string for custom filtering
   })
     .index("by_feed_hasEnded_startTime", [
       "feedId",


### PR DESCRIPTION
- Introduced beforeThisDateTime as an optional ISO date string for custom filtering in the userFeeds schema.
- Implemented a migration to unset beforeThisDateTime for existing userFeeds records, ensuring data consistency and integrity.

This change enhances the filtering capabilities of user feeds while maintaining backward compatibility.
