### PR TITLE
Update CTA messaging for non-owners in public list view

### DIFF
--- a/apps/web/app/(base)/[userName]/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/PublicListClient.tsx
@@ -350,7 +350,7 @@ export default function PublicListClient({ params }: Props) {
       {!isOwner && (
         <div className="mb-6 flex flex-col items-center justify-between gap-4 rounded-xl bg-interactive-3 px-6 py-4 sm:flex-row">
           <span className="text-lg font-bold text-interactive-1">
-            Follow {publicListData?.user.displayName || userName} in the app
+            You're missing what's next
           </span>
           <Button
             onClick={() => {
@@ -358,7 +358,7 @@ export default function PublicListClient({ params }: Props) {
             }}
             className="whitespace-nowrap"
           >
-            Get the app
+            Unlock live list
           </Button>
         </div>
       )}


### PR DESCRIPTION
## Summary
Updated the call-to-action (CTA) messaging displayed to non-owners viewing a public list to use more compelling and action-oriented language.

## Changes
- Changed headline from "Follow {displayName} in the app" to "You're missing what's next"
- Updated button text from "Get the app" to "Unlock live list"

## Details
These messaging changes aim to improve conversion by:
1. Creating a sense of urgency and FOMO ("You're missing what's next")
2. Emphasizing the value proposition of the app ("Unlock live list" vs generic "Get the app")
3. Removing dependency on the user's display name, making the message more universal and consistent

The functionality remains unchanged - clicking the button still opens the app in a new window.

https://claude.ai/code/session_01F4v2vM4ASLJsTS9gmfAnCr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated call-to-action messaging and button text on shared lists for non-owners to enhance clarity and engagement prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->