### PR TITLE
fix(expo): Upgrade zeego to v3 and fix menu tap passthrough

### DIFF
--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -33,6 +33,14 @@ Expo Router provides typed file-based navigation.
 - E2E tests use Maestro (`.maestro/` directory)
 - Run tests: `pnpm test`
 
+## Menus (Zeego)
+
+Zeego context/dropdown menus cause tap passthrough to underlying content due to iOS `UIContextMenuInteraction` not coordinating with React Native's touch system. A global overlay fix is in place:
+
+- `store.ts` has `isMenuOpen` / `setIsMenuOpen` state
+- `_layout.tsx` renders a `Pressable` overlay that swallows stray taps when a menu is open
+- **Any new menu component must call `setIsMenuOpen` via `onOpenChange`** — everything else is protected automatically
+
 ## Push Notifications
 
 OneSignal handles push notifications.

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -1,4 +1,10 @@
-import { Platform, StyleSheet, Text, View } from "react-native";
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 import appsFlyer from "react-native-appsflyer";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import {
@@ -40,7 +46,7 @@ import { useOTAUpdates } from "~/hooks/useOTAUpdates";
 import { usePendingFollow } from "~/hooks/usePendingFollow";
 import { useQuickActions } from "~/hooks/useQuickActions";
 import { useTimezoneAlert } from "~/hooks/useTimezoneAlert";
-import { useAppStore } from "~/store";
+import { useAppStore, useIsMenuOpen } from "~/store";
 import Config from "~/utils/config";
 import { getUserTimeZone } from "~/utils/dates";
 import { logDebug, logError } from "~/utils/errorLogging";
@@ -357,6 +363,7 @@ function RootLayoutContent() {
 
   useTimezoneAlert();
   const { needsUpdate } = useForceUpdate();
+  const isMenuOpen = useIsMenuOpen();
 
   if (needsUpdate) {
     return <ForceUpdateScreen />;
@@ -365,6 +372,14 @@ function RootLayoutContent() {
   return (
     <View style={{ flex: 1 }}>
       <InitialLayout />
+      {isMenuOpen && (
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={() => {
+            // Swallow tap to prevent passthrough to underlying content
+          }}
+        />
+      )}
       <StatusBar style={Platform.OS === "ios" ? "light" : "auto"} />
     </View>
   );

--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -37,6 +37,7 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu-primitives";
 import { useEventActions } from "~/hooks/useEventActions";
+import { useSetIsMenuOpen } from "~/store";
 import { logError } from "~/utils/errorLogging";
 import { hapticSuccess, toast } from "~/utils/feedback";
 
@@ -52,6 +53,7 @@ interface EventMenuProps {
   children?: React.ReactNode;
   onDelete?: () => Promise<void>;
   iconColor?: string;
+  onOpenChange?: (open: boolean) => void;
 }
 
 interface MenuItem {
@@ -83,7 +85,9 @@ export function EventMenu({
   children,
   onDelete,
   iconColor = "#FFF",
+  onOpenChange,
 }: EventMenuProps) {
+  const setIsMenuOpen = useSetIsMenuOpen();
   const {
     handleShare,
     handleDirections,
@@ -96,6 +100,11 @@ export function EventMenu({
     handleShowQR,
     showDiscover,
   } = useEventActions({ event, isSaved, demoMode, onDelete });
+
+  const handleOpenChange = (open: boolean) => {
+    setIsMenuOpen(open);
+    onOpenChange?.(open);
+  };
 
   const presentIntercom = async () => {
     try {
@@ -228,7 +237,7 @@ export function EventMenu({
 
   if (menuType === "context") {
     return (
-      <ContextMenuRoot>
+      <ContextMenuRoot modal={true} onOpenChange={handleOpenChange}>
         <ContextMenuTrigger asChild>
           {children ?? (
             <TouchableOpacity activeOpacity={0.6}>
@@ -270,7 +279,7 @@ export function EventMenu({
   }
 
   return (
-    <DropdownMenuRoot>
+    <DropdownMenuRoot modal={true} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         {children ?? (
           <TouchableOpacity activeOpacity={0.6}>

--- a/apps/expo/src/components/NavigationMenu.tsx
+++ b/apps/expo/src/components/NavigationMenu.tsx
@@ -16,7 +16,7 @@ import {
   History,
   MessageSquare,
 } from "~/components/icons";
-import { useAppStore } from "~/store";
+import { useAppStore, useSetIsMenuOpen } from "~/store";
 import { logError } from "~/utils/errorLogging";
 import { getPlanStatusFromUser } from "~/utils/plan";
 import {
@@ -57,7 +57,13 @@ function isRouteActive(routePath: string, active?: RouteType) {
 
 export function NavigationMenu({ active }: NavigationMenuProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const setIsMenuOpen = useSetIsMenuOpen();
   const { user } = useUser();
+
+  const handleOpenChange = (open: boolean) => {
+    setMenuOpen(open);
+    setIsMenuOpen(open);
+  };
   const discoverAccessOverride = useAppStore((s) => s.discoverAccessOverride);
 
   // Check if user is following anyone
@@ -106,7 +112,7 @@ export function NavigationMenu({ active }: NavigationMenuProps) {
 
   return (
     <View className="flex-1 items-center justify-center">
-      <DropdownMenuRoot open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuRoot open={menuOpen} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger>
           <TouchableOpacity activeOpacity={0.6}>
             <View className="flex-row items-center space-x-1">

--- a/apps/expo/src/components/ProfileMenu.tsx
+++ b/apps/expo/src/components/ProfileMenu.tsx
@@ -9,6 +9,7 @@ import * as DropdownMenu from "zeego/dropdown-menu";
 
 import { LogOut, MessageSquare, ShareIcon, User } from "~/components/icons";
 import { useSignOut } from "~/hooks/useSignOut";
+import { useSetIsMenuOpen } from "~/store";
 import { toast } from "~/utils/feedback";
 import { logError } from "../utils/errorLogging";
 import { UserProfileFlair } from "./UserProfileFlair";
@@ -17,6 +18,7 @@ export function ProfileMenu() {
   const { user } = useUser();
   const { isAuthenticated } = useConvexAuth();
   const signOut = useSignOut();
+  const setIsMenuOpen = useSetIsMenuOpen();
 
   const handleSignOut = () => {
     signOut().catch((error) => {
@@ -80,7 +82,7 @@ export function ProfileMenu() {
   );
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenu.Root onOpenChange={setIsMenuOpen}>
       <DropdownMenu.Trigger>
         {user?.username && isAuthenticated ? (
           <UserProfileFlair username={user.username} size="sm">

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -171,6 +171,10 @@ interface AppState {
   // Pending follow from deep link (used when user is not authenticated yet)
   pendingFollowUsername: string | null;
   setPendingFollowUsername: (username: string | null) => void;
+
+  // Menu open state (for blocking tap passthrough)
+  isMenuOpen: boolean;
+  setIsMenuOpen: (open: boolean) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -507,6 +511,10 @@ export const useAppStore = create<AppState>()(
       pendingFollowUsername: null,
       setPendingFollowUsername: (username) =>
         set({ pendingFollowUsername: username }),
+
+      // Menu open state
+      isMenuOpen: false,
+      setIsMenuOpen: (open) => set({ isMenuOpen: open }),
     }),
     {
       name: "app-storage",
@@ -514,7 +522,7 @@ export const useAppStore = create<AppState>()(
       // Do not persist ephemeral flags like discoverAccessOverride
       partialize: (state) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { discoverAccessOverride, ...rest } = state;
+        const { discoverAccessOverride, isMenuOpen, ...rest } = state;
         return rest;
       },
     },
@@ -602,6 +610,11 @@ export const usePreferredCalendarApp = () =>
   useAppStore((state) => state.preferredCalendarApp);
 export const useSetPreferredCalendarApp = () =>
   useAppStore((state) => state.setPreferredCalendarApp);
+
+// Menu state selectors (for blocking tap passthrough)
+export const useIsMenuOpen = () => useAppStore((state) => state.isMenuOpen);
+export const useSetIsMenuOpen = () =>
+  useAppStore((state) => state.setIsMenuOpen);
 
 // Pending follow selectors (for deferred deep link follow intent)
 export const usePendingFollowUsername = () =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,11 +400,11 @@ catalogs:
       specifier: ^2.28.0
       version: 2.30.0
     react-native-ios-context-menu:
-      specifier: ^3.1.0
-      version: 3.2.1
+      specifier: 3.1.0
+      version: 3.1.0
     react-native-ios-utilities:
-      specifier: ^5.1.0
-      version: 5.2.0
+      specifier: 5.1.2
+      version: 5.1.2
     react-native-keyboard-controller:
       specifier: ^1.18.5
       version: 1.20.4
@@ -493,8 +493,8 @@ catalogs:
       specifier: ^3.21.7
       version: 3.28.0
     zeego:
-      specifier: ^2.0.4
-      version: 2.0.4
+      specifier: ^3.0.6
+      version: 3.0.6
     zod:
       specifier: ^3.23.0
       version: 3.25.76
@@ -770,10 +770,10 @@ importers:
         version: 2.30.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react-native-ios-context-menu:
         specifier: 'catalog:'
-        version: 3.2.1(react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 3.1.0(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react-native-ios-utilities:
         specifier: 'catalog:'
-        version: 5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react-native-keyboard-controller:
         specifier: 'catalog:'
         version: 1.20.4(react-native-reanimated@4.2.1(react-native-worklets@0.7.1(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -812,7 +812,7 @@ importers:
         version: 2.2.1
       zeego:
         specifier: 'catalog:'
-        version: 2.0.4(@react-native-menu/menu@2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+        version: 3.0.6(@react-native-menu/menu@2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       zustand:
         specifier: 'catalog:'
         version: 4.5.5(@types/react@19.2.7)(react@19.1.0)
@@ -9398,15 +9398,15 @@ packages:
       react: 19.1.0
       react-native: '*'
 
-  react-native-ios-context-menu@3.2.1:
-    resolution: {integrity: sha512-OBQbb3I/VUx2wQgz4cqN614kt3nJ+qx5wxEdtGN1Aj4nYYL1orp7VLFkV6axof6DgOyv0YD6af2RUTok6a2xDQ==}
+  react-native-ios-context-menu@3.1.0:
+    resolution: {integrity: sha512-qdPSXMKUp5lDgmZeUPdv5sgBFhkFrIqma+zsnqJQYOvekb6Qs17yJy1Rqhrj0bJrwuduHzZX0aYbaA8whxqpDw==}
     peerDependencies:
       react: 19.1.0
       react-native: '*'
       react-native-ios-utilities: '*'
 
-  react-native-ios-utilities@5.2.0:
-    resolution: {integrity: sha512-RTw1Gk8rQhBL43+U80I+Nu8T7mLTNkj5RaG8vTs3ETEDqphS3L0Mrzk79RX0Jmm64HMad70GXHctXFlW1n0V8w==}
+  react-native-ios-utilities@5.1.2:
+    resolution: {integrity: sha512-H566MdgC1x0vW6D8EKweno1yRj/gQHeWiK0cRmyRexnUSk7oIecy7l2uyxXLYWFs+yvB/YIdLm+s2c19lKGfaw==}
     peerDependencies:
       react: 19.1.0
       react-native: '*'
@@ -10929,13 +10929,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zeego@2.0.4:
-    resolution: {integrity: sha512-mkKfUJmgcSGCTqWXW7ccqap8d8z6guQoLF5/mWlH17Jckd0BaFLVZ74y/uWvfBGaC9OawYVt/1MchPnQ8ieSxg==}
+  zeego@3.0.6:
+    resolution: {integrity: sha512-vg0GCMPYg6or/J91bwRnUpIYwz7QnhkyeKOdd3FjvICg+Gzq2D5QhD8k5RUSv1B+048LpNmNYdLm8qJVIbBONw==}
     peerDependencies:
-      '@react-native-menu/menu': '*'
+      '@react-native-menu/menu': 1.2.2
       react: 19.1.0
       react-native: '*'
-      react-native-ios-context-menu: ~2.5.1
+      react-native-ios-context-menu: 3.1.0
+      react-native-ios-utilities: 5.1.2
 
   zod-to-json-schema@3.22.5:
     resolution: {integrity: sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==}
@@ -14351,7 +14352,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.83.3
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -18963,6 +18964,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.83.3:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-cache: 0.83.3
+      metro-core: 0.83.3
+      metro-runtime: 0.83.3
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   metro-config@0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
@@ -19955,14 +19969,14 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
 
-  react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
+  react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
     dependencies:
       '@dominicstop/ts-event-emitter': 1.1.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
-      react-native-ios-utilities: 5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      react-native-ios-utilities: 5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
 
-  react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
+  react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
@@ -21645,14 +21659,15 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zeego@2.0.4(@react-native-menu/menu@2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-native-ios-context-menu@3.2.1(react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
+  zeego@3.0.6(@react-native-menu/menu@2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react-native-ios-context-menu@3.1.0(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0):
     dependencies:
       '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu': 2.1.2(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@react-native-menu/menu': 2.0.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
-      react-native-ios-context-menu: 3.2.1(react-native-ios-utilities@5.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      react-native-ios-context-menu: 3.1.0(react-native-ios-utilities@5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      react-native-ios-utilities: 5.1.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.2.7)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@types/react'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,8 +119,8 @@ catalog:
   "@react-native-community/datetimepicker": ~8.4.4
   "@react-native-community/netinfo": ^11.4.1
   "react-native-appsflyer": ^6.15.3
-  "react-native-ios-context-menu": ^3.1.0
-  "react-native-ios-utilities": ^5.1.0
+  "react-native-ios-context-menu": 3.1.0
+  "react-native-ios-utilities": 5.1.2
   "react-native-keyboard-controller": ^1.18.5
   "react-native-modal": 14.0.0-rc.1
   "react-native-onesignal": ^5.2.8
@@ -234,7 +234,7 @@ catalog:
   "vaul": ^0.9.1
   burnt: ^0.13.0
   "react-native-notifier": ^2.0.0
-  "zeego": ^2.0.4
+  "zeego": ^3.0.6
 
   # API & AI
   "@ai-sdk/anthropic": ^0.0.50


### PR DESCRIPTION
## Summary
- Upgrade zeego from v2 to v3 (fixes `onOpenChange` for ContextMenu on iOS)
- Pin `react-native-ios-context-menu@3.1.0` and `react-native-ios-utilities@5.1.2` to match zeego 3 peer requirements
- Fix menu tap passthrough issue where taps passed through to underlying content (e.g. navigation) when dismissing zeego context/dropdown menus
- Uses a global Zustand `isMenuOpen` state + a `Pressable` overlay in the root layout to swallow stray taps while any menu is open
- All three menu components (`EventMenu`, `ProfileMenu`, `NavigationMenu`) wired to the store
- Documented the pattern in `AGENTS.md` so new menus follow the same approach

## Test plan
- [ ] Open context menu on event card (long press), dismiss it, verify tap does not navigate
- [ ] Open profile menu in header, dismiss it, verify no unintended taps on header items
- [ ] Open navigation menu, dismiss it, verify no unintended navigation
- [ ] Verify menu item selection still works correctly for all three menus
- [ ] Verify app builds and runs without errors

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu overlay handling to prevent stray taps from interacting with underlying content when menus are open. Menu state is now properly coordinated across all menu components.

* **Chores**
  * Updated dependencies: react-native-ios-context-menu (3.1.0), react-native-ios-utilities (5.1.2), and zeego (^3.0.6).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->