### PR TITLE
backend: Fix PostHog backfill validation error for pageStatus field

### DIFF
--- a/packages/backend/convex/posthog.ts
+++ b/packages/backend/convex/posthog.ts
@@ -19,12 +19,14 @@ export const listUsersForBackfill = internalAction({
     ),
     continueCursor: v.union(v.string(), v.null()),
     isDone: v.boolean(),
+    pageStatus: v.union(v.string(), v.null()),
   }),
   handler: async (ctx, args) => {
     const users: {
       page: Doc<"users">[];
       continueCursor: string | null;
       isDone: boolean;
+      pageStatus: string | null;
     } = await ctx.runQuery(api.users.getAllUsersPaginated, {
       paginationOpts: args.paginationOpts,
     });
@@ -39,6 +41,7 @@ export const listUsersForBackfill = internalAction({
       page: mappedUsers,
       continueCursor: users.continueCursor,
       isDone: users.isDone,
+      pageStatus: users.pageStatus,
     };
   },
 });

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -448,10 +448,14 @@ export const getAllUsersPaginated = query({
     page: v.array(v.any()),
     continueCursor: v.union(v.string(), v.null()),
     isDone: v.boolean(),
+    pageStatus: v.union(v.string(), v.null()),
   }),
   handler: async (ctx, args) => {
     const result = await ctx.db.query("users").paginate(args.paginationOpts);
-    return result;
+    return {
+      ...result,
+      pageStatus: result.pageStatus ?? null,
+    };
   },
 });
 


### PR DESCRIPTION
TLDR: Fixed validation error in PostHog backfill by adding pageStatus field to validators and handlers.

Description:
- Added pageStatus field to getAllUsersPaginated query validator (required, not optional, as Convex paginate always returns it)
- Added pageStatus field to listUsersForBackfill action validator and handler
- Normalized undefined to null for pageStatus in getAllUsersPaginated handler to satisfy TypeScript types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pagination queries now return status metadata alongside results, enabling improved tracking of pagination progress across multiple requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->