### PR TITLE
fix: Sync event visibility with publicListEnabled setting

### DIFF
--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -48,10 +48,10 @@ export default function UserProfilePage() {
     status,
     loadMore,
   } = useStablePaginatedQuery(
-    api.feeds.getUserCreatedEvents,
+    api.feeds.getPublicUserFeed,
     targetUser
       ? {
-          userId: targetUser.id,
+          username: targetUser.username,
           filter: "upcoming" as const,
         }
       : "skip",

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -224,7 +224,7 @@ export const getDiscoverFeed = query({
   },
 });
 
-// Helper query to get a user's public feed (when publicListEnabled is true)
+// Helper query to get a user's public feed (shows only public events)
 export const getPublicUserFeed = query({
   args: {
     username: v.string(),
@@ -242,15 +242,21 @@ export const getPublicUserFeed = query({
       throw new ConvexError("User not found");
     }
 
-    // Check if the user has enabled public list sharing
-    if (!user.publicListEnabled) {
-      throw new ConvexError("User has not enabled public list sharing");
-    }
-
+    // Profile is always accessible - just show public events (empty if none)
     const feedId = `user_${user.id}`;
 
-    // Use the common query function
-    return queryFeed(ctx, feedId, paginationOpts, filter);
+    // Query feed
+    const result = await queryFeed(ctx, feedId, paginationOpts, filter);
+
+    // Filter to only public events
+    const publicEvents = result.page.filter(
+      (event) => event.visibility === "public",
+    );
+
+    return {
+      ...result,
+      page: publicEvents,
+    };
   },
 });
 

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -906,7 +906,68 @@ export const updatePublicListSettings = mutation({
 
     await ctx.db.patch(user._id, updates);
 
+    // Bulk update event visibility if publicListEnabled changed
+    if (
+      args.publicListEnabled !== undefined &&
+      args.publicListEnabled !== user.publicListEnabled
+    ) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.users.bulkUpdateEventVisibility,
+        {
+          userId: args.userId,
+          visibility: args.publicListEnabled ? "public" : "private",
+        },
+      );
+    }
+
     return null;
+  },
+});
+
+/**
+ * Bulk update all events for a user to match visibility setting
+ */
+export const bulkUpdateEventVisibility = internalMutation({
+  args: {
+    userId: v.string(),
+    visibility: v.union(v.literal("public"), v.literal("private")),
+  },
+  handler: async (ctx, { userId, visibility }) => {
+    const events = await ctx.db
+      .query("events")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+
+    for (const event of events) {
+      // Skip events that already have the target visibility
+      if (event.visibility === visibility) continue;
+
+      // Update the event's visibility
+      await ctx.db.patch(event._id, {
+        visibility,
+        updatedAt: new Date().toISOString(),
+      });
+
+      // Update feed entries based on visibility
+      if (visibility === "private") {
+        // Remove from follower feeds but keep in creator's personal feed
+        await ctx.runMutation(internal.feedHelpers.removeEventFromFeeds, {
+          eventId: event.id,
+          keepCreatorFeed: true,
+        });
+      } else {
+        // Re-add to feeds when making public
+        await ctx.runMutation(internal.feedHelpers.updateEventInFeeds, {
+          eventId: event.id,
+          userId: event.userId,
+          visibility,
+          startDateTime: event.startDateTime,
+          endDateTime: event.endDateTime,
+          similarityGroupId: event.similarityGroupId,
+        });
+      }
+    }
   },
 });
 


### PR DESCRIPTION
## Summary
- Profile pages now filter to only show public events (no more error thrown when publicListEnabled is false)
- Toggle publicListEnabled ON: bulk updates all events to public, adds to follower feeds
- Toggle publicListEnabled OFF: bulk updates all events to private, removes from follower feeds
- New events respect user's publicListEnabled setting when visibility not specified
- Expo profile page uses getPublicUserFeed instead of getUserCreatedEvents

## Test plan
- [ ] Visit a user's profile with mixed public/private events - should only see public events
- [ ] Toggle publicListEnabled ON for a user with private events - all events should become public
- [ ] Toggle publicListEnabled OFF for a user with public events - all events should become private
- [ ] Create a new event as user with publicListEnabled: true - should be public by default
- [ ] Create a new event as user with publicListEnabled: false - should be private by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event visibility now automatically updates across your entire event list when you change your public list settings.

* **Bug Fixes**
  * Improved event visibility filtering to ensure only public events display in user feeds based on privacy settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->