### PR TITLE
fix(backend): Move event similarity computation to backend for O(n) performance

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillSimilarity from "../migrations/backfillSimilarity.js";
 import type * as migrations_initializeAggregates from "../migrations/initializeAggregates.js";
 import type * as migrations_initializeUserFeedsAggregate from "../migrations/initializeUserFeedsAggregate.js";
 import type * as migrations_userFeedsMigration from "../migrations/userFeedsMigration.js";
@@ -33,6 +34,7 @@ import type * as model_notificationHelpers from "../model/notificationHelpers.js
 import type * as model_notifications from "../model/notifications.js";
 import type * as model_oneSignal from "../model/oneSignal.js";
 import type * as model_posthog from "../model/posthog.js";
+import type * as model_similarityHelpers from "../model/similarityHelpers.js";
 import type * as model_utils_urlScheme from "../model/utils/urlScheme.js";
 import type * as notifications from "../notifications.js";
 import type * as planetscaleSync from "../planetscaleSync.js";
@@ -65,6 +67,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillSimilarity": typeof migrations_backfillSimilarity;
   "migrations/initializeAggregates": typeof migrations_initializeAggregates;
   "migrations/initializeUserFeedsAggregate": typeof migrations_initializeUserFeedsAggregate;
   "migrations/userFeedsMigration": typeof migrations_userFeedsMigration;
@@ -76,6 +79,7 @@ declare const fullApi: ApiFromModules<{
   "model/notifications": typeof model_notifications;
   "model/oneSignal": typeof model_oneSignal;
   "model/posthog": typeof model_posthog;
+  "model/similarityHelpers": typeof model_similarityHelpers;
   "model/utils/urlScheme": typeof model_utils_urlScheme;
   notifications: typeof notifications;
   planetscaleSync: typeof planetscaleSync;

--- a/packages/backend/convex/migrations/backfillSimilarity.ts
+++ b/packages/backend/convex/migrations/backfillSimilarity.ts
@@ -1,0 +1,51 @@
+import { Migrations } from "@convex-dev/migrations";
+
+import type { DataModel } from "../_generated/dataModel.js";
+import { components, internal } from "../_generated/api.js";
+import { findSimilarEventForBackfill } from "../model/similarityHelpers.js";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+
+/**
+ * Migration to backfill similarToEventId for existing events.
+ *
+ * This migration processes events in order of creation (oldest first) so that
+ * canonical events are established before their duplicates are processed.
+ *
+ * Run with: npx convex run migrations/backfillSimilarity:runBackfillSimilarity
+ */
+export const backfillSimilarity = migrations.define({
+  table: "events",
+  batchSize: 50, // Smaller batch size since similarity computation is expensive
+  migrateOne: async (ctx, event) => {
+    try {
+      // Skip if already has similarToEventId set
+      if (event.similarToEventId !== undefined) {
+        return;
+      }
+
+      // Find similar events that were created before this one
+      const similarToEventId = await findSimilarEventForBackfill(ctx, event);
+
+      if (similarToEventId) {
+        await ctx.db.patch(event._id, {
+          similarToEventId,
+        });
+        console.log(
+          `Event ${event.id} linked to canonical event ${similarToEventId}`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        `Failed to process event ${event.id} in similarity backfill:`,
+        error,
+      );
+      throw error;
+    }
+  },
+});
+
+// Runner for the backfill migration
+export const runBackfillSimilarity = migrations.runner(
+  internal.migrations.backfillSimilarity.backfillSimilarity,
+);

--- a/packages/backend/convex/model/similarityHelpers.ts
+++ b/packages/backend/convex/model/similarityHelpers.ts
@@ -1,0 +1,273 @@
+import type { QueryCtx } from "../_generated/server";
+import type { Doc } from "../_generated/dataModel";
+
+// Thresholds matching current client-side values exactly
+const THRESHOLDS = {
+  startTimeMinutes: 60, // ±60 minutes
+  endTimeMinutes: 60, // ±60 minutes
+  nameSimilarity: 0.1, // 10%
+  descriptionSimilarity: 0.1, // 10%
+  locationSimilarity: 0.1, // 10%
+};
+
+// Convert text to word frequency vector (bag of words)
+function textToVector(text: string): Map<string, number> {
+  const wordMap = new Map<string, number>();
+  const words = text.toLowerCase().match(/\w+/g) || [];
+
+  words.forEach((word) => {
+    wordMap.set(word, (wordMap.get(word) || 0) + 1);
+  });
+
+  return wordMap;
+}
+
+// Calculate cosine similarity between two word vectors
+function cosineSimilarity(
+  vector1: Map<string, number>,
+  vector2: Map<string, number>,
+): number {
+  // Handle empty vectors
+  if (vector1.size === 0 || vector2.size === 0) {
+    return 0;
+  }
+
+  const intersection = new Set(
+    [...vector1.keys()].filter((x) => vector2.has(x)),
+  );
+
+  let dotProduct = 0;
+  intersection.forEach((word) => {
+    dotProduct += vector1.get(word)! * vector2.get(word)!;
+  });
+
+  function sumOfSquares(vector: Map<string, number>): number {
+    let sum = 0;
+    vector.forEach((value) => {
+      sum += value * value;
+    });
+    return sum;
+  }
+
+  const magnitude1 = Math.sqrt(sumOfSquares(vector1));
+  const magnitude2 = Math.sqrt(sumOfSquares(vector2));
+
+  if (magnitude1 === 0 || magnitude2 === 0) {
+    return 0;
+  }
+
+  return dotProduct / (magnitude1 * magnitude2);
+}
+
+// Check if two events are similar based on thresholds
+function areEventsSimilar(
+  event1: {
+    startDateTime: string;
+    endDateTime: string;
+    name?: string;
+    description?: string;
+    location?: string;
+  },
+  event2: {
+    startDateTime: string;
+    endDateTime: string;
+    name?: string;
+    description?: string;
+    location?: string;
+  },
+): boolean {
+  // Time difference in minutes
+  const startTimeDiff = Math.abs(
+    (new Date(event1.startDateTime).getTime() -
+      new Date(event2.startDateTime).getTime()) /
+      (1000 * 60),
+  );
+  const endTimeDiff = Math.abs(
+    (new Date(event1.endDateTime).getTime() -
+      new Date(event2.endDateTime).getTime()) /
+      (1000 * 60),
+  );
+
+  // Check time thresholds first (cheapest check)
+  if (startTimeDiff > THRESHOLDS.startTimeMinutes) {
+    return false;
+  }
+  if (endTimeDiff > THRESHOLDS.endTimeMinutes) {
+    return false;
+  }
+
+  // Text similarity checks
+  const nameSimilarity = cosineSimilarity(
+    textToVector(event1.name || ""),
+    textToVector(event2.name || ""),
+  );
+  if (nameSimilarity < THRESHOLDS.nameSimilarity) {
+    return false;
+  }
+
+  const descriptionSimilarity = cosineSimilarity(
+    textToVector(event1.description || ""),
+    textToVector(event2.description || ""),
+  );
+  if (descriptionSimilarity < THRESHOLDS.descriptionSimilarity) {
+    return false;
+  }
+
+  const locationSimilarity = cosineSimilarity(
+    textToVector(event1.location || ""),
+    textToVector(event2.location || ""),
+  );
+  if (locationSimilarity < THRESHOLDS.locationSimilarity) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Find a similar event for a new event being created.
+ * Returns the ID of the canonical (earliest) similar event, or null if none found.
+ *
+ * @param ctx - Convex query context
+ * @param newEvent - The new event data to check for similarity
+ * @returns The ID of the canonical similar event, or null
+ */
+export async function findSimilarEvent(
+  ctx: QueryCtx,
+  newEvent: {
+    startDateTime: string;
+    endDateTime: string;
+    name?: string;
+    description?: string;
+    location?: string;
+  },
+): Promise<string | null> {
+  // Calculate time window for query (±60 minutes from start time)
+  const newStartTime = new Date(newEvent.startDateTime);
+  const minTime = new Date(
+    newStartTime.getTime() - THRESHOLDS.startTimeMinutes * 60 * 1000,
+  ).toISOString();
+  const maxTime = new Date(
+    newStartTime.getTime() + THRESHOLDS.startTimeMinutes * 60 * 1000,
+  ).toISOString();
+
+  // Query events within the time window using the startDateTime index
+  const candidates = await ctx.db
+    .query("events")
+    .withIndex("by_startDateTime", (q) =>
+      q.gte("startDateTime", minTime).lte("startDateTime", maxTime),
+    )
+    .collect();
+
+  // Find the earliest similar event (by created_at)
+  let earliestSimilar: Doc<"events"> | null = null;
+
+  for (const candidate of candidates) {
+    // Check if events are similar
+    const isSimilar = areEventsSimilar(newEvent, {
+      startDateTime: candidate.startDateTime,
+      endDateTime: candidate.endDateTime,
+      name: candidate.name,
+      description: candidate.description,
+      location: candidate.location,
+    });
+
+    if (isSimilar) {
+      // If this candidate already points to a canonical event, use that
+      if (candidate.similarToEventId) {
+        return candidate.similarToEventId;
+      }
+
+      // Otherwise, check if this is earlier than our current earliest
+      if (
+        !earliestSimilar ||
+        new Date(candidate.created_at) < new Date(earliestSimilar.created_at)
+      ) {
+        earliestSimilar = candidate;
+      }
+    }
+  }
+
+  // Return the ID of the earliest similar event (canonical)
+  return earliestSimilar?.id ?? null;
+}
+
+/**
+ * Find a similar event for backfill purposes.
+ * Similar to findSimilarEvent but excludes the event being backfilled.
+ *
+ * @param ctx - Convex query context
+ * @param event - The event document being backfilled
+ * @returns The ID of the canonical similar event, or null
+ */
+export async function findSimilarEventForBackfill(
+  ctx: QueryCtx,
+  event: Doc<"events">,
+): Promise<string | null> {
+  // Calculate time window for query (±60 minutes from start time)
+  const eventStartTime = new Date(event.startDateTime);
+  const minTime = new Date(
+    eventStartTime.getTime() - THRESHOLDS.startTimeMinutes * 60 * 1000,
+  ).toISOString();
+  const maxTime = new Date(
+    eventStartTime.getTime() + THRESHOLDS.startTimeMinutes * 60 * 1000,
+  ).toISOString();
+
+  // Query events within the time window using the startDateTime index
+  const candidates = await ctx.db
+    .query("events")
+    .withIndex("by_startDateTime", (q) =>
+      q.gte("startDateTime", minTime).lte("startDateTime", maxTime),
+    )
+    .collect();
+
+  // Find the earliest similar event that was created BEFORE this event
+  let earliestSimilar: Doc<"events"> | null = null;
+  const eventCreatedAt = new Date(event.created_at);
+
+  for (const candidate of candidates) {
+    // Skip self
+    if (candidate.id === event.id) {
+      continue;
+    }
+
+    // Only consider events created before this one (they're the potential canonical)
+    const candidateCreatedAt = new Date(candidate.created_at);
+    if (candidateCreatedAt >= eventCreatedAt) {
+      continue;
+    }
+
+    // Check if events are similar
+    const isSimilar = areEventsSimilar(
+      {
+        startDateTime: event.startDateTime,
+        endDateTime: event.endDateTime,
+        name: event.name,
+        description: event.description,
+        location: event.location,
+      },
+      {
+        startDateTime: candidate.startDateTime,
+        endDateTime: candidate.endDateTime,
+        name: candidate.name,
+        description: candidate.description,
+        location: candidate.location,
+      },
+    );
+
+    if (isSimilar) {
+      // If this candidate already points to a canonical event, use that
+      if (candidate.similarToEventId) {
+        return candidate.similarToEventId;
+      }
+
+      // Otherwise, check if this is earlier than our current earliest
+      if (!earliestSimilar || candidateCreatedAt < new Date(earliestSimilar.created_at)) {
+        earliestSimilar = candidate;
+      }
+    }
+  }
+
+  // Return the ID of the earliest similar event (canonical)
+  return earliestSimilar?.id ?? null;
+}

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -79,6 +79,9 @@ export default defineSchema({
     description: v.optional(v.string()),
     // Batch tracking
     batchId: v.optional(v.string()),
+    // Similarity grouping - points to the canonical (earliest) similar event
+    // null/undefined means this event is canonical (no similar event found before it)
+    similarToEventId: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
     .index("by_custom_id", ["id"])


### PR DESCRIPTION
## Summary
- Fix scroll jitter caused by O(n²) similarity computation running on every render
- Move similarity calculation to backend at event creation time
- Add backfill migration for existing events

## Changes
- Add `similarToEventId` field to events schema
- Create `similarityHelpers.ts` with server-side cosine similarity logic
- Update `createEvent()` to compute similarity before insert
- Add backfill migration for existing events
- Update frontend to use O(n) grouping by pre-computed `similarToEventId`

## Test plan
- [ ] Deploy backend changes
- [ ] Run backfill: `npx convex run migrations/backfillSimilarity:runBackfillSimilarity`
- [ ] Create two similar events (same name, close start times) - verify second gets `similarToEventId`
- [ ] Scroll through 50+ events - verify no jitter
- [ ] Verify similar events still group correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The app now automatically detects and groups similar or duplicate events together. When creating a new event, the system checks for existing similar events and visually groups them with your primary event highlighted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->