### PR TITLE
 Refactor userFeeds hasEnded updates to use batched mutations and pagination

### DIFF
--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -32,7 +32,7 @@ crons.cron(
 crons.cron(
   "update hasEnded flags",
   "*/15 * * * *", // Every 15 minutes
-  internal.feeds.updateHasEndedFlags,
+  internal.feeds.updateHasEndedFlagsAction,
   {},
 );
 


### PR DESCRIPTION
Refactored the updateHasEndedFlags functionality to avoid Convex's "multiple paginated queries" limitation:

- Replaced single mutation with action-based approach
- Created updateHasEndedFlagsBatch mutation for processing single batches
- Created updateHasEndedFlagsAction to orchestrate multiple batch calls
- Updated cron job to use the new action
- Fixed unnecessary undefined check in hasEnded comparison

This fixes the cron job error that was occurring every 15 minutes due to attempting multiple paginated queries within a single mutation. The new approach handles large datasets (5000+ events) efficiently by processing them in batches.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the process for updating "hasEnded" flags to use a more efficient, paginated batch approach, enhancing performance and reliability for large data sets.

* **Chores**
  * Updated scheduled background tasks to use the new batch-based update method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->