### PR TITLE
fix(expo): Show contextual empty state for Following tab when no events

### DIFF
--- a/apps/expo/src/app/(tabs)/following.tsx
+++ b/apps/expo/src/app/(tabs)/following.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { Image } from "expo-image";
 import { Redirect, useRouter } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
@@ -114,6 +114,30 @@ function FollowingHeader() {
   );
 }
 
+function FollowingEmptyState() {
+  return (
+    <ScrollView
+      style={{ backgroundColor: "#F4F1FF" }}
+      contentContainerStyle={{
+        paddingTop: 100,
+        paddingBottom: 120,
+        flexGrow: 1,
+      }}
+      showsVerticalScrollIndicator={false}
+    >
+      <FollowingHeader />
+      <View className="items-center px-6 py-8">
+        <Text className="text-center text-lg text-neutral-2">
+          No upcoming events from people you follow
+        </Text>
+        <Text className="mt-2 text-center text-base text-neutral-3">
+          Check back later for new events
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
 function FollowingFeedContent() {
   const { user } = useUser();
   const stableTimestamp = useStableTimestamp();
@@ -199,6 +223,7 @@ function FollowingFeedContent() {
         savedEventIds={savedEventIds}
         source="following"
         HeaderComponent={FollowingHeader}
+        EmptyStateComponent={FollowingEmptyState}
       />
     </View>
   );

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -1022,6 +1022,7 @@ interface UserEventsListProps {
   isDiscoverFeed?: boolean;
   savedEventIds?: Set<string>;
   HeaderComponent?: React.ComponentType<Record<string, never>>;
+  EmptyStateComponent?: React.ComponentType<Record<string, never>>;
   source?: string;
 }
 
@@ -1041,6 +1042,7 @@ export default function UserEventsList(props: UserEventsListProps) {
     isDiscoverFeed = false,
     savedEventIds,
     HeaderComponent,
+    EmptyStateComponent,
     source,
   } = props;
   const { user } = useUser();
@@ -1092,6 +1094,9 @@ export default function UserEventsList(props: UserEventsListProps) {
   }
 
   if (collapsedEvents.length === 0) {
+    if (EmptyStateComponent) {
+      return <EmptyStateComponent />;
+    }
     return renderEmptyState();
   }
 


### PR DESCRIPTION
## Summary
- When users follow people but those users have no upcoming events, the Following tab now shows a helpful empty state
- Previously showed generic "Your events, all in one place" message which was confusing
- Now displays who the user is following and explains there are no upcoming events

## Changes
- Add `EmptyStateComponent` prop to `UserEventsList` for custom empty states
- Create `FollowingEmptyState` component that shows followed users list
- Display contextual message: "No upcoming events from people you follow"

## Test plan
- [ ] Follow a user who has no upcoming events
- [ ] Navigate to Following tab
- [ ] Verify you see "Following X lists" header with followed users
- [ ] Verify you see "No upcoming events from people you follow" message
- [ ] When followed user adds an event, verify it appears in the feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated empty state view for the Following tab that displays when no events are followed.
  * Enhanced the events list component with support for custom empty state displays, enabling more flexible UI customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->