### PR TITLE
Prevent tap-through when dismissing menus on iOS

### DIFF
--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -1,5 +1,5 @@
 import type { FunctionReturnType } from "convex/server";
-import React from "react";
+import React, { useCallback } from "react";
 import { Dimensions, TouchableOpacity, View } from "react-native";
 import Intercom from "@intercom/intercom-react-native";
 
@@ -37,6 +37,7 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu-primitives";
 import { useEventActions } from "~/hooks/useEventActions";
+import { useMenuStore } from "~/store/menuStore";
 import { logError } from "~/utils/errorLogging";
 import { hapticSuccess, toast } from "~/utils/feedback";
 
@@ -96,6 +97,19 @@ export function EventMenu({
     handleShowQR,
     showDiscover,
   } = useEventActions({ event, isSaved, demoMode, onDelete });
+
+  const { menuOpened, menuClosed } = useMenuStore();
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        menuOpened();
+      } else {
+        menuClosed();
+      }
+    },
+    [menuOpened, menuClosed],
+  );
 
   const presentIntercom = async () => {
     try {
@@ -228,7 +242,7 @@ export function EventMenu({
 
   if (menuType === "context") {
     return (
-      <ContextMenuRoot>
+      <ContextMenuRoot onOpenChange={handleOpenChange}>
         <ContextMenuTrigger asChild>
           {children ?? (
             <TouchableOpacity activeOpacity={0.6}>
@@ -270,7 +284,7 @@ export function EventMenu({
   }
 
   return (
-    <DropdownMenuRoot>
+    <DropdownMenuRoot onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         {children ?? (
           <TouchableOpacity activeOpacity={0.6}>

--- a/apps/expo/src/components/NavigationMenu.tsx
+++ b/apps/expo/src/components/NavigationMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { router } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
@@ -17,6 +17,7 @@ import {
   MessageSquare,
 } from "~/components/icons";
 import { useAppStore } from "~/store";
+import { useMenuStore } from "~/store/menuStore";
 import { logError } from "~/utils/errorLogging";
 import { getPlanStatusFromUser } from "~/utils/plan";
 import {
@@ -59,6 +60,19 @@ export function NavigationMenu({ active }: NavigationMenuProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const { user } = useUser();
   const discoverAccessOverride = useAppStore((s) => s.discoverAccessOverride);
+  const { menuOpened, menuClosed } = useMenuStore();
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setMenuOpen(open);
+      if (open) {
+        menuOpened();
+      } else {
+        menuClosed();
+      }
+    },
+    [menuOpened, menuClosed],
+  );
 
   // Check if user is following anyone
   const followingUsers = useQuery(api.users.getFollowingUsers);
@@ -106,7 +120,7 @@ export function NavigationMenu({ active }: NavigationMenuProps) {
 
   return (
     <View className="flex-1 items-center justify-center">
-      <DropdownMenuRoot open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuRoot open={menuOpen} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger>
           <TouchableOpacity activeOpacity={0.6}>
             <View className="flex-row items-center space-x-1">

--- a/apps/expo/src/components/ProfileMenu.tsx
+++ b/apps/expo/src/components/ProfileMenu.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Share, View } from "react-native";
 import { Image as ExpoImage } from "expo-image";
 import { router } from "expo-router";
@@ -9,6 +9,7 @@ import * as DropdownMenu from "zeego/dropdown-menu";
 
 import { LogOut, MessageSquare, ShareIcon, User } from "~/components/icons";
 import { useSignOut } from "~/hooks/useSignOut";
+import { useMenuStore } from "~/store/menuStore";
 import { toast } from "~/utils/feedback";
 import { logError } from "../utils/errorLogging";
 import { UserProfileFlair } from "./UserProfileFlair";
@@ -17,6 +18,18 @@ export function ProfileMenu() {
   const { user } = useUser();
   const { isAuthenticated } = useConvexAuth();
   const signOut = useSignOut();
+  const { menuOpened, menuClosed } = useMenuStore();
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        menuOpened();
+      } else {
+        menuClosed();
+      }
+    },
+    [menuOpened, menuClosed],
+  );
 
   const handleSignOut = () => {
     signOut().catch((error) => {
@@ -80,7 +93,7 @@ export function ProfileMenu() {
   );
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root onOpenChange={handleOpenChange}>
       <DropdownMenu.Trigger>
         {user?.username && isAuthenticated ? (
           <UserProfileFlair username={user.username} size="sm">

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -35,6 +35,7 @@ import {
 import { useAddEventFlow } from "~/hooks/useAddEventFlow";
 import { useEventActions } from "~/hooks/useEventActions";
 import { useUserTimezone } from "~/store";
+import { useMenuStore } from "~/store/menuStore";
 import { cn } from "~/utils/cn";
 import {
   formatEventDateRange,
@@ -314,6 +315,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
   const { fontScale } = useWindowDimensions();
   const { handleAddToCal, handleToggleVisibility, handleShare, showDiscover } =
     useEventActions({ event, isSaved, demoMode, source });
+  const { shouldIgnoreTap } = useMenuStore();
   const id = event.id;
   const e = event.event as AddToCalendarButtonPropsRestricted;
   const userTimezone = useUserTimezone();
@@ -461,6 +463,10 @@ export function UserEventListItem(props: UserEventListItemProps) {
       <Pressable
         className="relative"
         onPress={() => {
+          // Ignore taps that came from dismissing a menu to prevent tap-through
+          if (shouldIgnoreTap()) {
+            return;
+          }
           const isDemoEvent = id.startsWith("demo-");
           if (isDemoEvent) {
             router.navigate(`/onboarding/demo-event/${id}`);

--- a/apps/expo/src/store/menuStore.ts
+++ b/apps/expo/src/store/menuStore.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+
+/**
+ * Store for tracking menu open/close state to prevent tap-through issues.
+ *
+ * On iOS, when a native menu (via zeego) is dismissed by tapping outside,
+ * the tap event can pass through to underlying interactive components.
+ * This store helps coordinate menu state so components can ignore
+ * taps that occur immediately after a menu closes.
+ */
+
+interface MenuState {
+  /** Timestamp when any menu was last closed */
+  lastMenuClosedAt: number;
+  /** Number of currently open menus */
+  openMenuCount: number;
+  /** Report that a menu has opened */
+  menuOpened: () => void;
+  /** Report that a menu has closed */
+  menuClosed: () => void;
+  /**
+   * Check if a tap should be ignored because it likely came from
+   * dismissing a menu. Call this before handling navigation or
+   * other actions that could be triggered by tap-through.
+   * @param graceMs - Grace period in ms (default: 300)
+   */
+  shouldIgnoreTap: (graceMs?: number) => boolean;
+}
+
+export const useMenuStore = create<MenuState>((set, get) => ({
+  lastMenuClosedAt: 0,
+  openMenuCount: 0,
+
+  menuOpened: () => {
+    set((state) => ({
+      openMenuCount: state.openMenuCount + 1,
+    }));
+  },
+
+  menuClosed: () => {
+    set((state) => ({
+      openMenuCount: Math.max(0, state.openMenuCount - 1),
+      lastMenuClosedAt: Date.now(),
+    }));
+  },
+
+  shouldIgnoreTap: (graceMs = 300) => {
+    const { lastMenuClosedAt, openMenuCount } = get();
+    // If a menu is currently open, don't ignore (let the menu handle it)
+    if (openMenuCount > 0) {
+      return false;
+    }
+    // If a menu recently closed, ignore taps within the grace period
+    const elapsed = Date.now() - lastMenuClosedAt;
+    return elapsed < graceMs;
+  },
+}));


### PR DESCRIPTION
## Summary
Fixes an issue on iOS where tapping outside a native menu (via zeego) to dismiss it causes the tap event to pass through to underlying interactive components, triggering unintended navigation or actions.

## Changes
- **New store**: Created `menuStore.ts` with `useMenuStore` hook to track menu open/close state
  - Tracks the timestamp when menus close and the count of currently open menus
  - Provides `shouldIgnoreTap()` method to check if a tap should be ignored (within 300ms grace period after menu closes)
  
- **EventMenu.tsx**: Added menu state tracking
  - Imported `useMenuStore` and `useCallback`
  - Created `handleOpenChange` callback to notify store when menu opens/closes
  - Applied callback to both `ContextMenuRoot` and `DropdownMenuRoot` components

- **NavigationMenu.tsx**: Added menu state tracking
  - Imported `useMenuStore` and `useCallback`
  - Created `handleOpenChange` callback that updates local state and notifies store
  - Applied callback to `DropdownMenuRoot` component

- **ProfileMenu.tsx**: Added menu state tracking
  - Imported `useMenuStore` and `useCallback`
  - Created `handleOpenChange` callback to notify store when menu opens/closes
  - Applied callback to `DropdownMenu.Root` component

- **UserEventsList.tsx**: Added tap-through prevention
  - Imported `useMenuStore`
  - Added guard in `UserEventListItem` press handler to check `shouldIgnoreTap()` before navigating
  - Prevents navigation when tap occurs within grace period after menu dismissal

## Implementation Details
The solution uses a grace period (default 300ms) to ignore taps that occur immediately after a menu closes. This accounts for the time it takes for the tap event to propagate through the native layer. The store tracks both the count of open menus and the timestamp of the last closure to handle nested/multiple menus correctly.

https://claude.ai/code/session_01NDgPMx4RQX2vGcmNeNJ9Fu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved tap-through issue where user interactions registered on elements behind dismissing menus, particularly on iOS.

* **Improvements**
  * Enhanced menu state tracking to improve menu responsiveness and consistency across navigation, event, and profile interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->