### PR TITLE
fix(expo): Disable Sentry mobile replay to fix scroll jank

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -97,15 +97,17 @@ Sentry.init({
   integrations: [
     routingInstrumentation,
     Sentry.httpClientIntegration(),
-    Sentry.mobileReplayIntegration(),
+    // Mobile replay disabled - causes significant scroll jank on iOS
+    // Sentry.mobileReplayIntegration(),
   ],
   attachStacktrace: true,
   debug: false,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
   sendDefaultPii: true,
-  replaysSessionSampleRate: 1.0,
-  replaysOnErrorSampleRate: 1.0,
+  // Session replay disabled since mobileReplayIntegration causes scroll jank
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0,
 });
 
 appsFlyer.initSdk(


### PR DESCRIPTION
## Summary
- Disables Sentry's `mobileReplayIntegration` which was causing significant scroll jank on iOS
- Sets `replaysSessionSampleRate` and `replaysOnErrorSampleRate` to 0

## Problem
Sentry's mobile replay feature captures screen recordings during scrolling, which blocks the UI thread and causes visible stuttering/jank during list scrolling.

## Solution
Disable mobile replay while maintaining all other Sentry features (error tracking, tracing, profiling).

## Test plan
- [x] Verified scroll performance is smooth after disabling mobile replay
- [x] Verified other Sentry features (error tracking) still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled mobile session replay to resolve scroll jank issues on iOS devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->