### PR TITLE
 Extend publicMetadata schema in syncFromClerk mutation

### DIFF
--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -750,7 +750,23 @@ export const syncFromClerk = internalMutation({
     email: v.string(),
     displayName: v.string(),
     userImage: v.string(),
-    publicMetadata: v.optional(v.object({})),
+    publicMetadata: v.optional(
+      v.object({
+        showDiscover: v.optional(v.boolean()),
+        stripe: v.optional(
+          v.object({
+            customerId: v.optional(v.string()),
+          }),
+        ),
+        plan: v.optional(
+          v.object({
+            name: v.optional(v.string()),
+            status: v.optional(v.string()),
+            trialStartDate: v.optional(v.string()),
+          }),
+        ),
+      }),
+    ),
     firstName: v.optional(v.union(v.string(), v.null())),
     lastName: v.optional(v.union(v.string(), v.null())),
   },


### PR DESCRIPTION
- Extend publicMetadata schema to include optional fields for showDiscover, stripe customerId, and plan details (name, status, trialStartDate).
- This improves data integrity and allows for more comprehensive user metadata handling during synchronization with Clerk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated user profile metadata schema to support subscription management, payment processing, and personalization preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->