### PR TITLE
fix(expo): Replace LiquidGlassHeader with solid header in all event screen states

### DIFF
--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -44,7 +44,6 @@ import {
   ShareIcon,
   User,
 } from "~/components/icons";
-import { LiquidGlassHeader } from "~/components/LiquidGlassHeader";
 import LoadingSpinner from "~/components/LoadingSpinner";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useEventActions } from "~/hooks/useEventActions";
@@ -248,7 +247,11 @@ export default function Page() {
         <Stack.Screen
           options={{
             headerTransparent: false,
-            headerBackground: () => <LiquidGlassHeader />,
+            headerBackground: () => (
+              <View style={{ flex: 1, backgroundColor: "#E0D9FF" }} />
+            ),
+            headerTintColor: "#5A32FB",
+            headerTitleStyle: { color: "#5A32FB" },
             headerRight: () => null,
           }}
         />
@@ -266,7 +269,11 @@ export default function Page() {
         <Stack.Screen
           options={{
             headerTransparent: false,
-            headerBackground: () => <LiquidGlassHeader />,
+            headerBackground: () => (
+              <View style={{ flex: 1, backgroundColor: "#E0D9FF" }} />
+            ),
+            headerTintColor: "#5A32FB",
+            headerTitleStyle: { color: "#5A32FB" },
             headerRight: () => null,
           }}
         />
@@ -284,7 +291,11 @@ export default function Page() {
         <Stack.Screen
           options={{
             headerTransparent: false,
-            headerBackground: () => <LiquidGlassHeader />,
+            headerBackground: () => (
+              <View style={{ flex: 1, backgroundColor: "#E0D9FF" }} />
+            ),
+            headerTintColor: "#5A32FB",
+            headerTitleStyle: { color: "#5A32FB" },
             headerRight: () => null,
           }}
         />
@@ -339,7 +350,11 @@ export default function Page() {
           headerRight: HeaderRight,
           headerLeft: !canGoBack ? HeaderLeft : undefined,
           headerTransparent: false,
-          headerBackground: () => <LiquidGlassHeader />,
+          headerBackground: () => (
+            <View style={{ flex: 1, backgroundColor: "#E0D9FF" }} />
+          ),
+          headerTintColor: "#5A32FB",
+          headerTitleStyle: { color: "#5A32FB" },
         }}
       />
       <ScrollView

--- a/packages/backend/.cursor/rules/convex_rules.mdc
+++ b/packages/backend/.cursor/rules/convex_rules.mdc
@@ -159,7 +159,7 @@ export const listWithExtraArg = query({
     handler: async (ctx, args) => {
         return await ctx.db
         .query("messages")
-        .filter((q) => q.eq(q.field("author"), args.author))
+        .withIndex("by_author", (q) => q.eq("author", args.author))
         .order("desc")
         .paginate(args.paginationOpts);
     },


### PR DESCRIPTION
Update all Stack.Screen options in event detail to use consistent solid purple
header background (#E0D9FF) with matching tint colors. Also update Convex docs
to demonstrate withIndex instead of filter for paginated queries.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated event page headers with a new purple accent color scheme featuring a light purple background (#5A32FB) and matching purple title text. This cohesive design improves the overall visual appearance and consistency across all event-related screens in the application.

* **Performance**
  * Optimized backend data retrieval for faster access to event information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->