### PR TITLE
Populate event relations from Convex data instead of empty arrays

### DIFF
--- a/apps/web/app/(base)/[userName]/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/PublicListClient.tsx
@@ -63,9 +63,12 @@ function transformConvexEventsAsPublic(
       createdAt: new Date(event._creationTime),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- user is guaranteed to exist after filter
       user: transformConvexUser(event.user!),
-      eventFollows: [],
-      comments: [],
-      eventToLists: [],
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      eventFollows: (event.eventFollows ?? []) as any,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      comments: (event.comments ?? []) as any,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+      eventToLists: (event.eventToLists ?? []) as any,
     }));
 }
 

--- a/apps/web/app/(base)/[userName]/upcoming/page.tsx
+++ b/apps/web/app/(base)/[userName]/upcoming/page.tsx
@@ -49,9 +49,12 @@ function transformConvexEvents(
     visibility: event.visibility,
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user!),
-    eventFollows: [],
-    comments: [],
-    eventToLists: [],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    eventFollows: (event.eventFollows ?? []) as any,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    comments: (event.comments ?? []) as any,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    eventToLists: (event.eventToLists ?? []) as any,
   }));
 }
 

--- a/apps/web/app/(base)/explore/page.tsx
+++ b/apps/web/app/(base)/explore/page.tsx
@@ -42,9 +42,12 @@ function transformConvexEvents(
     visibility: event.visibility,
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user!),
-    eventFollows: [],
-    comments: [],
-    eventToLists: [],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    eventFollows: (event.eventFollows ?? []) as any,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    comments: (event.comments ?? []) as any,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+    eventToLists: (event.eventToLists ?? []) as any,
   }));
 }
 


### PR DESCRIPTION
## Summary
Updated event transformation functions across multiple pages to populate `eventFollows`, `comments`, and `eventToLists` fields from the Convex event data instead of initializing them as empty arrays.

## Changes
- **PublicListClient.tsx**: Modified `transformConvexEventsAsPublic()` to use actual event relation data from the Convex response
- **upcoming/page.tsx**: Modified `transformConvexEvents()` to use actual event relation data from the Convex response
- **explore/page.tsx**: Modified `transformConvexEvents()` to use actual event relation data from the Convex response

## Implementation Details
- Changed from hardcoded empty arrays (`[]`) to using nullish coalescing operator (`??`) to safely access relation fields from the event object
- Added TypeScript eslint disable comments for `@typescript-eslint/no-unsafe-assignment` and `@typescript-eslint/no-explicit-any` to handle the dynamic nature of the relation data
- Used type assertion (`as any`) to satisfy TypeScript while maintaining runtime flexibility
- This allows the API responses to properly populate related data instead of discarding it

https://claude.ai/code/session_01138FhJScCdNTEaZkAHjfCU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue affecting how event-related data displays across the application. Event followers, comments, and associated lists now properly populate and display when available. Previously, these important related event details would incorrectly appear empty, even when the underlying information was present and accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->