### PR TITLE
fix: use email as distinct_id for PostHog sync

### DIFF
--- a/packages/backend/convex/posthog.ts
+++ b/packages/backend/convex/posthog.ts
@@ -6,7 +6,7 @@ import { internalAction, internalQuery } from "./_generated/server";
 import * as PostHog from "./model/posthog";
 
 interface UserStats {
-  userId: string;
+  visitorId: string; // email - used as distinct_id in PostHog
   upcoming_created_events_count: number;
   upcoming_saved_events_count: number;
   upcoming_events_count: number;
@@ -16,7 +16,7 @@ interface UserStats {
 }
 
 const userStatsValidator = v.object({
-  userId: v.string(),
+  visitorId: v.string(), // email - used as distinct_id in PostHog
   upcoming_created_events_count: v.number(),
   upcoming_saved_events_count: v.number(),
   upcoming_events_count: v.number(),
@@ -47,7 +47,7 @@ export const debugUserStats = internalQuery({
       .withIndex("by_user", (q) => q.eq("userId", user.id))
       .collect();
 
-    console.log(`User ${args.username} (id: ${user.id})`);
+    console.log(`User ${args.username} (email: ${user.email})`);
     console.log(`Total created events: ${createdEvents.length}`);
     console.log(`Now ISO: ${nowIso}`);
 
@@ -111,7 +111,7 @@ export const debugUserStats = internalQuery({
     }
 
     return {
-      userId: user.id,
+      visitorId: user.email,
       upcoming_created_events_count: upcomingCreatedEvents.length,
       upcoming_saved_events_count: upcomingSavedEvents.length,
       upcoming_events_count,
@@ -201,7 +201,7 @@ export const getAllUsersWithStatsQuery = internalQuery({
         }
 
         return {
-          userId: user.id,
+          visitorId: user.email,
           upcoming_created_events_count,
           upcoming_saved_events_count,
           upcoming_events_count,
@@ -243,7 +243,7 @@ export const syncUserPropertiesToPostHog = internalAction({
     }
 
     const usersToIdentify: IdentifyUserParams[] = userStats.map((stats) => ({
-      userId: stats.userId,
+      userId: stats.visitorId,
       properties: {
         upcoming_created_events_count: stats.upcoming_created_events_count,
         upcoming_saved_events_count: stats.upcoming_saved_events_count,


### PR DESCRIPTION
## Problem

PostHog identifies users by email (or device ID), not Clerk user ID. The sync was sending properties to `user_xxxxx` which created separate person records instead of updating the existing ones.

## Solution

Use `user.email` as the `distinct_id` when syncing to PostHog so properties go to the correct person record.

## Changes

- Renamed `userId` to `visitorId` in the stats interface to clarify it's the PostHog identifier
- Changed from `user.id` (Clerk ID) to `user.email` as the distinct_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated identifier naming conventions across data structures for consistency.
  * Enhanced debug logging to display email addresses instead of user IDs for improved readability.
  * Synchronized PostHog integration with updated data field mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->