### PR TITLE
fix(expo): register segmented-control Expo plugin

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -146,6 +146,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ["expo-asset"],
     ["expo-web-browser"],
     ["expo-background-task"],
+    "@react-native-segmented-control/segmented-control",
   ],
   ios: {
     supportsTablet: false,


### PR DESCRIPTION
## Summary
- Adds `@react-native-segmented-control/segmented-control` to the Expo plugins array in `app.config.ts`
- The package was installed as a dependency but the Expo plugin wasn't registered, so the native `RNCSegmentedControl` view wasn't linked into the iOS build

## Test plan
- [ ] Run `npx expo prebuild` or `eas build` to regenerate native project
- [ ] Verify segmented control renders correctly on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated segmented control plugin to enable segmented control UI component support in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->