### PR TITLE
 Add FreakScene discovery API endpoint

### DIFF
--- a/packages/backend/convex/model/files.ts
+++ b/packages/backend/convex/model/files.ts
@@ -51,3 +51,57 @@ export async function uploadImageToCDNFromBase64(
     return null;
   }
 }
+
+function extractFilePathFromBytescaleUrl(url: string): string | null {
+  if (!url) return null;
+
+  const match = /\/uploads\/\d{4}\/\d{2}\/\d{2}\/[^?]+/.exec(url);
+  if (match) {
+    return match[0];
+  }
+
+  const altMatch = /\/image\/(.+?)(?:\?|$)/.exec(url);
+  if (altMatch) {
+    return `/${altMatch[1]}`;
+  }
+
+  return null;
+}
+
+export function buildBrandedImageUrl(
+  originalImageUrl: string | null | undefined,
+): string {
+  if (!originalImageUrl) {
+    return "";
+  }
+
+  const filePath = extractFilePathFromBytescaleUrl(originalImageUrl);
+  if (!filePath) {
+    console.warn(
+      "Could not extract file path from Bytescale URL:",
+      originalImageUrl,
+    );
+    return originalImageUrl;
+  }
+
+  const accountId = "12a1yek";
+  const baseUrl = `https://upcdn.io/${accountId}/image${filePath}`;
+  const params = new URLSearchParams();
+
+  params.set("w", "500");
+  params.set("h", "500");
+  params.set("crop", "smart");
+
+  params.set("image", "/uploads/Soonlist/soonlist-logo.png");
+  params.set("layer-w", "80");
+  params.set("gravity", "bottom-left");
+  params.set("padding", "15");
+
+  params.set("text", "soonlist.com");
+  params.set("color", "ffffff");
+  params.set("font-size", "200");
+  params.set("gravity", "bottom-right");
+  params.set("padding", "15");
+
+  return `${baseUrl}?${params.toString()}`;
+}


### PR DESCRIPTION
- Add buildBrandedImageUrl function to overlay Soonlist logo and text on event images
- Logo positioned bottom-left, 'soonlist.com' text bottom-right
- Add 'Captured by {displayName}' attribution to event descriptions with BB code formatting
- Update getDiscoverEventsForIntegration to include user display names
- Images are cropped to square (1:1) and optimized for 161x161 tile display


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for retrieving discovery events with formatted venue information and branded image URLs, enabling external platform integration capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->