### PR TITLE
 Add @react-native-community/netinfo to dependencies and workspace files

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -42,6 +42,7 @@
     "@intercom/intercom-react-native": "catalog:",
     "@react-native-async-storage/async-storage": "catalog:",
     "@react-native-community/datetimepicker": "catalog:",
+    "@react-native-community/netinfo": "catalog:",
     "@sentry/react-native": "catalog:",
     "@soonlist/api": "workspace:*",
     "@soonlist/backend": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ catalogs:
     '@react-native-community/datetimepicker':
       specifier: ^8.4.1
       version: 8.4.1
+    '@react-native-community/netinfo':
+      specifier: ^11.4.1
+      version: 11.4.1
     '@sentry/nextjs':
       specifier: ^8.35.0
       version: 8.55.0
@@ -578,6 +581,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 'catalog:'
         version: 8.4.1(expo@53.0.19(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0)))(babel-plugin-react-compiler@19.0.0-beta-af1b7da-20250417)(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0)
+      '@react-native-community/netinfo':
+        specifier: 'catalog:'
+        version: 11.4.1(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))
       '@sentry/react-native':
         specifier: 'catalog:'
         version: 6.14.0(encoding@0.1.13)(expo@53.0.19(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0)))(babel-plugin-react-compiler@19.0.0-beta-af1b7da-20250417)(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0)
@@ -4302,6 +4308,11 @@ packages:
         optional: true
       react-native-windows:
         optional: true
+
+  '@react-native-community/netinfo@11.4.1':
+    resolution: {integrity: sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==}
+    peerDependencies:
+      react-native: '>=0.59'
 
   '@react-native-menu/menu@1.2.3':
     resolution: {integrity: sha512-sEfiVIivsa0lSelFm9Wbm/RAi+XoEHc75GGhjwvSrj9KSCVvNNXwr9F8l42e1t/lzYvVYzmkYxLG6VKxrDYJiw==}
@@ -13535,6 +13546,10 @@ snapshots:
       react-native: 0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0)
     optionalDependencies:
       expo: 53.0.19(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0)))(babel-plugin-react-compiler@19.0.0-beta-af1b7da-20250417)(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0)
+
+  '@react-native-community/netinfo@11.4.1(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))':
+    dependencies:
+      react-native: 0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0)
 
   '@react-native-menu/menu@1.2.3(react-native@0.79.5(@babel/core@7.27.1)(@types/react@19.1.5)(react@19.0.0))(react@19.0.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -115,6 +115,7 @@ catalog:
   # React Native Additional packages
   "@react-native-async-storage/async-storage": 2.1.2
   "@react-native-community/datetimepicker": ^8.4.1
+  "@react-native-community/netinfo": ^11.4.1
   "react-native-appsflyer": ^6.15.3
   "react-native-ios-context-menu": ^3.1.0
   "react-native-ios-utilities": ^5.1.0


### PR DESCRIPTION
- Included @react-native-community/netinfo version 11.4.1 in pnpm-lock.yaml and pnpm-workspace.yaml for network state management.
- Updated package.json in the Expo app to reference the new netinfo package, ensuring proper integration for network connectivity features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the @react-native-community/netinfo package as a dependency for improved network information support in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->