### PR TITLE
Add Save to Soon button for deep linking to mobile app

### DIFF
--- a/apps/web/components/EventCard.tsx
+++ b/apps/web/components/EventCard.tsx
@@ -24,6 +24,7 @@ export default function EventCard(props: {
   followButton?: React.ReactNode;
   editButton?: React.ReactNode;
   deleteButton?: React.ReactNode;
+  saveToSoonButton?: React.ReactNode;
 }) {
   const {
     eventImage,
@@ -43,6 +44,7 @@ export default function EventCard(props: {
     followButton,
     editButton,
     deleteButton,
+    saveToSoonButton,
   } = props;
 
   const displayName = userDisplayName || (userName ? userName : "");
@@ -76,6 +78,7 @@ export default function EventCard(props: {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {saveToSoonButton}
           {calendarButton}
           {shareButton}
         </div>

--- a/apps/web/components/EventDisplays.tsx
+++ b/apps/web/components/EventDisplays.tsx
@@ -51,6 +51,7 @@ import { EditButton } from "./EditButton";
 import EventCard from "./EventCard";
 import { FollowEventButton } from "./FollowButtons";
 import { buildDefaultUrl } from "./ImageUpload";
+import { SaveToSoonButton } from "./SaveToSoonButton";
 import { ShareButton } from "./ShareButton";
 import { UserProfileFlair } from "./UserProfileFlair";
 
@@ -615,6 +616,7 @@ function EventActionButtons({
       size === "sm" ? "transform scale-[0.55] origin-bottom-right" : "";
     return (
       <div className={cn("flex w-full flex-wrap items-center gap-3", scale)}>
+        <SaveToSoonButton eventId={id} type="icon" variant="outline" />
         <ShareButton type="icon" event={event} id={id} />
         <CalendarButton
           type="icon"
@@ -665,6 +667,7 @@ function EventActionButtons({
           />
         </Link>
       </div>
+      <SaveToSoonButton eventId={id} type="icon" variant="outline" />
       <ShareButton type="icon" event={event} id={id} />
       <CalendarButton
         type="icon"
@@ -782,18 +785,14 @@ export function EventListItem(props: EventListItemProps) {
                 />
               )}
           </div>
-          <div className="absolute -bottom-0.5 -right-2 z-10">
-            {/* <EventActionButtons
-              user={user}
-              event={event as AddToCalendarButtonPropsRestricted}
-              id={id}
-              isOwner={!!isOwner}
-              isFollowing={isFollowing}
-              visibility={props.visibility}
-              variant="minimal"
-              size="sm"
-            /> */}
-
+          <div className="absolute -bottom-0.5 -right-2 z-10 flex gap-1">
+            <SaveToSoonButton
+              eventId={id}
+              type="icon"
+              variant="outline"
+              size="icon"
+              className="origin-bottom-right scale-[0.55] transform"
+            />
             {!isOwner && (
               <FollowEventButton
                 eventId={id}
@@ -1041,6 +1040,9 @@ export function EventPage(props: EventPageProps) {
         />
       }
       shareButton={<ShareButton type="icon" event={event} id={id} />}
+      saveToSoonButton={
+        <SaveToSoonButton eventId={id} type="icon" variant="outline" />
+      }
       followButton={
         <div>
           {user && !isSelf && (

--- a/apps/web/components/SaveToSoonButton.tsx
+++ b/apps/web/components/SaveToSoonButton.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Smartphone } from "lucide-react";
+
+import { Button } from "@soonlist/ui/button";
+
+interface SaveToSoonButtonProps {
+  eventId: string;
+  variant?: "default" | "outline" | "secondary" | "ghost" | "link";
+  size?: "default" | "sm" | "lg" | "icon";
+  className?: string;
+  type?: "button" | "icon";
+}
+
+const APP_STORE_URL = "https://apps.apple.com/us/app/soonlist/id6467723160";
+
+export function SaveToSoonButton({
+  eventId,
+  variant = "default",
+  size = "default",
+  className,
+  type = "button",
+}: SaveToSoonButtonProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isIOS = () => {
+    if (typeof navigator === "undefined") return false;
+    return /iPad|iPhone|iPod/.test(navigator.userAgent);
+  };
+
+  const handleSaveToSoon = () => {
+    setIsLoading(true);
+
+    // Check if we're on iOS
+    if (!isIOS()) {
+      // Not on iOS, go directly to App Store
+      window.open(APP_STORE_URL, "_blank");
+      setIsLoading(false);
+      return;
+    }
+
+    // Try universal link first (works if app is installed)
+    const universalLink = `https://soonlist.com/event/${eventId}`;
+
+    // Create a timer to fallback to App Store
+    const fallbackTimer = setTimeout(() => {
+      window.location.href = APP_STORE_URL;
+      setIsLoading(false);
+    }, 2000);
+
+    // Try to open the universal link
+    try {
+      window.location.href = universalLink;
+
+      // If the app opens, the page will lose focus
+      // Clear the fallback timer if we detect the app opened
+      const visibilityChangeHandler = () => {
+        if (document.visibilityState === "hidden") {
+          clearTimeout(fallbackTimer);
+          setIsLoading(false);
+        }
+      };
+
+      document.addEventListener("visibilitychange", visibilityChangeHandler);
+
+      // Clean up the event listener after a delay
+      setTimeout(() => {
+        document.removeEventListener(
+          "visibilitychange",
+          visibilityChangeHandler,
+        );
+      }, 3000);
+    } catch (error) {
+      console.error("Error opening app:", error);
+      clearTimeout(fallbackTimer);
+      window.location.href = APP_STORE_URL;
+      setIsLoading(false);
+    }
+  };
+
+  if (type === "icon") {
+    return (
+      <Button
+        onClick={handleSaveToSoon}
+        size="icon"
+        variant={variant}
+        className={className}
+        disabled={isLoading}
+        title="Save to Soon"
+      >
+        <Smartphone className="h-6 w-6" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      onClick={handleSaveToSoon}
+      variant={variant}
+      size={size}
+      className={className}
+      disabled={isLoading}
+    >
+      <Smartphone className="mr-2 h-4 w-4" />
+      {isLoading ? "Opening..." : "Save to Soon"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add reusable SaveToSoonButton component that enables users to save events to the mobile app
- Implement smart app detection that opens the Soonlist app if installed or App Store if not
- Integrate the button across all event displays in the web app

## Technical Implementation
- **Universal Links**: Uses https://soonlist.com/event/{eventId} to attempt app opening
- **Fallback Strategy**: Opens App Store after 2-second timeout if app doesn't open
- **iOS Detection**: Detects iOS devices and opens App Store in new tab for non-iOS users  
- **App Detection**: Uses visibilitychange event to detect when app successfully opens

## Integration Points
- Event ID pages (/event/[eventId])
- Event lists and cards (all variants including minimal and card views)
- Positioned alongside existing share and calendar buttons
- Follows existing button patterns with icon and full button variants

## Test Plan
- [ ] Test on iOS device with app installed - should open to specific event
- [ ] Test on iOS device without app - should open App Store
- [ ] Test on non-iOS device - should open App Store in new tab
- [ ] Verify button appears on event pages, lists, and cards
- [ ] Confirm styling matches existing button patterns

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Save to Soon button across event views (cards, lists, and event pages), appearing alongside existing action icons.
  * Tapping the button opens the Soon app via a universal link; if the app isn’t installed, it directs you to the App Store.
  * Supports both icon-only and standard button styles, sized to fit each layout, with responsive loading states to prevent duplicate taps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->