### PR TITLE
Refine /new drag-and-drop toast tracking without sessionStorage

### DIFF
--- a/apps/web/components/DragAndDropProvider.tsx
+++ b/apps/web/components/DragAndDropProvider.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { useBatchProgress } from "~/hooks/useBatchProgress";
+import { useBatchProgressStore } from "~/hooks/useBatchProgressStore";
 import { useDragAndDropHandler } from "~/hooks/useDragAndDropHandler";
 import { isTargetPage } from "~/lib/pasteEventUtils";
 
@@ -18,6 +19,10 @@ interface DragAndDropProviderProps {
 export function DragAndDropProvider({ children }: DragAndDropProviderProps) {
   const pathname = usePathname();
   const currentUser = useQuery(api.users.getCurrentUser);
+  const pendingBatchId = useBatchProgressStore((state) => state.pendingBatchId);
+  const clearPendingBatchId = useBatchProgressStore(
+    (state) => state.clearPendingBatchId,
+  );
 
   // Only enable the drag and drop handler on target pages and when user is authenticated
   const shouldEnable = isTargetPage(pathname) && !!currentUser;
@@ -32,9 +37,12 @@ export function DragAndDropProvider({ children }: DragAndDropProviderProps) {
       },
     });
 
+  const activeBatchId = currentBatchId ?? pendingBatchId;
+
   // Track batch progress with toast notifications
   useBatchProgress({
-    batchId: currentBatchId,
+    batchId: activeBatchId,
+    onSettled: clearPendingBatchId,
   });
 
   return (

--- a/apps/web/hooks/useBatchProgress.tsx
+++ b/apps/web/hooks/useBatchProgress.tsx
@@ -10,13 +10,17 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 interface UseBatchProgressOptions {
   batchId: string | null;
+  onSettled?: () => void;
 }
 
 /**
  * Hook to track batch upload progress with updating toast
  * Updates the same toast from loading to success/error state
  */
-export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
+export function useBatchProgress({
+  batchId,
+  onSettled,
+}: UseBatchProgressOptions): void {
   const router = useRouter();
   const toastIdRef = useRef<string | number | null>(null);
   const hasShownCompletionRef = useRef(false);
@@ -87,8 +91,9 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
 
       // Clear the ref since the toast is now handled
       toastIdRef.current = null;
+      onSettled?.();
     }
-  }, [batchStatus]);
+  }, [batchStatus, onSettled, router]);
 
   // Cleanup: dismiss toast when component unmounts or batchId changes
   useEffect(() => {

--- a/apps/web/hooks/useBatchProgressStore.ts
+++ b/apps/web/hooks/useBatchProgressStore.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { create } from "zustand";
+
+interface BatchProgressStore {
+  pendingBatchId: string | null;
+  setPendingBatchId: (batchId: string) => void;
+  clearPendingBatchId: () => void;
+}
+
+export const useBatchProgressStore = create<BatchProgressStore>((set) => ({
+  pendingBatchId: null,
+  setPendingBatchId: (batchId) => set({ pendingBatchId: batchId }),
+  clearPendingBatchId: () => set({ pendingBatchId: null }),
+}));

--- a/apps/web/hooks/useDragAndDropHandler.ts
+++ b/apps/web/hooks/useDragAndDropHandler.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
+import { useBatchProgressStore } from "~/hooks/useBatchProgressStore";
 import {
   generateBatchId,
   generateTempId,
@@ -65,6 +66,9 @@ export function useDragAndDropHandler(
   const isProcessingRef = useRef(false);
 
   const createEventBatch = useMutation(api.ai.createEventBatch);
+  const setPendingBatchId = useBatchProgressStore(
+    (state) => state.setPendingBatchId,
+  );
 
   // Handle drag enter
   const handleDragEnter = useCallback(
@@ -255,6 +259,7 @@ export function useDragAndDropHandler(
         if (result.batchId) {
           // Store the batchId for progress tracking
           setCurrentBatchId(result.batchId);
+          setPendingBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId
           // The backend processes them asynchronously


### PR DESCRIPTION
### Motivation
- Dropping images on `/new` navigated away and lost the in-memory batch id, preventing completion toasts from appearing after the route change.  
- The goal is to preserve batch progress across SPA navigation without persisting state across browser sessions.  
- Prefer an in-memory approach scoped to the active SPA session rather than `sessionStorage` for simpler lifecycle management.

### Description
- Added an in-memory Zustand store `apps/web/hooks/useBatchProgressStore.ts` exposing `pendingBatchId`, `setPendingBatchId`, and `clearPendingBatchId`.  
- Updated `useDragAndDropHandler` to call `setPendingBatchId(result.batchId)` when a batch is created so progress is available after navigation.  
- Updated `DragAndDropProvider` to compute `activeBatchId = currentBatchId ?? pendingBatchId` and pass that into `useBatchProgress`, and to clear pending state when progress settles.  
- Extended `useBatchProgress` to accept an optional `onSettled` callback and invoke it when a batch completes or fails, and removed the previous `apps/web/lib/batchProgressStorage.ts` implementation.

### Testing
- Ran targeted formatting with `pnpm -F @soonlist/web exec prettier --write` on the modified files, which completed successfully.  
- Ran `eslint` on the modified files; the run completed with warnings only and no errors.  
- Ran TypeScript checks with `pnpm -F @soonlist/web typecheck`, which passed.  
- Attempted full monorepo checks with `pnpm lint:fix && pnpm format:fix && pnpm check`, but that command did not complete within this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950ea5929c832a9070599fa1a6b14e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced batch operation tracking and management during file uploads.
  
* **Bug Fixes**
  * Improved cleanup and state management when batch operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->