### PR TITLE
Fix duplicate action button rendering in UserEventsList

### DIFF
--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -589,7 +589,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
             <View className="-mb-2 mt-1.5 flex-row items-center justify-start gap-3">
               {ActionButton && <ActionButton event={event} />}
 
-              {!isDiscoverFeed && (
+              {!isDiscoverFeed && !ActionButton && (
                 <TouchableOpacity
                   className="-mb-0.5 -ml-2.5 flex-row items-center gap-2 bg-interactive-2 px-4 py-2.5"
                   style={{ borderRadius: 16 }}


### PR DESCRIPTION
## Summary
Fixed a conditional rendering issue in the UserEventListItem component that was causing duplicate action buttons to display when both an ActionButton prop and the fallback button were present.

## Changes
- Updated the conditional logic for the fallback TouchableOpacity button to only render when both `!isDiscoverFeed` AND `!ActionButton` conditions are met
- Previously, the fallback button would render even when a custom ActionButton was already displayed, causing visual duplication

## Details
The fix ensures that when a custom `ActionButton` component is provided via props, the default button implementation is not rendered. This prevents UI clutter and maintains the intended behavior where either a custom action button or the default one should be shown, but not both.

https://claude.ai/code/session_01RNhmdJXTN1oYRzPAc9KB66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted action button display logic in event lists to prevent conflicting actions in certain contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->