### PR TITLE
fix: replace TouchableOpacity with Pressable for sign-in buttons

### DIFF
--- a/apps/expo/src/components/AppleSignInButton.tsx
+++ b/apps/expo/src/components/AppleSignInButton.tsx
@@ -18,7 +18,7 @@ export const AppleSignInButton: React.FC<AppleSignInButtonProps> = ({
         name="logo-apple"
         size={24}
         color="white"
-        style={{ marginRight: 12 }}
+        style={{ marginRight: 10 }}
       />
       <Text className="text-base font-semibold text-white">
         Continue with Apple

--- a/apps/expo/src/components/EmailSignInButton.tsx
+++ b/apps/expo/src/components/EmailSignInButton.tsx
@@ -14,7 +14,7 @@ export function EmailSignInButton({ onPress }: EmailSignInButtonProps) {
       onPress={onPress}
     >
       <View className="flex-row items-center justify-center">
-        <View style={{ marginRight: 12 }}>
+        <View style={{ marginRight: 10 }}>
           <Mail size={24} color="#162135" />
         </View>
         <Text className="text-base font-medium text-[#162135]">

--- a/apps/expo/src/components/GoogleSignInButton.tsx
+++ b/apps/expo/src/components/GoogleSignInButton.tsx
@@ -19,7 +19,7 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
         <Image
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-require-imports
           source={require("../assets/google-logo.png") as ImageSourcePropType}
-          style={{ width: 24, height: 24, marginRight: 12 }}
+          style={{ width: 24, height: 24, marginRight: 10 }}
           contentFit="contain"
           cachePolicy="disk"
           transition={100}


### PR DESCRIPTION
TouchableOpacity was making buttons too transparent on press, looking like a rendering glitch. Switched to Pressable with a subtle scale-down (0.98) and slightly darkened background color for a nicer press effect.

https://claude.ai/code/session_015VqZELrL6e5AXieBLH45gD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual feedback on sign-in buttons (Apple, Email, and Google) with scale animation and background color changes when pressed for enhanced user interaction clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->