### PR TITLE
Fix drag-and-drop notifications on /add page

### DIFF
--- a/apps/web/lib/pasteEventUtils.ts
+++ b/apps/web/lib/pasteEventUtils.ts
@@ -136,8 +136,8 @@ export function hasFiles(dataTransfer: DataTransfer): boolean {
  * Checks if the current pathname is a target page for image paste handling
  */
 export function isTargetPage(pathname: string): boolean {
-  // /new page
-  if (pathname === "/new") return true;
+  // /new and /add pages
+  if (pathname === "/new" || pathname === "/add") return true;
 
   // Event list pages: /[userName]/upcoming
   if (/^\/[^/]+\/upcoming$/.exec(pathname)) return true;
@@ -154,7 +154,7 @@ export function isTargetPage(pathname: string): boolean {
 export function getPageContext(
   pathname: string,
 ): "new" | "eventList" | "eventPage" | "other" {
-  if (pathname === "/new") return "new";
+  if (pathname === "/new" || pathname === "/add") return "new";
   if (/^\/[^/]+\/upcoming$/.exec(pathname)) return "eventList";
   if (/^\/event\/[^/]+$/.exec(pathname)) return "eventPage";
   return "other";


### PR DESCRIPTION
### Motivation
- Users dropping images onto the `/add` (slash add) page did not receive the same batch/toast notifications and progress tracking as other target pages because `/add` was not recognized as a target page or mapped to the `new` context.

### Description
- Include `/add` in `isTargetPage` so the drag-and-drop/image paste handlers enable on the slash add page by treating it as a target page.
- Map `/add` to the same page context as `/new` in `getPageContext` so post-drop navigation and toast/progress behavior are consistent.
- Changed file: `apps/web/lib/pasteEventUtils.ts` where both checks were updated.

### Testing
- Ran `pnpm lint:fix` and it completed successfully.
- Ran `pnpm format:fix` and it completed successfully.
- Ran `pnpm check` (typecheck/lint/format) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950ea5929c832a9070599fa1a6b14e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection and context handling for the "add" page route to ensure it's properly recognized as a new page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->