### PR TITLE
 Add applinks:soonlist.com to iOS associatedDomains in Expo config

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -173,7 +173,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         },
       ],
     },
-    associatedDomains: ["applinks:www.soonlist.com"],
+    associatedDomains: ["applinks:www.soonlist.com", "applinks:soonlist.com"],
   },
   android: {
     package: getUniqueIdentifier(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - iOS universal links from soonlist.com (non-www) now open directly in the app. Previously, only www.soonlist.com links deep-linked. This ensures consistent behavior for links from emails, messages, Safari, and other apps.
- Chores
  - Updated app configuration to expand associated domains for iOS universal links. No user action required; behavior takes effect with the next app update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->