### PR TITLE
Replace full-page spinner with skeleton loaders for better UX

### DIFF
--- a/apps/web/app/(base)/[userName]/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/PublicListClient.tsx
@@ -17,10 +17,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@soonlist/ui/dialog";
+import { Skeleton } from "@soonlist/ui/skeleton";
 
 import type { EventWithUser } from "~/components/EventList";
 import { EventList } from "~/components/EventList";
-import { FullPageLoadingSpinner } from "~/components/FullPageLoadingSpinner";
 import { UserInfo } from "~/components/UserInfo";
 import { useStableTimestamp } from "~/hooks/useStableQuery";
 
@@ -174,9 +174,29 @@ export default function PublicListClient({ params }: Props) {
     }
   };
 
-  // Show full page spinner until all data is loaded
+  // Show skeleton until all data is loaded
   if (currentUser === undefined || publicListData === undefined) {
-    return <FullPageLoadingSpinner />;
+    return (
+      <div className="mx-auto max-w-2xl">
+        {/* User info skeleton */}
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-12 rounded-full" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+        <div className="p-2" />
+        {/* List title skeleton */}
+        <Skeleton className="mb-6 h-8 w-48" />
+        {/* Event list skeletons */}
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-20 w-full rounded-xl" />
+          <Skeleton className="h-20 w-full rounded-xl" />
+          <Skeleton className="h-20 w-full rounded-xl" />
+        </div>
+      </div>
+    );
   }
 
   // If user is the owner and public list is not enabled, show setup

--- a/apps/web/app/(base)/[userName]/loading.tsx
+++ b/apps/web/app/(base)/[userName]/loading.tsx
@@ -1,5 +1,25 @@
-import { FullPageLoadingSpinner } from "~/components/FullPageLoadingSpinner";
+import { Skeleton } from "@soonlist/ui/skeleton";
 
 export default function Loading() {
-  return <FullPageLoadingSpinner />;
+  return (
+    <div className="mx-auto max-w-2xl">
+      {/* User info skeleton */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-12 rounded-full" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+      <div className="p-2" />
+      {/* List title skeleton */}
+      <Skeleton className="mb-6 h-8 w-48" />
+      {/* Event list skeletons */}
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-20 w-full rounded-xl" />
+        <Skeleton className="h-20 w-full rounded-xl" />
+        <Skeleton className="h-20 w-full rounded-xl" />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -47,7 +47,7 @@ import { UserProfileFlair } from "./UserProfileFlair";
 const excludedMenuRoutes = ["/install"];
 
 export function Header() {
-  const { user } = useUser();
+  const { isLoaded, user } = useUser();
   const pathname = usePathname();
   const hideMenu = excludedMenuRoutes.includes(pathname);
 
@@ -73,6 +73,19 @@ export function Header() {
       <header className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between px-4">
         <div className="flex items-center sm:grow sm:gap-0">
           <NavigationMenu>
+            {!isLoaded && (
+              <Link
+                href="/"
+                className="relative flex items-center"
+                aria-label="Soonlist"
+              >
+                <Logo variant="mark" className="size-7 sm:hidden" />
+                <Logo
+                  variant="hidePreview"
+                  className="hidden scale-75 sm:block"
+                />
+              </Link>
+            )}
             <SignedIn>
               <Link
                 href={`/${user?.username}/upcoming`}
@@ -102,6 +115,17 @@ export function Header() {
           </NavigationMenu>
         </div>
         <div className="flex shrink-0 items-center gap-3">
+          {!isLoaded && (
+            <>
+              {/* Desktop skeleton: approximate size of Add event button + avatar */}
+              <div className="hidden items-center gap-3 lg:flex">
+                <div className="h-9 w-24 animate-pulse rounded-md bg-gray-100" />
+                <div className="size-9 animate-pulse rounded-full bg-gray-100" />
+              </div>
+              {/* Mobile skeleton: approximate size of hamburger menu */}
+              <div className="size-9 animate-pulse rounded-md bg-gray-100 lg:hidden" />
+            </>
+          )}
           <SignedIn>
             <Nav />
             <NavigationMenu>


### PR DESCRIPTION
## Summary
Replaced the `FullPageLoadingSpinner` component with skeleton loaders that provide a more accurate visual preview of the page layout during loading. This improves perceived performance and user experience by showing the expected content structure rather than a generic spinner.

## Key Changes
- **PublicListClient.tsx**: Replaced full-page spinner with a skeleton layout that mirrors the actual page structure (user info, list title, and event cards)
- **loading.tsx**: Updated the route loading state to use the same skeleton layout as PublicListClient for consistency
- **Header.tsx**: Added skeleton loaders for header elements (logo and action buttons) that display while user authentication state is loading, preventing layout shift

## Implementation Details
- Skeleton loaders use the `@soonlist/ui/skeleton` component with appropriate dimensions and styling
- The skeleton layout in both PublicListClient and loading.tsx is identical, ensuring consistent loading states
- Header skeleton loaders use `animate-pulse` for a subtle loading indicator while `isLoaded` is false
- All skeletons respect the existing layout constraints (max-w-2xl container, responsive design)
- Removed unused `FullPageLoadingSpinner` import from both files

https://claude.ai/code/session_01YaSxoyng9F2zd7vPgnGcgL