### PR TITLE
 Add OneSignal timezone scheduling and weekly digest cron action

### DIFF
--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -8,7 +8,7 @@ const crons = cronJobs();
 crons.cron(
   "weekly notifications",
   "0 9 * * 0", // Every Sunday at 9:00 AM
-  internal.notifications.sendWeeklyNotifications,
+  internal.notifications.scheduleWeeklyTimezoneDigest,
   {},
 );
 


### PR DESCRIPTION
- **Add scheduled weekly timezone notifications via OneSignal**
- **Refactor weekly notification scheduling and enhance OneSignal integration**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Weekly digest notifications now schedule for delivery at a consistent local time (e.g., 9:00 AM on Mondays) across timezones.
  - Improved reliability with idempotent scheduling to prevent duplicate sends.
- Bug Fixes
  - Better handling when notification configuration is missing, avoiding unintended sends.
- Chores
  - Updated internal scheduling to use the new timezone-aware notification flow.
  - Development-only logging for clearer diagnostics without impacting production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->