### PR TITLE
Fix unsafe optional chaining in user profile navigation links

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -75,7 +75,7 @@ export function Header() {
           <NavigationMenu>
             <SignedIn>
               <Link
-                href={`/${user?.username}/upcoming`}
+                href={user?.username ? `/${user.username}/upcoming` : "/"}
                 className="relative flex items-center"
                 aria-label="Soonlist"
               >
@@ -140,7 +140,11 @@ export function Nav() {
       <NavigationMenuList className="flex gap-2">
         <SignedIn>
           <NavigationMenuItem className="hidden lg:block">
-            <Link href={`/${user?.username}/upcoming`} legacyBehavior passHref>
+            <Link
+              href={user?.username ? `/${user.username}/upcoming` : "/"}
+              legacyBehavior
+              passHref
+            >
               <NavigationMenuLink className={navigationMenuTriggerStyle()}>
                 <CalendarHeart className="mr-2 size-4" />
                 My Feed
@@ -419,7 +423,7 @@ export function MobileNav() {
           <div className="flex flex-col space-y-3">
             <MobileLink
               key="user-nav-my-feed"
-              href={`/${user?.username}/upcoming`}
+              href={user?.username ? `/${user.username}/upcoming` : "/"}
               onOpenChange={setOpen}
               signedInOnly
               className="flex items-center gap-2 text-interactive-1"


### PR DESCRIPTION
## Summary
Fixed potential runtime errors in navigation links by replacing unsafe optional chaining with proper null checks before accessing the `username` property.

## Changes
- Updated three navigation link instances in `Header.tsx` to safely handle cases where `user?.username` might be undefined
- Changed from `href={`/${user?.username}/upcoming`}` to `href={user?.username ? `/${user.username}/upcoming` : "/"}`
- Applied fix to:
  - Main header navigation link (line 78)
  - Navigation menu link in `Nav()` component (line 143)
  - Mobile navigation link in `MobileNav()` component (line 426)

## Implementation Details
The original code used optional chaining (`user?.username`) within a template literal, which could result in URLs like `"/undefined/upcoming"` if the user object wasn't fully loaded. The fix adds a ternary operator to explicitly check if `username` exists before constructing the URL, falling back to the home page (`"/"`) if the username is unavailable. This ensures users are never directed to invalid routes and improves the robustness of the navigation flow.

https://claude.ai/code/session_01JxetuYeVWBcCj2yiufjR5t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced navigation robustness: Header and navigation links now gracefully handle missing user information by falling back to the home page instead of generating broken links. This ensures a smoother user experience when user data is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->