### PR TITLE
Separate public list from discover feed

### DIFF
--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -865,6 +865,17 @@ export const updatePublicListSettings = mutation({
       throw new ConvexError("User not found");
     }
 
+    // Check if user has showDiscover enabled - prevent enabling public list if they do
+    const userShowDiscover =
+      (user.publicMetadata as { showDiscover?: boolean } | null)
+        ?.showDiscover ?? false;
+
+    if (args.publicListEnabled === true && userShowDiscover) {
+      throw new ConvexError(
+        "Cannot enable public list when showDiscover is enabled. Please contact support if you need both features.",
+      );
+    }
+
     const updates: Record<string, boolean | string | undefined> = {
       updatedAt: new Date().toISOString(),
     };


### PR DESCRIPTION
## Problem
When users enable `publicListEnabled`, all their public events were appearing in the discover feed. This should only happen if they also have `showDiscover = true`.

## Solution
Added checks to ensure only events from users with `showDiscover = true` appear in discover feed.

## Changes
- **feedHelpers.ts**: Modified `updateEventInFeeds` to check user's `publicMetadata.showDiscover` before adding events to discover feed
- **users.ts**: Added validation in `updatePublicListSettings` to prevent enabling public list when `showDiscover = true`

## Result
- Users with `publicListEnabled = true` and `showDiscover = false/undefined` will have events only on their `/user/list` page
- Users with `showDiscover = true` will have events in discover feed as before
- The two features are now mutually exclusive and won't cause confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery feed visibility now automatically responds to individual user preference settings, giving users control over their presence in shared discovery feeds

* **Improvements**
  * Added validation to prevent enabling public lists when certain user preference configurations are active, maintaining setting consistency and preventing incompatible combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->