### PR TITLE
 Set visibility to "public" in transformConvexEventsAsPublic function

### DIFF
--- a/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
@@ -62,7 +62,7 @@ function transformConvexEventsAsPublic(
         eventMetadata: event.eventMetadata,
         endDateTime: new Date(event.endDateTime),
         startDateTime: new Date(event.startDateTime),
-        visibility: event.visibility,
+        visibility: "public", // This is only used for public lists that a user have opted into, so we can safely set it to public.
         createdAt: new Date(event._creationTime),
         user: transformConvexUser(event.user),
         eventFollows: [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event visibility handling to consistently display events as "public" in public lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->