### PR TITLE
fix(backend): Sync grouped feed when unsaving event

### DIFF
--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1301,8 +1301,17 @@ export async function unfollowEvent(
         .unique();
 
       if (feedEntry) {
+        const similarityGroupId = feedEntry.similarityGroupId;
         await userFeedsAggregate.deleteIfExists(ctx, feedEntry);
         await ctx.db.delete(feedEntry._id);
+
+        // Sync grouped feed entry (removes group if empty, or updates primary/count)
+        if (similarityGroupId) {
+          await ctx.runMutation(
+            internal.feedGroupHelpers.upsertGroupedFeedEntry,
+            { feedId, similarityGroupId },
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fix bug where events persist in mobile feed after unsaving
- Sync `userFeedGroups` when deleting from `userFeeds` in `unfollowEvent`
- Apply same pattern used in `feedHelpers.ts:620-631`

## Problem

When a user unsaves an event in the Expo app, the event stays in their feed but just removes the person who saved it. The `userFeeds` entry was deleted but the corresponding `userFeedGroups` entry was not updated.

## Solution

Capture `similarityGroupId` before deletion and call `upsertGroupedFeedEntry` to sync the grouped feed. This:
- Removes the group entirely if empty
- Updates primary/count if other events remain in the group

## Test plan

- [ ] Save an event in Expo app
- [ ] Confirm it appears in feed
- [ ] Unsave the event  
- [ ] Confirm it disappears from feed
- [ ] Check Convex dashboard: `userFeedGroups` entry should be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization of grouped feed entries when unfollowing events, ensuring consistent feed updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->