### PR TITLE
 Add /event/* Universal Link for GQ59Z4XZHZ.com.soonlist.app

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -2,9 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": [
-          "GQ59Z4XZHZ.com.soonlist.app"
-        ],
+        "appID": "GQ59Z4XZHZ.com.soonlist.app",
         "paths": [
           "/event/*"
         ]

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -5,7 +5,9 @@
         "appIDs": [
           "GQ59Z4XZHZ.com.soonlist.app"
         ],
-        "components": []
+        "paths": [
+          "/event/*"
+        ]
       }
     ]
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS Universal Links now open /event/* pages directly in the Soonlist app for a smoother handoff from web to app.

* **Bug Fixes**
  * Improved reliability of Universal Link matching on iOS by refining the domain association so event links consistently open in-app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->