### PR TITLE
Server-side grouped feeds: schema, helpers, migrations, and client update

### DIFF
--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -44,4 +44,12 @@ crons.cron(
   {},
 );
 
+// Update hasEnded flags for userFeedGroups every 15 minutes
+crons.cron(
+  "update grouped hasEnded flags",
+  "*/15 * * * *", // Every 15 minutes
+  internal.feeds.updateHasEndedFlagsForFeedGroupsAction,
+  {},
+);
+
 export default crons;

--- a/packages/backend/convex/feedGroupHelpers.ts
+++ b/packages/backend/convex/feedGroupHelpers.ts
@@ -1,0 +1,107 @@
+import type { MutationCtx } from "./_generated/server";
+import { selectPrimaryEventForFeed } from "./model/similarityHelpers";
+
+export async function upsertGroupedFeedEntryFromMembership(
+  ctx: MutationCtx,
+  args: { feedId: string; similarityGroupId: string },
+) {
+  const membership = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_feed_group", (q) =>
+      q.eq("feedId", args.feedId).eq("similarityGroupId", args.similarityGroupId),
+    )
+    .collect();
+
+  if (membership.length === 0) {
+    await removeGroupedFeedEntryIfNoMembers(ctx, args);
+    return;
+  }
+
+  const primaryEvent = await selectPrimaryEventForFeed(ctx, args);
+  if (!primaryEvent) {
+    await removeGroupedFeedEntryIfNoMembers(ctx, args);
+    return;
+  }
+
+  const eventStartTime = new Date(primaryEvent.startDateTime).getTime();
+  const eventEndTime = new Date(primaryEvent.endDateTime).getTime();
+  const hasEnded = eventEndTime < Date.now();
+  const similarEventsCount = Math.max(0, membership.length - 1);
+
+  const existing = await ctx.db
+    .query("userFeedGroups")
+    .withIndex("by_feed_group", (q) =>
+      q.eq("feedId", args.feedId).eq("similarityGroupId", args.similarityGroupId),
+    )
+    .first();
+
+  const nextDoc = {
+    feedId: args.feedId,
+    similarityGroupId: args.similarityGroupId,
+    primaryEventId: primaryEvent.id,
+    eventStartTime,
+    eventEndTime,
+    hasEnded,
+    similarEventsCount,
+  };
+
+  if (!existing) {
+    await ctx.db.insert("userFeedGroups", nextDoc);
+  } else {
+    await ctx.db.patch(existing._id, nextDoc);
+  }
+}
+
+export async function removeGroupedFeedEntryIfNoMembers(
+  ctx: MutationCtx,
+  args: { feedId: string; similarityGroupId: string },
+) {
+  const membership = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_feed_group", (q) =>
+      q.eq("feedId", args.feedId).eq("similarityGroupId", args.similarityGroupId),
+    )
+    .collect();
+
+  if (membership.length > 0) {
+    return;
+  }
+
+  const existing = await ctx.db
+    .query("userFeedGroups")
+    .withIndex("by_feed_group", (q) =>
+      q.eq("feedId", args.feedId).eq("similarityGroupId", args.similarityGroupId),
+    )
+    .first();
+
+  if (existing) {
+    await ctx.db.delete(existing._id);
+  }
+}
+
+export async function syncGroupedFeedEntriesForEvent(
+  ctx: MutationCtx,
+  args: { eventId: string },
+) {
+  const feedEntries = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_event", (q) => q.eq("eventId", args.eventId))
+    .collect();
+
+  const uniquePairs = new Map<string, { feedId: string; similarityGroupId: string }>();
+
+  for (const entry of feedEntries) {
+    if (!entry.similarityGroupId) {
+      continue;
+    }
+    const key = `${entry.feedId}:${entry.similarityGroupId}`;
+    uniquePairs.set(key, {
+      feedId: entry.feedId,
+      similarityGroupId: entry.similarityGroupId,
+    });
+  }
+
+  for (const pair of uniquePairs.values()) {
+    await upsertGroupedFeedEntryFromMembership(ctx, pair);
+  }
+}

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -60,6 +60,46 @@ async function queryFeed(
   };
 }
 
+// Helper function to query grouped feed entries
+async function queryFeedGrouped(
+  ctx: QueryCtx,
+  feedId: string,
+  paginationOpts: PaginationOptions,
+  filter: "upcoming" | "past" = "upcoming",
+) {
+  const hasEnded = filter === "past";
+  const order = filter === "upcoming" ? "asc" : "desc";
+
+  const feedQuery = ctx.db
+    .query("userFeedGroups")
+    .withIndex("by_feed_hasEnded_startTime", (q) =>
+      q.eq("feedId", feedId).eq("hasEnded", hasEnded),
+    )
+    .order(order);
+
+  const feedResults = await feedQuery.paginate(paginationOpts);
+
+  const events = await Promise.all(
+    feedResults.page.map(async (groupEntry) => {
+      const event = await getEventById(ctx, groupEntry.primaryEventId);
+      if (!event) {
+        return null;
+      }
+      return {
+        ...event,
+        similarEventsCount: groupEntry.similarEventsCount,
+      };
+    }),
+  );
+
+  const validEvents = events.filter((event) => event !== null);
+
+  return {
+    ...feedResults,
+    page: validEvents,
+  };
+}
+
 // Main feed query that uses proper hasEnded-based filtering
 export const getFeed = query({
   args: {
@@ -86,6 +126,30 @@ export const getFeed = query({
 
     // Use the common query function
     return queryFeed(ctx, feedId, paginationOpts, filter);
+  },
+});
+
+export const getFeedGrouped = query({
+  args: {
+    feedId: v.string(),
+    paginationOpts: paginationOptsValidator,
+    filter: v.union(v.literal("upcoming"), v.literal("past")),
+  },
+  handler: async (ctx, { feedId, paginationOpts, filter }) => {
+    if (feedId.startsWith("user_")) {
+      const requestedUserId = feedId.replace("user_", "");
+      const currentUserId = await getUserId(ctx);
+
+      if (!currentUserId) {
+        throw new ConvexError("Authentication required to access user feeds");
+      }
+
+      if (requestedUserId !== currentUserId) {
+        throw new ConvexError("Unauthorized access to user feed");
+      }
+    }
+
+    return queryFeedGrouped(ctx, feedId, paginationOpts, filter);
   },
 });
 
@@ -277,6 +341,47 @@ export const updateHasEndedFlagsBatch = internalMutation({
   },
 });
 
+// Internal mutation to update hasEnded flags for grouped feed entries
+export const updateHasEndedFlagsForFeedGroupsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    updated: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const currentTime = Date.now();
+    let updated = 0;
+
+    const result = await ctx.db
+      .query("userFeedGroups")
+      .order("asc")
+      .paginate({ numItems: batchSize, cursor });
+
+    for (const entry of result.page) {
+      const shouldHaveEnded = entry.eventEndTime < currentTime;
+
+      if (entry.hasEnded !== shouldHaveEnded) {
+        await ctx.db.patch(entry._id, {
+          hasEnded: shouldHaveEnded,
+        });
+        updated++;
+      }
+    }
+
+    return {
+      processed: result.page.length,
+      updated,
+      nextCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
 // Internal query to get discover feed events without pagination (for external integrations)
 export const getDiscoverEventsForIntegration = internalQuery({
   args: {
@@ -369,6 +474,53 @@ export const updateHasEndedFlagsAction = internalAction({
 
     console.log(
       `Updated hasEnded flags: ${totalUpdated} changed out of ${totalProcessed} processed`,
+    );
+
+    return {
+      totalProcessed,
+      totalUpdated,
+    };
+  },
+});
+
+// Internal action to update hasEnded flags across grouped feed entries
+export const updateHasEndedFlagsForFeedGroupsAction = internalAction({
+  args: {},
+  returns: v.object({
+    totalProcessed: v.number(),
+    totalUpdated: v.number(),
+  }),
+  handler: async (ctx) => {
+    let totalProcessed = 0;
+    let totalUpdated = 0;
+    let cursor: string | null = null;
+    const batchSize = 2048;
+
+    while (true) {
+      const result: {
+        processed: number;
+        updated: number;
+        nextCursor: string | null;
+        isDone: boolean;
+      } = await ctx.runMutation(
+        internal.feeds.updateHasEndedFlagsForFeedGroupsBatch,
+        {
+          cursor,
+          batchSize,
+        },
+      );
+
+      totalProcessed += result.processed;
+      totalUpdated += result.updated;
+
+      if (result.isDone) {
+        break;
+      }
+      cursor = result.nextCursor;
+    }
+
+    console.log(
+      `Updated grouped hasEnded flags: ${totalUpdated} changed out of ${totalProcessed} processed`,
     );
 
     return {

--- a/packages/backend/convex/migrations/backfillSimilarityGroupIds.ts
+++ b/packages/backend/convex/migrations/backfillSimilarityGroupIds.ts
@@ -1,0 +1,30 @@
+import { Migrations } from "@convex-dev/migrations";
+
+import type { DataModel } from "../_generated/dataModel.js";
+import { components, internal } from "../_generated/api.js";
+import {
+  findSimilarityGroupForBackfill,
+  generateSimilarityGroupId,
+} from "../model/similarityHelpers";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+
+export const backfillSimilarityGroupIds = migrations.define({
+  table: "events",
+  batchSize: 50,
+  migrateOne: async (ctx, event) => {
+    if (event.similarityGroupId) {
+      return;
+    }
+
+    const similarityGroupId =
+      (await findSimilarityGroupForBackfill(ctx, event)) ??
+      generateSimilarityGroupId();
+
+    await ctx.db.patch(event._id, { similarityGroupId });
+  },
+});
+
+export const runBackfillSimilarityGroupIds = migrations.runner(
+  internal.migrations.backfillSimilarityGroupIds.backfillSimilarityGroupIds,
+);

--- a/packages/backend/convex/migrations/backfillUserFeedGroups.ts
+++ b/packages/backend/convex/migrations/backfillUserFeedGroups.ts
@@ -1,0 +1,26 @@
+import { Migrations } from "@convex-dev/migrations";
+
+import type { DataModel } from "../_generated/dataModel.js";
+import { components, internal } from "../_generated/api.js";
+import { upsertGroupedFeedEntryFromMembership } from "../feedGroupHelpers";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+
+export const backfillUserFeedGroups = migrations.define({
+  table: "userFeeds",
+  batchSize: 200,
+  migrateOne: async (ctx, feedEntry) => {
+    if (!feedEntry.similarityGroupId) {
+      return;
+    }
+
+    await upsertGroupedFeedEntryFromMembership(ctx, {
+      feedId: feedEntry.feedId,
+      similarityGroupId: feedEntry.similarityGroupId,
+    });
+  },
+});
+
+export const runBackfillUserFeedGroups = migrations.runner(
+  internal.migrations.backfillUserFeedGroups.backfillUserFeedGroups,
+);

--- a/packages/backend/convex/migrations/backfillUserFeedSimilarityGroupIds.ts
+++ b/packages/backend/convex/migrations/backfillUserFeedSimilarityGroupIds.ts
@@ -1,0 +1,34 @@
+import { Migrations } from "@convex-dev/migrations";
+
+import type { DataModel } from "../_generated/dataModel.js";
+import { components, internal } from "../_generated/api.js";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+
+export const backfillUserFeedSimilarityGroupIds = migrations.define({
+  table: "userFeeds",
+  batchSize: 200,
+  migrateOne: async (ctx, feedEntry) => {
+    if (feedEntry.similarityGroupId) {
+      return;
+    }
+
+    const event = await ctx.db
+      .query("events")
+      .withIndex("by_custom_id", (q) => q.eq("id", feedEntry.eventId))
+      .unique();
+
+    if (!event?.similarityGroupId) {
+      return;
+    }
+
+    await ctx.db.patch(feedEntry._id, {
+      similarityGroupId: event.similarityGroupId,
+    });
+  },
+});
+
+export const runBackfillUserFeedSimilarityGroupIds = migrations.runner(
+  internal.migrations.backfillUserFeedSimilarityGroupIds
+    .backfillUserFeedSimilarityGroupIds,
+);

--- a/packages/backend/convex/migrations/userFeedsMigration.ts
+++ b/packages/backend/convex/migrations/userFeedsMigration.ts
@@ -34,6 +34,7 @@ export const populateUserFeeds = migrations.define({
             eventEndTime,
             addedAt: currentTime,
             hasEnded: eventEndTime < currentTime, // always set
+            similarityGroupId: event.similarityGroupId,
           });
           addedCount++;
         }
@@ -64,6 +65,7 @@ export const populateUserFeeds = migrations.define({
               eventEndTime,
               addedAt: currentTime,
               hasEnded: eventEndTime < currentTime, // always set
+              similarityGroupId: event.similarityGroupId,
             });
             addedCount++;
           }
@@ -101,6 +103,7 @@ export const populateUserFeeds = migrations.define({
                 eventEndTime,
                 addedAt: currentTime,
                 hasEnded: eventEndTime < currentTime, // always set
+                similarityGroupId: event.similarityGroupId,
               });
               addedCount++;
             }

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -14,6 +14,10 @@ import {
 } from "../aggregates";
 import { DEFAULT_TIMEZONE } from "../constants";
 import { generateNumericId, generatePublicId } from "../utils";
+import {
+  findSimilarityGroup,
+  generateSimilarityGroupId,
+} from "./similarityHelpers";
 
 // Type for event data (based on AddToCalendarButtonProps)
 interface EventData {
@@ -731,6 +735,15 @@ export async function createEvent(
   const startDateTime = parseDateTime(eventData.startDate, startTime, timeZone);
   const endDateTime = parseDateTime(eventData.endDate, endTime, timeZone);
 
+  const similarityGroupId =
+    (await findSimilarityGroup(ctx, {
+      startDateTime: startDateTime.toISOString(),
+      endDateTime: endDateTime.toISOString(),
+      name: eventData.name,
+      description: eventData.description,
+      location: eventData.location,
+    })) ?? generateSimilarityGroupId();
+
   // Create the event
   const eventDocId = await ctx.db.insert("events", {
     id: eventId,
@@ -754,6 +767,7 @@ export async function createEvent(
     startTime,
     description: eventData.description,
     batchId,
+    similarityGroupId,
   });
 
   // Sync with aggregates for efficient stats
@@ -792,6 +806,7 @@ export async function createEvent(
     visibility: visibility || "public",
     startDateTime: startDateTime.toISOString(),
     endDateTime: endDateTime.toISOString(),
+    similarityGroupId,
   });
 
   return { id: eventId };
@@ -952,6 +967,7 @@ export async function updateEvent(
       visibility: visibility || existingEvent.visibility,
       startDateTime: startDateTime.toISOString(),
       endDateTime: endDateTime.toISOString(),
+      similarityGroupId: existingEvent.similarityGroupId,
     });
 
     // If changing to public, fan out to list followers
@@ -1348,6 +1364,7 @@ export async function toggleEventVisibility(
         visibility,
         startDateTime: event.startDateTime,
         endDateTime: event.endDateTime,
+        similarityGroupId: event.similarityGroupId,
       });
 
       // Fan out to list followers when event becomes public

--- a/packages/backend/convex/model/similarityHelpers.ts
+++ b/packages/backend/convex/model/similarityHelpers.ts
@@ -1,0 +1,215 @@
+import type { Doc } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import { generatePublicId } from "../utils";
+
+const TIME_THRESHOLD_MINUTES = 60;
+const TEXT_SIMILARITY_THRESHOLD = 0.1;
+
+function textToVector(text: string): Map<string, number> {
+  const wordMap = new Map<string, number>();
+  const words = text.toLowerCase().match(/\w+/g) || [];
+
+  for (const word of words) {
+    wordMap.set(word, (wordMap.get(word) || 0) + 1);
+  }
+
+  return wordMap;
+}
+
+function cosineSimilarity(
+  vector1: Map<string, number>,
+  vector2: Map<string, number>,
+): number {
+  if (vector1.size === 0 || vector2.size === 0) {
+    return 0;
+  }
+
+  const intersection = new Set(
+    [...vector1.keys()].filter((key) => vector2.has(key)),
+  );
+  let dotProduct = 0;
+  for (const word of intersection) {
+    dotProduct += (vector1.get(word) || 0) * (vector2.get(word) || 0);
+  }
+
+  const sumOfSquares = (vector: Map<string, number>) => {
+    let sum = 0;
+    for (const value of vector.values()) {
+      sum += value * value;
+    }
+    return sum;
+  };
+
+  const denominator =
+    Math.sqrt(sumOfSquares(vector1)) * Math.sqrt(sumOfSquares(vector2));
+  return denominator === 0 ? 0 : dotProduct / denominator;
+}
+
+function minutesBetween(dateA: string, dateB: string): number {
+  return Math.abs(
+    (new Date(dateA).getTime() - new Date(dateB).getTime()) / 60000,
+  );
+}
+
+export function areEventsSimilar(
+  eventA: Pick<
+    Doc<"events">,
+    "startDateTime" | "endDateTime" | "name" | "description" | "location"
+  >,
+  eventB: Pick<
+    Doc<"events">,
+    "startDateTime" | "endDateTime" | "name" | "description" | "location"
+  >,
+): boolean {
+  const startTimeDifference = minutesBetween(
+    eventA.startDateTime,
+    eventB.startDateTime,
+  );
+  const endTimeDifference = minutesBetween(
+    eventA.endDateTime,
+    eventB.endDateTime,
+  );
+
+  const nameSimilarity = cosineSimilarity(
+    textToVector(eventA.name || ""),
+    textToVector(eventB.name || ""),
+  );
+  const descriptionSimilarity = cosineSimilarity(
+    textToVector(eventA.description || ""),
+    textToVector(eventB.description || ""),
+  );
+  const locationSimilarity = cosineSimilarity(
+    textToVector(eventA.location || ""),
+    textToVector(eventB.location || ""),
+  );
+
+  return (
+    startTimeDifference <= TIME_THRESHOLD_MINUTES &&
+    endTimeDifference <= TIME_THRESHOLD_MINUTES &&
+    nameSimilarity >= TEXT_SIMILARITY_THRESHOLD &&
+    descriptionSimilarity >= TEXT_SIMILARITY_THRESHOLD &&
+    locationSimilarity >= TEXT_SIMILARITY_THRESHOLD
+  );
+}
+
+export function generateSimilarityGroupId() {
+  return `sg_${generatePublicId()}`;
+}
+
+export async function findSimilarityGroup(
+  ctx: QueryCtx,
+  event: Pick<
+    Doc<"events">,
+    "startDateTime" | "endDateTime" | "name" | "description" | "location"
+  >,
+) {
+  const startTime = new Date(event.startDateTime).getTime();
+  const windowStart = new Date(
+    startTime - TIME_THRESHOLD_MINUTES * 60 * 1000,
+  ).toISOString();
+  const windowEnd = new Date(
+    startTime + TIME_THRESHOLD_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  const candidates = await ctx.db
+    .query("events")
+    .withIndex("by_startDateTime", (q) =>
+      q.gte("startDateTime", windowStart).lte("startDateTime", windowEnd),
+    )
+    .collect();
+
+  for (const candidate of candidates) {
+    if (!candidate.similarityGroupId) {
+      continue;
+    }
+    if (areEventsSimilar(candidate, event)) {
+      return candidate.similarityGroupId;
+    }
+  }
+
+  return null;
+}
+
+export async function findSimilarityGroupForBackfill(
+  ctx: QueryCtx,
+  event: Doc<"events">,
+) {
+  const startTime = new Date(event.startDateTime).getTime();
+  const windowStart = new Date(
+    startTime - TIME_THRESHOLD_MINUTES * 60 * 1000,
+  ).toISOString();
+  const windowEnd = new Date(
+    startTime + TIME_THRESHOLD_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  const candidates = await ctx.db
+    .query("events")
+    .withIndex("by_startDateTime", (q) =>
+      q.gte("startDateTime", windowStart).lte("startDateTime", windowEnd),
+    )
+    .collect();
+
+  const earlierCandidates = candidates.filter(
+    (candidate) =>
+      candidate.similarityGroupId &&
+      new Date(candidate.created_at).getTime() <=
+        new Date(event.created_at).getTime(),
+  );
+
+  for (const candidate of earlierCandidates) {
+    if (areEventsSimilar(candidate, event)) {
+      return candidate.similarityGroupId;
+    }
+  }
+
+  return null;
+}
+
+export async function selectPrimaryEventForFeed(
+  ctx: QueryCtx,
+  args: { feedId: string; similarityGroupId: string },
+): Promise<Doc<"events"> | null> {
+  const membership = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_feed_group", (q) =>
+      q.eq("feedId", args.feedId).eq("similarityGroupId", args.similarityGroupId),
+    )
+    .collect();
+
+  if (membership.length === 0) {
+    return null;
+  }
+
+  const memberEvents = await Promise.all(
+    membership.map((member) =>
+      ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", member.eventId))
+        .unique(),
+    ),
+  );
+
+  const validEvents = memberEvents.filter(
+    (event): event is Doc<"events"> => event !== null,
+  );
+
+  if (validEvents.length === 0) {
+    return null;
+  }
+
+  const feedUserId = args.feedId.startsWith("user_")
+    ? args.feedId.replace("user_", "")
+    : null;
+
+  if (feedUserId) {
+    const ownEvent = validEvents.find((event) => event.userId === feedUserId);
+    if (ownEvent) {
+      return ownEvent;
+    }
+  }
+
+  return validEvents.sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  )[0];
+}

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -79,6 +79,8 @@ export default defineSchema({
     description: v.optional(v.string()),
     // Batch tracking
     batchId: v.optional(v.string()),
+    // Similarity group ID (optional during migration)
+    similarityGroupId: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
     .index("by_custom_id", ["id"])
@@ -87,7 +89,8 @@ export default defineSchema({
     .index("by_visibility_and_startDateTime", ["visibility", "startDateTime"])
     .index("by_user_and_endDateTime", ["userId", "endDateTime"])
     .index("by_visibility_and_endDateTime", ["visibility", "endDateTime"])
-    .index("by_batch_id", ["batchId"]),
+    .index("by_batch_id", ["batchId"])
+    .index("by_similarity_group", ["similarityGroupId"]),
 
   eventToLists: defineTable({
     eventId: v.string(),
@@ -208,6 +211,8 @@ export default defineSchema({
     addedAt: v.number(), // When added to feed (timestamp)
     hasEnded: v.boolean(), // Pre-computed field: true if event has ended, false if ongoing/upcoming (now required)
     beforeThisDateTime: v.optional(v.string()), // Optional ISO date string for custom filtering
+    // Similarity group membership for grouped feed derivation
+    similarityGroupId: v.optional(v.string()),
   })
     .index("by_feed_hasEnded_startTime", [
       "feedId",
@@ -215,7 +220,25 @@ export default defineSchema({
       "eventStartTime",
     ]) // For efficient filtering and sorting
     .index("by_feed_event", ["feedId", "eventId"]) // For deduplication checks
-    .index("by_event", ["eventId"]), // For event removal across all feeds
+    .index("by_event", ["eventId"]) // For event removal across all feeds
+    .index("by_feed_group", ["feedId", "similarityGroupId"]),
+
+  userFeedGroups: defineTable({
+    feedId: v.string(),
+    similarityGroupId: v.string(),
+    primaryEventId: v.string(),
+    eventStartTime: v.number(),
+    eventEndTime: v.number(),
+    hasEnded: v.boolean(),
+    similarEventsCount: v.number(),
+  })
+    .index("by_feed_hasEnded_startTime", [
+      "feedId",
+      "hasEnded",
+      "eventStartTime",
+    ])
+    .index("by_feed_group", ["feedId", "similarityGroupId"])
+    .index("by_group", ["similarityGroupId"]),
 
   guestOnboardingData: defineTable({
     ownerToken: v.string(), // Guest user ID


### PR DESCRIPTION
### Motivation
- Eliminate client-side O(n²) similarity grouping that causes UI stuttering by moving grouping and counts to the server.
- Provide stable, paginated grouped feeds where each real-world event appears once and grouping respects per-feed membership and privacy rules.
- Keep backward compatibility so legacy clients continue using `userFeeds` while new clients read deduped rows from `userFeedGroups`.

### Description
- Schema: add `events.similarityGroupId`, add `userFeeds.similarityGroupId` + `by_feed_group` index, and introduce a new `userFeedGroups` table with indexes for feed-scoped pagination and `similarEventsCount`.
- Similarity & grouping: add `packages/backend/convex/model/similarityHelpers.ts` implementing `areEventsSimilar`, `findSimilarityGroup`, `generateSimilarityGroupId`, and `selectPrimaryEventForFeed` to elect primaries using `userFeeds` membership only.
- Derived/dual-write maintenance: add `packages/backend/convex/feedGroupHelpers.ts` with `upsertGroupedFeedEntryFromMembership`, `removeGroupedFeedEntryIfNoMembers`, and `syncGroupedFeedEntriesForEvent`, and thread `similarityGroupId` through `packages/backend/convex/feedHelpers.ts` so every `userFeeds` insert/patch/delete upserts/removes the corresponding `userFeedGroups` row in the same mutation.
- Queries, cron & sync: add `getFeedGrouped` in `packages/backend/convex/feeds.ts` (reads `userFeedGroups` and attaches `similarEventsCount`), add grouped `hasEnded` maintenance and cron in `packages/backend/convex/crons.ts`, and wire similarity group assignment into `createEvent` and sync paths (`planetscaleSync.ts`).
- Migrations & backfill: add migrations `backfillSimilarityGroupIds`, `backfillUserFeedSimilarityGroupIds`, and `backfillUserFeedGroups` under `packages/backend/convex/migrations` to populate `events.similarityGroupId`, then `userFeeds.similarityGroupId`, then derived `userFeedGroups`.
- Client: update Expo list `apps/expo/src/components/UserEventsList.tsx` to use server-provided grouping (`getFeedGrouped`) and remove client-side `collapseSimilarEvents` logic while rendering `similarEventsCount` from the server.

### Testing
- No automated tests were run as part of this change; migrations and runtime behavior should be validated in staging by running the backfill sequence: `backfillSimilarityGroupIds` → `backfillUserFeedSimilarityGroupIds` → `backfillUserFeedGroups`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968af6c3798832aa065e685d0062824)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a grouped feed system to organize similar events together with counts.
  * Added automatic similarity detection for events based on time, name, and location.
  * Introduced a new grouped feed query with pagination and filtering options.

* **Refactor**
  * Removed automatic collapsing of similar events in event lists; events now display as individual entries with similarity counts.
  * Restructured event grouping logic to operate at the backend level.

* **Chores**
  * Added scheduled tasks to maintain grouped feed metadata.
  * Created data migrations to backfill grouping information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->