### PR TITLE
revert: Remove overscroll background color changes

### DIFF
--- a/apps/web/app/(marketing)/layout.tsx
+++ b/apps/web/app/(marketing)/layout.tsx
@@ -8,7 +8,7 @@ import { ResetNewEventContext } from "~/context/ResetNewEventContext";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-interactive-3">
+    <div>
       <ResetNewEventContext />
       <Header />
       <div className="h-14" aria-hidden />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({
       className={`!overflow-x-hidden ${kalam.variable} ${plex_sans.variable}`}
     >
       <PHProvider>
-        <body className="overflow-x-hidden bg-interactive-3">
+        <body className="overflow-x-hidden">
           <TRPCReactProvider>
             <Providers>
               <PostHogClient />


### PR DESCRIPTION
## Summary
- Reverts the `bg-interactive-3` background color added to `<body>` in `app/layout.tsx`
- Reverts the `min-h-screen bg-interactive-3` added to the marketing layout wrapper
- Keeps all header redesign changes from #894 (fixed positioning, glassmorphism, logo mark variant, etc.)

## Test plan
- [ ] Verify overscroll on mobile shows default (white) background instead of interactive-3
- [ ] Verify header still renders correctly with glassmorphism effect
- [ ] Verify marketing pages render without background color issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed background color and minimum height styling from the marketing layout section.
  * Adjusted background styling on the main page layout for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->