### PR TITLE
Make Discover navigation item conditional based on user metadata

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -134,6 +134,9 @@ export function Nav() {
   const { user } = useUser();
   const pathname = usePathname();
   const isJoinPage = pathname === "/join";
+  const showDiscover = (
+    user?.publicMetadata as { showDiscover?: boolean } | undefined
+  )?.showDiscover;
 
   return (
     <NavigationMenu>
@@ -152,16 +155,18 @@ export function Nav() {
             </Link>
           </NavigationMenuItem>
         </SignedIn>
-        <SignedIn>
-          <NavigationMenuItem className="hidden lg:block">
-            <Link href={`/explore`} legacyBehavior passHref>
-              <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-                <Globe2Icon className="mr-2 size-4" />
-                Discover
-              </NavigationMenuLink>
-            </Link>
-          </NavigationMenuItem>
-        </SignedIn>
+        {showDiscover && (
+          <SignedIn>
+            <NavigationMenuItem className="hidden lg:block">
+              <Link href={`/explore`} legacyBehavior passHref>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  <Globe2Icon className="mr-2 size-4" />
+                  Discover
+                </NavigationMenuLink>
+              </Link>
+            </NavigationMenuItem>
+          </SignedIn>
+        )}
         <SignedOut>
           <NavigationMenuItem className="hidden lg:block">
             <Link href="/sign-in" legacyBehavior passHref>
@@ -353,6 +358,9 @@ export function MobileNav() {
 
   const plan = user?.publicMetadata.plan as { name?: string } | undefined;
   const planName = plan?.name;
+  const showDiscover = (
+    user?.publicMetadata as { showDiscover?: boolean } | undefined
+  )?.showDiscover;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -431,16 +439,18 @@ export function MobileNav() {
               <CalendarHeart className="size-4" />
               My Feed
             </MobileLink>
-            <MobileLink
-              key={"user-nav-explore"}
-              href={"/explore"}
-              onOpenChange={setOpen}
-              signedInOnly
-              className="flex items-center gap-2 text-interactive-1"
-            >
-              <Globe2Icon className="size-4" />
-              Discover
-            </MobileLink>
+            {showDiscover && (
+              <MobileLink
+                key={"user-nav-explore"}
+                href={"/explore"}
+                onOpenChange={setOpen}
+                signedInOnly
+                className="flex items-center gap-2 text-interactive-1"
+              >
+                <Globe2Icon className="size-4" />
+                Discover
+              </MobileLink>
+            )}
           </div>
           <SignedIn>
             <div className="p-1.5"></div>


### PR DESCRIPTION
## Summary
This PR makes the "Discover" navigation menu item conditional, only displaying it for users who have the `showDiscover` flag enabled in their public metadata. This change applies to both desktop and mobile navigation components.

## Key Changes
- Added `showDiscover` flag extraction from `user.publicMetadata` in the `Nav` component
- Wrapped the desktop "Discover" navigation menu item with a conditional check
- Added `showDiscover` flag extraction from `user.publicMetadata` in the `MobileNav` component
- Wrapped the mobile "Discover" navigation link with a conditional check

## Implementation Details
- The `showDiscover` flag is safely extracted from `user.publicMetadata` with proper TypeScript typing to handle cases where it may be undefined
- The conditional rendering uses the existing `SignedIn` wrapper for the desktop version, ensuring the item only appears for authenticated users with the flag enabled
- The mobile version uses the same flag to conditionally render the `MobileLink` component
- This allows for feature flagging or gradual rollout of the Discover feature to specific users

https://claude.ai/code/session_01Ckw6y1EtcktVeDgPLJYi78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Discover menu item visibility is now conditional for signed-in users across navigation views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->