### PR TITLE
Align web event capture default visibility with Expo

### DIFF
--- a/apps/web/app/(minimal)/new/EventsFromImage.tsx
+++ b/apps/web/app/(minimal)/new/EventsFromImage.tsx
@@ -9,6 +9,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { buildDefaultUrl } from "~/components/ImageUpload";
 import { useWorkflowStore } from "~/hooks/useWorkflowStore";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 import { optimizeImageToBase64 } from "~/lib/imageOptimization";
 
 // Maximum base64 size to prevent journal overflow (900KB to be safe with 1MB limit)
@@ -87,7 +88,7 @@ export function EventsFromImage({
         userId: currentUser.id,
         username: currentUser.username || currentUser.id,
         sendNotification: false, // Web doesn't have push notifications
-        visibility: "public",
+        visibility: DEFAULT_VISIBILITY,
         lists: [],
       });
 

--- a/apps/web/app/(minimal)/new/newEventProgressStages.tsx
+++ b/apps/web/app/(minimal)/new/newEventProgressStages.tsx
@@ -47,6 +47,7 @@ import {
 } from "~/context/NewEventProgressContext";
 import { TimezoneContext } from "~/context/TimezoneContext";
 import { useWorkflowStore } from "~/hooks/useWorkflowStore";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 import {
   UploadImageForProcessingButton,
   UploadImageForProcessingDropzone,
@@ -151,7 +152,7 @@ export function ProgressStages({
     resolver: zodResolver(organizeFormSchema),
     defaultValues: {
       notes: notes || "",
-      visibility: visibility || "public",
+      visibility: visibility || DEFAULT_VISIBILITY,
       lists: eventLists,
     },
   });
@@ -367,7 +368,7 @@ function AddEvent() {
         userId: currentUser.id,
         username: currentUser.username || currentUser.id,
         sendNotification: false,
-        visibility: "public",
+        visibility: DEFAULT_VISIBILITY,
         lists: [],
       });
 
@@ -395,7 +396,7 @@ function AddEvent() {
         userId: currentUser.id,
         username: currentUser.username || currentUser.id,
         sendNotification: false,
-        visibility: "public",
+        visibility: DEFAULT_VISIBILITY,
         lists: [],
       });
 

--- a/apps/web/app/(minimal)/new/uploadImages.tsx
+++ b/apps/web/app/(minimal)/new/uploadImages.tsx
@@ -10,6 +10,7 @@ import { Button } from "@soonlist/ui/button";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
 import { useWorkflowStore } from "~/hooks/useWorkflowStore";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 import { optimizeFileToBase64 } from "~/lib/imageOptimization";
 
 export const UploadImageForProcessingDropzone = () => {
@@ -42,7 +43,7 @@ export const UploadImageForProcessingDropzone = () => {
         userId: currentUser.id,
         username: currentUser.username || currentUser.id,
         sendNotification: false,
-        visibility: "public",
+        visibility: DEFAULT_VISIBILITY,
         lists: [],
       });
 
@@ -138,7 +139,7 @@ export const UploadImageForProcessingButton = () => {
         userId: currentUser.id,
         username: currentUser.username || currentUser.id,
         sendNotification: false,
-        visibility: "public",
+        visibility: DEFAULT_VISIBILITY,
         lists: [],
       });
 

--- a/apps/web/components/YourDetails.tsx
+++ b/apps/web/components/YourDetails.tsx
@@ -28,6 +28,7 @@ import {
 import { Textarea } from "@soonlist/ui/textarea";
 
 import { useNewEventContext } from "~/context/NewEventContext";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 
 export const organizeFormSchema = z.object({
   notes: z.string().optional(),
@@ -57,7 +58,7 @@ export function YourDetails({
     resolver: zodResolver(organizeFormSchema),
     defaultValues: {
       notes: comment || "",
-      visibility: visibility || "public",
+      visibility: visibility || DEFAULT_VISIBILITY,
       lists: eventListOptions || [],
     },
   });

--- a/apps/web/context/NewEventContext.tsx
+++ b/apps/web/context/NewEventContext.tsx
@@ -35,7 +35,7 @@ export const NewEventProvider = ({ children }: { children: ReactNode }) => {
     NewEventContextState["organizeData"]
   >({
     notes: "",
-    visibility: "public",
+    visibility: DEFAULT_VISIBILITY,
     lists: [],
   });
   const [eventData, setEventData] =

--- a/apps/web/hooks/useDragAndDropHandler.ts
+++ b/apps/web/hooks/useDragAndDropHandler.ts
@@ -14,6 +14,7 @@ import {
   MAX_BATCH_SIZE,
   validateImageCount,
 } from "~/lib/batchUtils";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 import { optimizeFileToBase64 } from "~/lib/imageOptimization";
 import {
   extractFilesFromDataTransfer,
@@ -248,7 +249,7 @@ export function useDragAndDropHandler(
           userId: currentUser.id,
           username: currentUser.username || currentUser.id,
           sendNotification: false,
-          visibility: "public",
+          visibility: DEFAULT_VISIBILITY,
           lists: [],
         });
 

--- a/apps/web/hooks/useImagePasteHandler.ts
+++ b/apps/web/hooks/useImagePasteHandler.ts
@@ -13,6 +13,7 @@ import {
   generateTempId,
   validateImageCount,
 } from "~/lib/batchUtils";
+import { DEFAULT_VISIBILITY } from "~/lib/constants";
 import { optimizeFileToBase64 } from "~/lib/imageOptimization";
 import {
   extractFilesFromClipboard,
@@ -176,7 +177,7 @@ export function useImagePasteHandler(
           userId: currentUser.id,
           username: currentUser.username || currentUser.id,
           sendNotification: false,
-          visibility: "public",
+          visibility: DEFAULT_VISIBILITY,
           lists: [],
         });
 


### PR DESCRIPTION
### Motivation
- The web app used hardcoded `"public"` defaults when creating/capturing events which made discoverable behavior differ from the Expo mobile app. 
- The goal is to make web event-capture flows match Expo by using the shared default visibility constant.

### Description
- Replaced hardcoded `"public"` visibility with the shared `DEFAULT_VISIBILITY` constant across web event-capture flows so the default visibility is consistent with the Expo app.
- Updated the organize form and `NewEventContext` to use `DEFAULT_VISIBILITY` as the initial/default value so form state and context are aligned.
- Updated image/text/url/paste/drag-and-drop entry points to send `visibility: DEFAULT_VISIBILITY` when creating events so all capture paths behave the same.
- Files changed: `apps/web/app/(minimal)/new/newEventProgressStages.tsx`, `apps/web/app/(minimal)/new/uploadImages.tsx`, `apps/web/app/(minimal)/new/EventsFromImage.tsx`, `apps/web/hooks/useImagePasteHandler.ts`, `apps/web/hooks/useDragAndDropHandler.ts`, `apps/web/components/YourDetails.tsx`, and `apps/web/context/NewEventContext.tsx`.

### Testing
- Ran `pnpm lint:fix` which completed successfully.
- Ran `pnpm format:fix` which completed successfully.
- Ran `pnpm check` (typecheck + lint + format) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950eb7b890832abb7a9a5b9be847ff)