### PR TITLE
 Unify aggregate persistence; while-loop migrations; namespace clears Use replaceOrInsert/deleteIfExists; cursor-driven batch migrations

### DIFF
--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -46,7 +46,7 @@ export const updateEventInFeeds = internalMutation({
       };
       const id = await ctx.db.insert("userFeeds", doc);
       const insertedDoc = (await ctx.db.get(id))!;
-      await userFeedsAggregate.insert(ctx, insertedDoc);
+      await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
     } else {
       const oldDoc = existingCreatorEntry;
       const newHasEnded = eventEndTime < currentTime;
@@ -56,7 +56,7 @@ export const updateEventInFeeds = internalMutation({
         hasEnded: newHasEnded,
       });
       const updatedDoc = (await ctx.db.get(existingCreatorEntry._id))!;
-      await userFeedsAggregate.replace(ctx, oldDoc, updatedDoc);
+      await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
     }
 
     // 2. Add to discover feed if public
@@ -80,7 +80,7 @@ export const updateEventInFeeds = internalMutation({
         };
         const id = await ctx.db.insert("userFeeds", doc);
         const insertedDoc = (await ctx.db.get(id))!;
-        await userFeedsAggregate.insert(ctx, insertedDoc);
+        await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
       } else {
         const oldDoc = existingDiscoverEntry;
         const newHasEnded = eventEndTime < currentTime;
@@ -90,7 +90,7 @@ export const updateEventInFeeds = internalMutation({
           hasEnded: newHasEnded,
         });
         const updatedDoc = (await ctx.db.get(existingDiscoverEntry._id))!;
-        await userFeedsAggregate.replace(ctx, oldDoc, updatedDoc);
+        await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
       }
     }
 
@@ -120,7 +120,7 @@ export const updateEventInFeeds = internalMutation({
         };
         const id = await ctx.db.insert("userFeeds", doc);
         const insertedDoc = (await ctx.db.get(id))!;
-        await userFeedsAggregate.insert(ctx, insertedDoc);
+        await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
       } else {
         const oldDoc = existingFollowerEntry;
         const newHasEnded = eventEndTime < currentTime;
@@ -130,7 +130,7 @@ export const updateEventInFeeds = internalMutation({
           hasEnded: newHasEnded,
         });
         const updatedDoc = (await ctx.db.get(existingFollowerEntry._id))!;
-        await userFeedsAggregate.replace(ctx, oldDoc, updatedDoc);
+        await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
       }
     }
   },
@@ -177,7 +177,7 @@ export const addEventToUserFeed = internalMutation({
       };
       const id = await ctx.db.insert("userFeeds", doc);
       const insertedDoc = (await ctx.db.get(id))!;
-      await userFeedsAggregate.insert(ctx, insertedDoc);
+      await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
     }
   },
 });
@@ -211,7 +211,7 @@ export const removeEventFromFeeds = internalMutation({
       }
 
       // Delete all other entries (including discover and other user feeds)
-      await userFeedsAggregate.delete(ctx, entry);
+      await userFeedsAggregate.deleteIfExists(ctx, entry);
       await ctx.db.delete(entry._id);
     }
   },

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -246,7 +246,7 @@ export const updateHasEndedFlagsBatch = internalMutation({
           hasEnded: shouldHaveEnded,
         });
         const updatedDoc = (await ctx.db.get(entry._id))!;
-        await userFeedsAggregate.replace(ctx, oldDoc, updatedDoc);
+        await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
         updated++;
       }
     }

--- a/packages/backend/convex/migrations/initializeAggregates.ts
+++ b/packages/backend/convex/migrations/initializeAggregates.ts
@@ -60,14 +60,14 @@ export const initializeEventAggregatesBatch = internalMutation({
  * Initialize aggregates for all existing events (orchestrator)
  */
 export const initializeEventAggregates = internalMutation({
-  args: {},
+  args: { cursor: v.union(v.string(), v.null()) },
   returns: v.null(),
-  handler: async (ctx) => {
+  handler: async (ctx, args) => {
     console.log("Starting event aggregates initialization...");
 
     // Note: We clear per-namespace inside the batch to avoid requiring a full scan of namespaces
 
-    let cursor: string | null = null;
+    let cursor: string | null = args.cursor;
     let totalProcessed = 0;
     let batchNumber = 0;
     let done = false;
@@ -101,7 +101,7 @@ export const initializeEventAggregates = internalMutation({
       // Schedule next batch
       await ctx.scheduler.runAfter(
         0,
-        internal.migrations.initializeAggregates.initializeEventAggregatesBatch,
+        internal.migrations.initializeAggregates.initializeEventAggregates,
         { cursor },
       );
 
@@ -154,14 +154,14 @@ export const initializeEventFollowsAggregatesBatch = internalMutation({
  * Initialize aggregates for all existing eventFollows (orchestrator)
  */
 export const initializeEventFollowsAggregates = internalMutation({
-  args: {},
+  args: { cursor: v.union(v.string(), v.null()) },
   returns: v.null(),
-  handler: async (ctx) => {
+  handler: async (ctx, args) => {
     console.log("Starting eventFollows aggregates initialization...");
 
     // Note: We clear per-namespace inside the batch to avoid requiring a full scan of namespaces
 
-    let cursor: string | null = null;
+    let cursor: string | null = args.cursor;
     let totalProcessed = 0;
     let batchNumber = 0;
     let done = false;
@@ -197,7 +197,7 @@ export const initializeEventFollowsAggregates = internalMutation({
       await ctx.scheduler.runAfter(
         0,
         internal.migrations.initializeAggregates
-          .initializeEventFollowsAggregatesBatch,
+          .initializeEventFollowsAggregates,
         { cursor },
       );
 
@@ -219,12 +219,12 @@ export const initializeAllAggregates = internalMutation({
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeAggregates.initializeEventAggregates,
-      {},
+      { cursor: null },
     );
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeAggregates.initializeEventFollowsAggregates,
-      {},
+      { cursor: null },
     );
     return null;
   },

--- a/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
+++ b/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
@@ -56,14 +56,14 @@ export const initializeUserFeedsAggregateBatch = internalMutation({
  * Initialize aggregate for all existing userFeeds entries (orchestrator)
  */
 export const initializeUserFeedsAggregate = internalMutation({
-  args: {},
+  args: { cursor: v.union(v.string(), v.null()) },
   returns: v.null(),
-  handler: async (ctx) => {
+  handler: async (ctx, args) => {
     console.log("Starting userFeeds aggregate initialization...");
 
     // Note: We clear per-namespace inside the batch to avoid requiring a full scan of namespaces
 
-    let cursor: string | null = null;
+    let cursor: string | null = args.cursor;
     let totalProcessed = 0;
     let batchNumber = 0;
     let done = false;
@@ -99,7 +99,7 @@ export const initializeUserFeedsAggregate = internalMutation({
       await ctx.scheduler.runAfter(
         0,
         internal.migrations.initializeUserFeedsAggregate
-          .initializeUserFeedsAggregateBatch,
+          .initializeUserFeedsAggregate,
         { cursor },
       );
 

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -623,8 +623,8 @@ export async function createEvent(
   // Sync with aggregates for efficient stats
   const createdEvent = await ctx.db.get(eventDocId);
   if (createdEvent) {
-    await eventsByCreation.insert(ctx, createdEvent);
-    await eventsByStartTime.insert(ctx, createdEvent);
+    await eventsByCreation.replaceOrInsert(ctx, createdEvent, createdEvent);
+    await eventsByStartTime.replaceOrInsert(ctx, createdEvent, createdEvent);
   }
 
   // Add comment if provided
@@ -732,8 +732,8 @@ export async function updateEvent(
   const updatedEvent = await ctx.db.get(existingEvent._id);
   if (updatedEvent) {
     // Sync with aggregates (replace updates the sort keys)
-    await eventsByCreation.replace(ctx, existingEvent, updatedEvent);
-    await eventsByStartTime.replace(ctx, existingEvent, updatedEvent);
+    await eventsByCreation.replaceOrInsert(ctx, existingEvent, updatedEvent);
+    await eventsByStartTime.replaceOrInsert(ctx, existingEvent, updatedEvent);
   }
 
   // Handle comment
@@ -856,7 +856,7 @@ export async function deleteEvent(
   // Delete all related records
   for (const ef of eventFollows) {
     // Remove from eventFollows aggregate before deleting
-    await eventFollowsAggregate.delete(ctx, ef);
+    await eventFollowsAggregate.deleteIfExists(ctx, ef);
     await ctx.db.delete(ef._id);
   }
 
@@ -875,8 +875,8 @@ export async function deleteEvent(
   });
 
   // Remove from aggregates before deleting the event
-  await eventsByCreation.delete(ctx, event);
-  await eventsByStartTime.delete(ctx, event);
+  await eventsByCreation.deleteIfExists(ctx, event);
+  await eventsByStartTime.deleteIfExists(ctx, event);
 
   // Delete the event
   await ctx.db.delete(event._id);
@@ -909,7 +909,11 @@ export async function followEvent(
     // Sync with eventFollows aggregate
     const createdFollow = await ctx.db.get(followId);
     if (createdFollow) {
-      await eventFollowsAggregate.insert(ctx, createdFollow);
+      await eventFollowsAggregate.replaceOrInsert(
+        ctx,
+        createdFollow,
+        createdFollow,
+      );
     }
 
     // Get event to add to user's feed
@@ -947,7 +951,7 @@ export async function unfollowEvent(
 
   if (existingFollow) {
     // Remove from eventFollows aggregate before deleting
-    await eventFollowsAggregate.delete(ctx, existingFollow);
+    await eventFollowsAggregate.deleteIfExists(ctx, existingFollow);
     await ctx.db.delete(existingFollow._id);
 
     // Remove from user's feed


### PR DESCRIPTION
- **Refactor userFeeds and event aggregates to use replaceOrInsert and deleteIfExists**
- **Enhance aggregate initialization by adding cursor support**
- **Refactor aggregate initialization to simplify cursor handling**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches aggregates to idempotent replaceOrInsert/deleteIfExists and refactors migrations to clear per-namespace and self-schedule via cursors.
> 
> - **Aggregates persistence**:
>   - Replace `insert`/`replace` with `replaceOrInsert` and `delete` with `deleteIfExists` across `packages/backend/convex/{feedHelpers.ts,feeds.ts,model/events.ts}`.
> - **Migrations**:
>   - Batch initializers (`initializeAggregates.ts`, `initializeUserFeedsAggregate.ts`): clear aggregate namespaces once per user/feed before processing, then `replaceOrInsert` each item.
>   - Orchestrators simplified: kick off first batch; batches self-schedule with cursors (remove while-loop orchestration).
> - **Feeds maintenance**:
>   - `updateHasEndedFlagsBatch` now syncs via `replaceOrInsert` after patches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87a46b37abe5592fadc6d84500fd4c16c03c2452. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved reliability when updating or deleting feeds, events, and follows to prevent errors from missing records.
  * Ensured feed and aggregate entries stay consistent and correctly ordered.

* Performance
  * Added batch-based, self-scheduled processing to handle large data sets without long-running jobs.
  * Reduced duplicate entries with per-namespace clearing for cleaner aggregates.

* Chores
  * Simplified background initialization flows for feeds, events, and follows to be more resilient and maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->