### PR TITLE
backend: Add PostHog backfill endpoint and user listing query

### DIFF
--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -3,7 +3,12 @@ import { ConvexError, v } from "convex/values";
 
 import type { DatabaseReader } from "./_generated/server";
 import { internal } from "./_generated/api";
-import { internalMutation, mutation, query } from "./_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
 import { onboardingDataValidator, userAdditionalInfoValidator } from "./schema";
 
 const MAX_USERNAME_LENGTH = 64;
@@ -440,10 +445,29 @@ export const getCurrentUser = query({
 /**
  * List users for PostHog backfill - paginated query
  */
-export const listForBackfill = query({
+export const listForBackfill = internalQuery({
   args: {
     paginationOpts: paginationOptsValidator,
   },
+  returns: v.object({
+    page: v.array(
+      v.object({
+        id: v.string(),
+        email: v.string(),
+        username: v.string(),
+      }),
+    ),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+    splitCursor: v.optional(v.union(v.string(), v.null())),
+    pageStatus: v.optional(
+      v.union(
+        v.literal("SplitRecommended"),
+        v.literal("SplitRequired"),
+        v.null(),
+      ),
+    ),
+  }),
   handler: async (ctx, { paginationOpts }) => {
     const results = await ctx.db
       .query("users")


### PR DESCRIPTION
Add HTTP endpoint and Convex query to support PostHog backfill operations.

- Add /posthog/backfill HTTP endpoint with bearer token authentication
- Add paginated listForBackfill query for fetching user data
- Update README with usage example for backfill script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend infrastructure for user data backfill and export capabilities with secure token-based authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->