### PR TITLE
fix(web): preserve event follow state in upcoming page

### DIFF
--- a/apps/web/app/(base)/[userName]/upcoming/page.tsx
+++ b/apps/web/app/(base)/[userName]/upcoming/page.tsx
@@ -49,7 +49,8 @@ function transformConvexEvents(
     visibility: event.visibility,
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user!),
-    eventFollows: [],
+    // Preserve follow state so save/unsave UI reflects current user state.
+    eventFollows: event.eventFollows,
     comments: [],
     eventToLists: [],
   }));


### PR DESCRIPTION
Pass through eventFollows from Convex data instead of replacing with
an empty array, so save/unsave UI correctly reflects current user state.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upcoming events not displaying their correct saved/unsaved state. Events now properly reflect whether they have been saved or not in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->