### PR TITLE
Improve public list sharing: URL-only for iMessage OG + metadata as 'list name by display name'

### DIFF
--- a/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/list/PublicListClient.tsx
@@ -144,18 +144,10 @@ export default function PublicListClient({ params }: Props) {
 
   const handleShareClick = async () => {
     const url = `${window.location.origin}/${userName}/list`;
-    const listName =
-      publicListData?.user.publicListName ||
-      `${publicListData?.user.displayName}'s events`;
-
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- navigator.share may not exist in all browsers
     if (navigator.share) {
       try {
-        await navigator.share({
-          title: `${listName} | Soonlist`,
-          text: `Check out ${listName} on Soonlist`,
-          url: url,
-        });
+        await navigator.share({ url });
         console.log("List shared successfully");
       } catch (error) {
         console.error("Error sharing:", error);

--- a/apps/web/app/(base)/[userName]/list/page.tsx
+++ b/apps/web/app/(base)/[userName]/list/page.tsx
@@ -31,19 +31,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const listName =
       publicListData.user.publicListName ||
       `${publicListData.user.displayName}'s events`;
+    const byline = `by ${publicListData.user.displayName}`;
 
     return {
-      title: `${listName} | Soonlist`,
-      description: `Check out ${publicListData.user.displayName}'s events on Soonlist`,
+      title: `${listName} ${byline}`,
+      description: `Check out ${listName} ${byline}`,
       openGraph: {
-        title: `${listName} | Soonlist`,
-        description: `Check out ${publicListData.user.displayName}'s events on Soonlist`,
+        title: `${listName} ${byline}`,
+        description: `Check out ${listName} ${byline}`,
         type: "website",
       },
       twitter: {
         card: "summary",
-        title: `${listName} | Soonlist`,
-        description: `Check out ${publicListData.user.displayName}'s events on Soonlist`,
+        title: `${listName} ${byline}`,
+        description: `Check out ${listName} ${byline}`,
       },
     };
   } catch (error) {

--- a/packages/api/src/routers/aiHelpers.ts
+++ b/packages/api/src/routers/aiHelpers.ts
@@ -44,7 +44,7 @@ const openrouter = createOpenAI({
   apiKey: process.env.OPENROUTER_API_KEY || "",
   baseURL: process.env.OPENROUTER_BASE_URL || "",
 });
-const MODEL = "google/gemini-2.0-flash-001";
+const MODEL = "google/gemini-2.5-flash";
 const aiConfig = {
   model: openrouter(MODEL),
   mode: "json",

--- a/packages/backend/convex/model/aiHelpers.ts
+++ b/packages/backend/convex/model/aiHelpers.ts
@@ -27,7 +27,7 @@ const openrouter = createOpenAI({
   apiKey: process.env.OPENROUTER_API_KEY || "",
   baseURL: process.env.OPENROUTER_BASE_URL || "",
 });
-const MODEL = "google/gemini-2.0-flash-001";
+const MODEL = "google/gemini-2.5-flash";
 const aiConfig = {
   model: openrouter(MODEL),
   mode: "json",


### PR DESCRIPTION
Changes:\n- Share only the URL from public list page so iMessage shows Open Graph preview.\n- Metadata titles/descriptions now use 'list name by display name' across OG/Twitter.\n\nFiles:\n- apps/web/app/(base)/[userName]/list/PublicListClient.tsx\n- apps/web/app/(base)/[userName]/list/page.tsx\n\nThis should make shares render a clean preview in iMessage and display a clearer title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved share functionality for public lists by simplifying the shared content to only include the URL.
  * Updated public list page metadata for more consistent and descriptive titles and descriptions, now including the list name and user display name.
  * Upgraded AI model used for generating responses to enhance performance and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->