### PR TITLE
Fix source sticker placement and clean up unused RevenueCat code

### DIFF
--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -17,16 +17,12 @@ import LoadingSpinner from "~/components/LoadingSpinner";
 import SaveShareButton from "~/components/SaveShareButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import { useAppStore, useStableTimestamp } from "~/store";
 import { getPlanStatusFromUser } from "~/utils/plan";
 
 function DiscoverContent() {
   const { user } = useUser();
   const discoverAccessOverride = useAppStore((s) => s.discoverAccessOverride);
-  const { customerInfo } = useRevenueCat();
-  const hasUnlimited =
-    customerInfo?.entitlements.active.unlimited?.isActive ?? false;
 
   // Compute access early to skip queries if denied
   const showDiscover = user ? getPlanStatusFromUser(user).showDiscover : false;
@@ -140,7 +136,6 @@ function DiscoverContent() {
             isFetchingNextPage={status === "LoadingMore"}
             ActionButton={SaveShareButtonWrapper}
             showCreator="always"
-            hasUnlimited={hasUnlimited}
             hideDiscoverableButton={true}
             isDiscoverFeed={true}
             savedEventIds={savedEventIds}

--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -16,14 +16,10 @@ import LoadingSpinner from "~/components/LoadingSpinner";
 import UserEventsList from "~/components/UserEventsList";
 import { useRatingPrompt } from "~/hooks/useRatingPrompt";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import { useAppStore, useStableTimestamp } from "~/store";
 
 function MyFeedContent() {
   const { user } = useUser();
-  const { customerInfo } = useRevenueCat();
-  const hasUnlimited =
-    customerInfo?.entitlements.active.unlimited?.isActive ?? false;
 
   // Use the stable timestamp from the store that updates every 15 minutes
   // This prevents InvalidCursor errors while still filtering for upcoming events
@@ -104,8 +100,7 @@ function MyFeedContent() {
           isLoadingFirstPage={status === "LoadingFirstPage"}
           showCreator="savedFromOthers"
           stats={stats}
-          promoCard={{ type: "addEvents" }}
-          hasUnlimited={hasUnlimited}
+          showSourceStickers
           savedEventIds={savedEventIds}
           source="feed"
         />

--- a/apps/expo/src/app/(tabs)/past.tsx
+++ b/apps/expo/src/app/(tabs)/past.tsx
@@ -15,13 +15,9 @@ import AddEventButton from "~/components/AddEventButton";
 import LoadingSpinner from "~/components/LoadingSpinner";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import { useRevenueCat } from "~/providers/RevenueCatProvider";
 
 function PastEventsContent() {
   const { user } = useUser();
-  const { customerInfo } = useRevenueCat();
-  const hasUnlimited =
-    customerInfo?.entitlements.active.unlimited?.isActive ?? false;
 
   // Fetch user stats
   const stats = useQuery(
@@ -88,7 +84,7 @@ function PastEventsContent() {
             onEndReached={handleLoadMore}
             showCreator="savedFromOthers"
             isFetchingNextPage={status === "LoadingMore"}
-            hasUnlimited={hasUnlimited}
+            showSourceStickers
             savedEventIds={savedEventIds}
             source="past"
           />

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -58,10 +58,6 @@ interface ActionButtonProps {
   event: Event;
 }
 
-interface PromoCardProps {
-  type: "addEvents";
-}
-
 interface UserEventListItemProps {
   event: Event;
   ActionButton?: React.ComponentType<ActionButtonProps>;
@@ -585,7 +581,7 @@ const SourceSticker = ({
   return content;
 };
 
-const SourceStickersRow = () => {
+const SourceStickersRow = ({ hideText = false }: { hideText?: boolean }) => {
   const { fontScale } = useWindowDimensions();
   const iconSize = 24 * fontScale;
 
@@ -673,13 +669,12 @@ const SourceStickersRow = () => {
   ];
 
   return (
-    <View className="px-4">
-      <Text
-        className="mb-4 text-center text-base font-medium text-neutral-1"
-        style={{ fontSize: 16 * fontScale }}
-      >
-        Add events from screenshots or photos
-      </Text>
+    <View className="mb-6 px-4">
+      {!hideText && (
+        <View className="mb-4">
+          <TapToAddText textSize={16} />
+        </View>
+      )}
       <View className="flex-row flex-wrap items-center justify-center gap-3">
         {row1.map((source, index) => (
           <SourceSticker
@@ -702,6 +697,33 @@ const SourceStickersRow = () => {
           />
         ))}
       </View>
+    </View>
+  );
+};
+
+const TapToAddText = ({ textSize = 16 }: { textSize?: number }) => {
+  const { fontScale } = useWindowDimensions();
+  const fontSize = textSize * fontScale;
+  const iconSize = 20 * fontScale;
+  const plusIconSize = 12 * fontScale;
+
+  return (
+    <View className="flex-row items-center justify-center">
+      <Text className="text-center text-neutral-2" style={{ fontSize }}>
+        Tap
+      </Text>
+      <View
+        className="mx-1.5 items-center justify-center rounded-full bg-interactive-1"
+        style={{
+          width: iconSize,
+          height: iconSize,
+        }}
+      >
+        <PlusIcon size={plusIconSize} color="#FFF" strokeWidth={3} />
+      </View>
+      <Text className="text-center text-neutral-2" style={{ fontSize }}>
+        to add from screenshots or photos
+      </Text>
     </View>
   );
 };
@@ -831,29 +853,7 @@ const EmptyStateHeader = () => {
       >
         Your events, <Text style={{ color: "#5A32FB" }}>all in one place</Text>
       </Text>
-      <View className="flex-row items-center justify-center">
-        <Text
-          className="text-center text-base text-neutral-2"
-          style={{ fontSize: 16 * fontScale }}
-        >
-          Tap
-        </Text>
-        <View
-          className="mx-1.5 items-center justify-center rounded-full bg-interactive-1"
-          style={{
-            width: 20 * fontScale,
-            height: 20 * fontScale,
-          }}
-        >
-          <PlusIcon size={12 * fontScale} color="#FFF" strokeWidth={3} />
-        </View>
-        <Text
-          className="text-center text-base text-neutral-2"
-          style={{ fontSize: 16 * fontScale }}
-        >
-          to add from screenshots
-        </Text>
-      </View>
+      <TapToAddText textSize={16} />
     </TouchableOpacity>
   );
 };
@@ -865,9 +865,8 @@ interface UserEventsListProps {
   onEndReached: () => void;
   isFetchingNextPage: boolean;
   isLoadingFirstPage?: boolean;
-  promoCard?: PromoCardProps;
+  showSourceStickers?: boolean;
   demoMode?: boolean;
-  hasUnlimited?: boolean;
   stats?: EventStatsData;
   hideDiscoverableButton?: boolean;
   isDiscoverFeed?: boolean;
@@ -884,7 +883,7 @@ export default function UserEventsList(props: UserEventsListProps) {
     onEndReached,
     isFetchingNextPage,
     isLoadingFirstPage = false,
-    promoCard,
+    showSourceStickers = false,
     demoMode,
     stats,
     hideDiscoverableButton = false,
@@ -913,6 +912,7 @@ export default function UserEventsList(props: UserEventsListProps) {
         showsVerticalScrollIndicator={false}
       >
         <EmptyStateHeader />
+        {showSourceStickers && <SourceStickersRow hideText />}
         <GhostEventCard index={0} />
         <GhostEventCard index={1} />
         <GhostEventCard index={2} />
@@ -941,7 +941,7 @@ export default function UserEventsList(props: UserEventsListProps) {
           <ActivityIndicator size="large" color="#5A32FB" />
         </View>
       ) : null}
-      {promoCard ? <SourceStickersRow /> : null}
+      {showSourceStickers ? <SourceStickersRow /> : null}
     </>
   );
 


### PR DESCRIPTION
- Add SourceStickersRow to empty state when user has 0 events
- Replace promoCard prop with showSourceStickers boolean for simplicity
- Remove unused hasUnlimited prop from UserEventsList
- Create reusable TapToAddText component for consistent messaging
- Update text to 'to add from screenshots or photos'
- Hide text in empty state, show in footer when user has events
- Enable stickers in Feed and Past tabs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified source sticker and promotional content display logic across discover, feed, and past tabs.
  * Updated tap-to-add action text styling and formatting.
  * Removed subscription entitlement checks for feature access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->