### PR TITLE
Fix public list feature opening in app

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -4,7 +4,30 @@
       {
         "appID": "GQ59Z4XZHZ.com.soonlist.app",
         "paths": [
-          "/event/*"
+          "/event/*",
+          "NOT /",
+          "NOT /api/*",
+          "NOT /_next/*",
+          "NOT /new",
+          "NOT /privacy",
+          "NOT /terms",
+          "NOT /terms-ios",
+          "NOT /contact",
+          "NOT /2024",
+          "NOT /2024/*",
+          "NOT /get-started",
+          "NOT /explore",
+          "NOT /explore/*",
+          "NOT /sign-in",
+          "NOT /sign-in/*",
+          "NOT /join",
+          "NOT /sign-up",
+          "NOT /sign-up/*",
+          "NOT /install",
+          "NOT /account",
+          "NOT /account/*",
+          "NOT /about",
+          "/*"
         ]
       }
     ]


### PR DESCRIPTION
Update apple-app-site-association to include user profile paths (/{username}) so iOS can open public list pages directly in the app. Added exclusions for known static routes (api, auth, marketing pages, etc.) to prevent them from opening in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced native app security by updating the Apple App Site Association configuration. Expanded URL access restrictions to prevent unintended deep linking and tighten control over which URLs are associated with the app, while preserving core event path functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->