### PR TITLE
 Add index param and stable React keys in iconNode map

### DIFF
--- a/apps/expo/src/components/icons/createLucideIcon.ts
+++ b/apps/expo/src/components/icons/createLucideIcon.ts
@@ -39,13 +39,14 @@ const createLucideIcon = (iconName: string, iconNode: IconNode): LucideIcon => {
           ...customAttrs,
         },
         [
-          ...(iconNode.map(([tag, attrs]) => {
+          ...(iconNode.map(([tag, attrs], index) => {
             const upperCasedTag = (tag.charAt(0).toUpperCase() +
               tag.slice(1)) as keyof typeof NativeSvg;
             // duplicating the attributes here because generating the OTA update bundles don't inherit the SVG properties from parent (codepush, expo-updates)
             return createElement(
               NativeSvg[upperCasedTag] as FunctionComponent<LucideProps>,
               {
+                key: `${iconName}-${index}`,
                 ...childDefaultAttributes,
                 ...customAttrs,
                 ...attrs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved occasional React warnings and rare visual inconsistencies in icons by ensuring stable keys for icon elements.

* **Performance**
  * Improved rendering stability for icons during dynamic updates or list rendering, reducing unnecessary re-renders and flicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->