### PR TITLE
 Set visibility to "public" in transformConvexEventsAsPublic function Add type guard for events with users and expand public event list query

### DIFF
--- a/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
@@ -62,7 +62,7 @@ function transformConvexEventsAsPublic(
         eventMetadata: event.eventMetadata,
         endDateTime: new Date(event.endDateTime),
         startDateTime: new Date(event.startDateTime),
-        visibility: event.visibility,
+        visibility: "public", // This is only used for public lists that a user have opted into, so we can safely set it to public.
         createdAt: new Date(event._creationTime),
         user: transformConvexUser(event.user),
         eventFollows: [],

--- a/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
@@ -64,7 +64,7 @@ function transformConvexEventsAsPublic(
     eventMetadata: event.eventMetadata,
     endDateTime: new Date(event.endDateTime),
     startDateTime: new Date(event.startDateTime),
-    visibility: event.visibility,
+    visibility: "public",
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user),
     eventFollows: [],

--- a/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
@@ -28,6 +28,12 @@ interface Props {
   params: Promise<{ userName: string }>;
 }
 
+function hasConvexUser<T extends { user: Doc<"users"> | null }>(
+  item: T,
+): item is T & { user: Doc<"users"> } {
+  return item.user !== null;
+}
+
 const transformConvexUser = (user: Doc<"users">): User => {
   return {
     ...user,
@@ -47,29 +53,24 @@ function transformConvexEventsAsPublic(
 ): EventWithUser[] {
   if (!events) return [];
 
-  return (
-    events
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive programming for runtime safety
-      .filter((event) => event.user !== null)
-      .map((event) => ({
-        id: event.id,
-        userId: event.userId,
-        updatedAt: event.updatedAt ? new Date(event.updatedAt) : null,
-        userName: event.userName,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        event: event.event,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        eventMetadata: event.eventMetadata,
-        endDateTime: new Date(event.endDateTime),
-        startDateTime: new Date(event.startDateTime),
-        visibility: "public", // This is only used for public lists that a user have opted into, so we can safely set it to public.
-        createdAt: new Date(event._creationTime),
-        user: transformConvexUser(event.user),
-        eventFollows: [],
-        comments: [],
-        eventToLists: [],
-      }))
-  );
+  return events.filter(hasConvexUser).map((event) => ({
+    id: event.id,
+    userId: event.userId,
+    updatedAt: event.updatedAt ? new Date(event.updatedAt) : null,
+    userName: event.userName,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    event: event.event,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    eventMetadata: event.eventMetadata,
+    endDateTime: new Date(event.endDateTime),
+    startDateTime: new Date(event.startDateTime),
+    visibility: event.visibility,
+    createdAt: new Date(event._creationTime),
+    user: transformConvexUser(event.user),
+    eventFollows: [],
+    comments: [],
+    eventToLists: [],
+  }));
 }
 
 // Transform Convex events to EventWithUser format (for feed events)
@@ -78,27 +79,24 @@ function transformConvexEvents(
 ): EventWithUser[] {
   if (!events) return [];
 
-  return events
-    .filter((event) => event.user !== null)
-    .map((event) => ({
-      id: event.id,
-      userId: event.userId,
-      updatedAt: event.updatedAt ? new Date(event.updatedAt) : null,
-      userName: event.userName,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      event: event.event,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      eventMetadata: event.eventMetadata,
-      endDateTime: new Date(event.endDateTime),
-      startDateTime: new Date(event.startDateTime),
-      visibility: event.visibility,
-      createdAt: new Date(event._creationTime),
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- user is guaranteed to exist after filter
-      user: transformConvexUser(event.user!),
-      eventFollows: [],
-      comments: [],
-      eventToLists: [],
-    }));
+  return events.filter(hasConvexUser).map((event) => ({
+    id: event.id,
+    userId: event.userId,
+    updatedAt: event.updatedAt ? new Date(event.updatedAt) : null,
+    userName: event.userName,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    event: event.event,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    eventMetadata: event.eventMetadata,
+    endDateTime: new Date(event.endDateTime),
+    startDateTime: new Date(event.startDateTime),
+    visibility: event.visibility,
+    createdAt: new Date(event._creationTime),
+    user: transformConvexUser(event.user),
+    eventFollows: [],
+    comments: [],
+    eventToLists: [],
+  }));
 }
 
 export default function PublicListClient({ params }: Props) {


### PR DESCRIPTION
- **Set visibility to "public" in transformConvexEventsAsPublic for public lists in PublicListClient.tsx**
- **Refactor event filtering in PublicListClient to use hasConvexUser for null safety and improve readability. Update getPublicListEvents to enrich events and filter based on visibility for public lists.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public event lists now include both events created by the user and events the user follows.
  * Followed events are shown only if they are public, while all created events are visible to the user.

* **Refactor**
  * Enhanced event filtering and data enrichment for a more consistent and streamlined event display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->