### PR TITLE
fix(expo): Unify loading state background and spinner position

### DIFF
--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -149,7 +149,8 @@ export default function Page() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-white">
+        <View className="flex-1 bg-interactive-3">
+          <View className="h-[100px]" />
           <LoadingSpinner />
         </View>
       </AuthLoading>

--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -122,7 +122,8 @@ function MyFeed() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-white">
+        <View className="flex-1 bg-interactive-3">
+          <View className="h-[100px]" />
           <LoadingSpinner />
         </View>
       </AuthLoading>

--- a/apps/expo/src/app/(tabs)/following.tsx
+++ b/apps/expo/src/app/(tabs)/following.tsx
@@ -210,7 +210,8 @@ function FollowingFeed() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-white">
+        <View className="flex-1 bg-interactive-3">
+          <View className="h-[100px]" />
           <LoadingSpinner />
         </View>
       </AuthLoading>

--- a/apps/expo/src/app/(tabs)/past.tsx
+++ b/apps/expo/src/app/(tabs)/past.tsx
@@ -102,7 +102,8 @@ export default function PastEvents() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-white">
+        <View className="flex-1 bg-interactive-3">
+          <View className="h-[100px]" />
           <LoadingSpinner />
         </View>
       </AuthLoading>


### PR DESCRIPTION
## Summary
- Fix jarring visual transition between two sequential loading states when app initially loads
- Change AuthLoading background from white to interactive-3 (#F4F1FF) in all tab screens
- Add 100px top spacer to match spinner position with UserEventsList loading state

## Test plan
- [ ] Open app fresh (cold start)
- [ ] Verify loading spinner background is consistent (no white flash)
- [ ] Verify spinner position remains stable between loading states
- [ ] Test all tabs: feed, following, past, discover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated loading screen backgrounds across multiple views to use the app's interactive theme color scheme.
  * Added improved vertical spacing to loading indicators for better visual hierarchy and presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->