### PR TITLE
 Add token-auth /share/v1/capture, shareTokens, and iOS plan

### DIFF
--- a/docs/share-extension-plan.md
+++ b/docs/share-extension-plan.md
@@ -1,0 +1,156 @@
+### Share Extension Capture Plan (Single Image, Headless, Convex)
+
+#### Objectives
+
+- Single image only; no deep links; instant handoff to the backend.
+- Match existing client optimization: width 640, WEBP, quality 0.5, base64.
+- Extension shows minimal UI (spinner → sent/failed), then dismisses.
+- Server does AI extraction and sends a push when done.
+
+#### End-to-end flow
+
+1. User shares an image to the extension.
+2. Extension loads the first image only, resizes to width 640, encodes as WEBP (quality 0.5), base64-encodes the bytes.
+3. Extension POSTs JSON to Convex `POST /share/v1/capture` with `X-Share-Token` header and immediately dismisses after a 2xx “accepted” response.
+4. Backend calls `ai.eventFromImageBase64Direct` to schedule processing and push notification.
+
+---
+
+### Encoding and size (match existing app behavior)
+
+- Match `apps/expo/src/hooks/useCreateEvent.ts` `optimizeImage`:
+  - width: 640 px (height computed by aspect ratio)
+  - format: WEBP
+  - quality: 0.5
+  - base64 output in request payload
+
+Notes on iOS encoding:
+
+- Prefer encoding WEBP via `CGImageDestination` with `UTType.webP` when supported.
+- If WEBP encoding is not available at runtime, fallback to JPEG (quality 0.5) and include a `format` hint so the server accepts and uploads it. The backend uploader should accept WEBP and JPEG; if needed, transcode to WEBP server-side.
+
+---
+
+### Share extension (Swift) behavior
+
+- Single image only. Ignore additional attachments.
+- UI: non-interactive, minimal.
+  - Show: "Capturing…" with spinner.
+  - On 2xx: show "Sent!" briefly, then dismiss.
+  - On error: show "Failed to send" with a Close button (or auto-dismiss after a short delay).
+- Auth: read a separate share token from App Group `UserDefaults(suiteName: group.com.soonlist[.dev])`.
+- Network: synchronous POST while the extension is visible; background transfers aren’t available for share extensions.
+
+Payload (single image):
+
+```json
+{
+  "kind": "image",
+  "base64Image": "<base64 of image/webp>",
+  "format": "image/webp",
+  "timezone": "America/Los_Angeles",
+  "comment": null,
+  "lists": [],
+  "visibility": "private"
+}
+```
+
+Headers:
+
+- `Content-Type: application/json`
+- `X-Share-Token: <token>`
+
+Response (example):
+
+```json
+{ "ok": true, "jobId": "<id>" }
+```
+
+Dismiss the extension after any 2xx response (the server will continue processing and push a notification upon completion).
+
+Pseudocode for resizing and WEBP encode:
+
+```swift
+// 1) Load first UIImage from NSItemProvider
+// 2) Resize to width=640, preserve aspect ratio
+// 3) Encode WEBP (quality 0.5) using CGImageDestination + UTType.webP
+//    Fallback to JPEG if WEBP unavailable
+// 4) Base64-encode and POST JSON
+```
+
+---
+
+### Backend (Convex)
+
+- Add `convex/http.ts` route using `httpAction`:
+
+  - `POST /share/v1/capture`
+  - Validates `X-Share-Token` → resolves `userId`/`username`.
+  - For `kind === "image"`:
+    - Calls `ai.eventFromImageBase64Direct` with provided `base64Image`, `timezone`, defaults for `comment`, `lists`, `visibility`, and `sendNotification: true`.
+  - Returns `{ ok: true, jobId }`.
+
+- Share token helpers:
+
+  - Table: `shareTokens` with fields: `token`, `userId`, `username`, `createdAt`, `revokedAt?`.
+  - Mutation: `shareTokens.createShareToken({ userId })` → random token, associates `username`.
+  - Internal query: `shareTokens.resolveShareToken({ token })` → `{ userId, username } | null`.
+  - Optional TTL/rotation and logout revocation.
+
+- Accepting formats:
+
+  - The endpoint accepts `format` hint (`image/webp` or `image/jpeg`).
+  - `internal.files.uploadImage` should accept both; if not, transcode to WEBP server-side in the action before upload.
+
+- Processing path (existing):
+  - `ai.eventFromImageBase64Direct` → schedules `ai.processSingleImageWithNotification`.
+  - `ai.processSingleImage` runs `extractEventFromBase64Image` and `files.uploadImage` in parallel, validates and inserts event, then optionally sends a push notification.
+
+---
+
+### Main app (Expo) integration
+
+- On login/sign-in success:
+
+  - Call Convex mutation `shareTokens.createShareToken` to get a token bound to the user.
+  - Persist in App Group under stable keys: `shareToken`, `userId`, `username`, `timezone`.
+  - Keep updated on auth changes and timezone changes.
+
+- Configuration for the extension:
+  - Provide base API URL (Convex deployment) via extension `Info.plist` key, e.g., `ConvexHttpBaseURL`.
+  - Use dev/prod switching via bundleIdentifier suffix (`.dev.share`).
+
+---
+
+### Rationale: separate share token
+
+- Least privilege: limits the extension to capture-only.
+- Easy revocation/rotation without touching app session.
+- Simpler than bringing full app auth into an extension.
+
+---
+
+### Error handling & UX
+
+- Missing token or network error → show failure and dismiss quickly.
+- WEBP encode failure → fallback to JPEG 0.5; include `format` in payload.
+- AI takes several seconds → user does not wait; they receive a push on completion.
+
+---
+
+### Testing checklist
+
+- Dev build: verify POST to `/share/v1/capture` with WebP @ 640/0.5, receive `{ ok: true, jobId }`.
+- Backend logs show `eventFromImageBase64Direct` scheduled; event created; image uploaded.
+- Verify push notification arrives with event link.
+- Revoke token → POST returns 401. Create new token → POST succeeds.
+- Fallback path: force WEBP unsupported → JPEG path still accepted and uploaded.
+
+---
+
+### Acceptance criteria
+
+- Share extension sends a single image as base64 WebP (640 width, q=0.5) and dismisses on 2xx.
+- Backend endpoint authenticates via share token and returns `{ ok: true, jobId }`.
+- Event is created and image uploaded; user receives a push notification.
+- No deep links used; works on iOS 16–18 (iOS 26 typo) without foregrounding the app.

--- a/packages/backend/convex/README.md
+++ b/packages/backend/convex/README.md
@@ -160,10 +160,18 @@ To add new functions:
 
 The users table includes the following fields:
 
-- shareTokens: tokens for the iOS share extension authentication
+## Schema
 
-  - fields: `token`, `userId`, `username`, `createdAt`, `revokedAt`
-  - indexes: `by_token`, `by_user`
+### ShareTokens Table
+
+Tokens for the iOS share extension authentication:
+
+- fields: `token`, `userId`, `username`, `createdAt`, `revokedAt`
+- indexes: `by_token`, `by_user`
+
+### Users Table
+
+The users table includes the following fields:
 
 - `id` - Custom user ID (from Clerk)
 - `username` - Unique username

--- a/packages/backend/convex/README.md
+++ b/packages/backend/convex/README.md
@@ -160,6 +160,11 @@ To add new functions:
 
 The users table includes the following fields:
 
+- shareTokens: tokens for the iOS share extension authentication
+
+  - fields: `token`, `userId`, `username`, `createdAt`, `revokedAt`
+  - indexes: `by_token`, `by_user`
+
 - `id` - Custom user ID (from Clerk)
 - `username` - Unique username
 - `email` - User email

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -31,6 +31,7 @@ import type * as model_oneSignal from "../model/oneSignal.js";
 import type * as model_utils_urlScheme from "../model/utils/urlScheme.js";
 import type * as notifications from "../notifications.js";
 import type * as planetscaleSync from "../planetscaleSync.js";
+import type * as shareTokens from "../shareTokens.js";
 import type * as users from "../users.js";
 import type * as utils from "../utils.js";
 import type * as workflows_eventIngestion from "../workflows/eventIngestion.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   "model/utils/urlScheme": typeof model_utils_urlScheme;
   notifications: typeof notifications;
   planetscaleSync: typeof planetscaleSync;
+  shareTokens: typeof shareTokens;
   users: typeof users;
   utils: typeof utils;
   "workflows/eventIngestion": typeof workflows_eventIngestion;

--- a/packages/backend/convex/ai.ts
+++ b/packages/backend/convex/ai.ts
@@ -369,6 +369,9 @@ export const processSingleImage = internalAction({
     userId: v.string(),
     username: v.string(),
     batchId: v.optional(v.string()),
+    format: v.optional(
+      v.union(v.literal("image/webp"), v.literal("image/jpeg")),
+    ),
   },
   returns: v.object({
     success: v.boolean(),
@@ -388,6 +391,7 @@ export const processSingleImage = internalAction({
         }),
         ctx.runAction(internal.files.uploadImage, {
           base64Image: args.base64Image,
+          contentType: args.format,
         }),
       ]);
 
@@ -457,6 +461,9 @@ export const eventFromImageBase64Direct = mutation({
     sendNotification: v.optional(v.boolean()),
     userId: v.string(),
     username: v.string(),
+    format: v.optional(
+      v.union(v.literal("image/webp"), v.literal("image/jpeg")),
+    ),
   },
   returns: v.object({
     success: v.boolean(),
@@ -477,6 +484,7 @@ export const eventFromImageBase64Direct = mutation({
         userId: args.userId,
         username: args.username,
         sendNotification: args.sendNotification ?? true,
+        format: args.format,
       },
     );
 
@@ -621,6 +629,9 @@ export const processSingleImageWithNotification = internalAction({
     userId: v.string(),
     username: v.string(),
     sendNotification: v.boolean(),
+    format: v.optional(
+      v.union(v.literal("image/webp"), v.literal("image/jpeg")),
+    ),
   },
   handler: async (ctx, args) => {
     const result: { success: boolean; eventId?: string; error?: string } =
@@ -632,6 +643,7 @@ export const processSingleImageWithNotification = internalAction({
         visibility: args.visibility,
         userId: args.userId,
         username: args.username,
+        format: args.format,
       });
 
     if (result.success && result.eventId && args.sendNotification) {

--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -9,11 +9,15 @@ import * as Files from "./model/files";
 export const uploadImage = internalAction({
   args: {
     base64Image: v.string(),
+    contentType: v.optional(v.string()),
   },
   returns: v.string(),
   handler: async (_, args) => {
     try {
-      const result = await Files.uploadImageToCDNFromBase64(args.base64Image);
+      const result = await Files.uploadImageToCDNFromBase64(
+        args.base64Image,
+        args.contentType,
+      );
       if (!result) {
         throw new ConvexError("Failed to upload image to CDN");
       }

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -211,12 +211,16 @@ http.route({
         );
       }
 
-      const timezone =
-        body.timezone && body.timezone.trim() !== ""
-          ? body.timezone
-          : DEFAULT_TIMEZONE;
+      const timezone = body.timezone?.trim() || DEFAULT_TIMEZONE;
       const lists = Array.isArray(body.lists) ? body.lists : [];
       const visibility = body.visibility ?? "private";
+
+      // Validate format parameter
+      const validFormats = ["image/webp", "image/jpeg"] as const;
+      const format =
+        body.format && validFormats.includes(body.format)
+          ? body.format
+          : undefined;
 
       // Schedule processing
       const result = await ctx.runMutation(api.ai.eventFromImageBase64Direct, {
@@ -228,7 +232,7 @@ http.route({
         sendNotification: true,
         userId: resolved.userId,
         username: resolved.username,
-        format: body.format,
+        format,
       });
 
       return new Response(

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -154,12 +154,21 @@ http.route({
       }
 
       // Resolve token → user
-      const resolved = await ctx.runQuery(
-        internal.shareTokens.resolveShareToken,
-        {
+      let resolved;
+      try {
+        resolved = await ctx.runQuery(internal.shareTokens.resolveShareToken, {
           token,
-        },
-      );
+        });
+      } catch {
+        // If .unique() throws due to duplicate tokens, treat as unauthorized
+        return new Response(
+          JSON.stringify({ ok: false, error: "Unauthorized" }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
       if (!resolved) {
         return new Response(
           JSON.stringify({ ok: false, error: "Unauthorized" }),

--- a/packages/backend/convex/model/files.ts
+++ b/packages/backend/convex/model/files.ts
@@ -3,6 +3,7 @@
  */
 export async function uploadImageToCDNFromBase64(
   base64Image: string,
+  contentType?: string,
 ): Promise<string | null> {
   try {
     if (!base64Image || typeof base64Image !== "string") {
@@ -25,7 +26,9 @@ export async function uploadImageToCDNFromBase64(
       {
         method: "POST",
         headers: {
-          "Content-Type": "image/webp",
+          "Content-Type": contentType?.startsWith("image/")
+            ? contentType
+            : "image/webp",
           Authorization: "Bearer public_12a1yekATNiLj4VVnREZ8c7LM8V8",
         },
         body: imageBuffer,

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -236,4 +236,14 @@ export default defineSchema({
     .index("by_batch_id", ["batchId"])
     .index("by_user", ["userId"])
     .index("by_user_and_status", ["userId", "status"]),
+
+  shareTokens: defineTable({
+    token: v.string(),
+    userId: v.string(),
+    username: v.string(),
+    createdAt: v.string(), // ISO date string
+    revokedAt: v.union(v.string(), v.null()), // ISO date string or null
+  })
+    .index("by_token", ["token"]) // For quick token lookup
+    .index("by_user", ["userId"]),
 });

--- a/packages/backend/convex/shareTokens.ts
+++ b/packages/backend/convex/shareTokens.ts
@@ -42,7 +42,20 @@ export const createShareToken = mutation({
       .withIndex("by_custom_id", (q) => q.eq("id", userId))
       .first();
 
-    const username = user?.username || userId;
+    if (!user) {
+      throw new ConvexError({
+        message: "User not found",
+        data: { userId },
+      });
+    }
+    if (!user.username) {
+      throw new ConvexError({
+        message: "User is missing username",
+        data: { userId },
+      });
+    }
+
+    const username = user.username;
 
     // Generate a unique token, checking for collisions
     let token: string;

--- a/packages/backend/convex/shareTokens.ts
+++ b/packages/backend/convex/shareTokens.ts
@@ -5,9 +5,10 @@ import { internalMutation, internalQuery, mutation } from "./_generated/server";
 function generateShareToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
-  // Convert to base64url
-  const b64 = btoa(String.fromCharCode(...bytes));
-  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  // Convert to lowercase hex string
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 export const createShareToken = mutation({


### PR DESCRIPTION
- Introduced a new document outlining the share extension capture plan for single image sharing, detailing objectives, encoding, and backend integration with Convex.
- Implemented the `/share/v1/capture` endpoint in the backend to handle image uploads, including token validation and processing logic.
- Enhanced image processing functions to accept content type for better handling of image formats (WEBP and JPEG).
- Added share token management with creation, resolution, and revocation functionalities to support secure image sharing.
- Updated schema to include shareTokens table for managing share tokens associated with users.

This update streamlines the image sharing process through the share extension, ensuring efficient backend handling and user authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - iOS share extension for single-photo capture: resize to 640px, prefer WEBP (q=0.5) with JPEG fallback, send JSON POST with X-Share-Token, 5 MB payload limit, returns 202 + jobId, and dismisses on success; server schedules processing and sends completion notification.
  - Token-based share flow: create, resolve, revoke share tokens for extension auth and app integration.

- **Documentation**
  - Added capture plan, schema notes, token guidance, and testing/acceptance checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->