### PR TITLE
fix(web): wire up real eventFollows data and fix follow state detection

### DIFF
--- a/apps/web/app/(base)/[userName]/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/PublicListClient.tsx
@@ -63,7 +63,7 @@ function transformConvexEventsAsPublic(
       createdAt: new Date(event._creationTime),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- user is guaranteed to exist after filter
       user: transformConvexUser(event.user!),
-      eventFollows: [],
+      eventFollows: event.eventFollows,
       comments: [],
       eventToLists: [],
     }));

--- a/apps/web/app/(base)/[userName]/upcoming/page.tsx
+++ b/apps/web/app/(base)/[userName]/upcoming/page.tsx
@@ -49,7 +49,7 @@ function transformConvexEvents(
     visibility: event.visibility,
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user!),
-    eventFollows: [],
+    eventFollows: event.eventFollows,
     comments: [],
     eventToLists: [],
   }));

--- a/apps/web/app/(base)/explore/page.tsx
+++ b/apps/web/app/(base)/explore/page.tsx
@@ -42,7 +42,7 @@ function transformConvexEvents(
     visibility: event.visibility,
     createdAt: new Date(event._creationTime),
     user: transformConvexUser(event.user!),
-    eventFollows: [],
+    eventFollows: event.eventFollows,
     comments: [],
     eventToLists: [],
   }));

--- a/apps/web/components/EventDisplays.tsx
+++ b/apps/web/components/EventDisplays.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { atcb_action } from "add-to-calendar-button-react";
+import { useQuery } from "convex/react";
 import { Copy, Earth, EyeOff, Instagram, MapPin } from "lucide-react";
 
 import type { DateInfo, EventMetadata, SimilarityDetails } from "@soonlist/cal";
@@ -13,6 +14,7 @@ import type {
   ATCBActionEventConfig,
 } from "@soonlist/cal/types";
 import type { Comment, EventFollow, List, User } from "@soonlist/db/types";
+import { api } from "@soonlist/backend/convex/_generated/api";
 import {
   eventTimesAreDefined,
   formatRelativeTime,
@@ -669,13 +671,15 @@ function EventActionButtons({
 
 export function EventListItem(props: EventListItemProps) {
   const { user: clerkUser } = useUser();
+  const currentUser = useQuery(api.users.getCurrentUser);
   const { user, eventFollows, id, event, filePath, visibility } = props;
   const { timezone: userTimezone } = useContext(TimezoneContext);
   const roles = clerkUser?.unsafeMetadata.roles as string[] | undefined;
-  const isSelf = clerkUser?.id === user?.id;
+  const viewerUserId = currentUser?.id ?? clerkUser?.id;
+  const isSelf = viewerUserId === user?.id;
   const isOwner = isSelf || roles?.includes("admin");
   const isFollowing = !!eventFollows.find(
-    (item) => item.userId === clerkUser?.id,
+    (item) => item.userId === viewerUserId,
   );
   const image =
     event.images?.[3] ||


### PR DESCRIPTION
## Summary
- Pass actual `eventFollows` from Convex queries instead of hardcoded empty arrays on public list, upcoming, and explore pages
- Fix follow state detection in `EventListItem` to use Convex user ID (`currentUser.id`) for accurate `isFollowing` and `isSelf` checks
- Add `useQuery(api.users.getCurrentUser)` to resolve the correct user ID

## Test plan
- [ ] Verify follow buttons reflect correct state on public list, upcoming, and explore pages
- [ ] Verify "isSelf" detection works correctly for own events
- [ ] Verify follow/unfollow actions work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event follow lists now display actual follower data instead of appearing empty across multiple pages.
  * Improved accuracy of personal follow status indicators by refining viewer identification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->