### PR TITLE
feat(expo): Anchor modals to tabs for deep link navigation

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -58,6 +58,12 @@ const queryClient = new QueryClient();
 // Export Expo Router's default error boundary
 export { ErrorBoundary } from "expo-router";
 
+// Anchor modals to tabs so deep links show the modal over the feed
+// See: https://docs.expo.dev/router/advanced/modals/#handle-deep-linked-modals
+export const unstable_settings = {
+  anchor: "(tabs)",
+};
+
 // This adds accessGroup support to Clerk's token cache: https://github.com/clerk/javascript/blob/main/packages/expo/src/token-cache/index.ts
 const tokenCache = {
   async getToken(key: string) {


### PR DESCRIPTION
## Summary
- Add `unstable_settings` with `anchor: "(tabs)"` to root layout
- When users deep link to event modals (e.g., from Instagram), the tabs/feed remain in the navigation stack
- Users can now dismiss the modal and land on the feed instead of having no navigation context

## Why
Previously, deep linking to `/event/123` opened the event modal with nothing behind it. Dismissing the modal had nowhere to go. Now the feed is anchored behind the modal.

## Docs
https://docs.expo.dev/router/advanced/modals/#handle-deep-linked-modals

## Test plan
- [ ] Deep link to an event from outside the app (e.g., `soonlist://event/123`)
- [ ] Verify modal opens over the feed
- [ ] Dismiss the modal and verify you land on the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modal behavior to correctly display over the feed when accessed through deep links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->