### PR TITLE
chore: add resolve_pr_parallel command and helper scripts

### DIFF
--- a/.claude/commands/resolve_pr_parallel.md
+++ b/.claude/commands/resolve_pr_parallel.md
@@ -1,0 +1,49 @@
+---
+name: resolve_pr_parallel
+description: Resolve all PR comments using parallel processing
+argument-hint: "[optional: PR number or current PR]"
+---
+
+Resolve all PR comments using parallel processing.
+
+Claude Code automatically detects and understands your git context:
+
+- Current branch detection
+- Associated PR context
+- All PR comments and review threads
+- Can work with any PR by specifying the PR number, or ask it.
+
+## Workflow
+
+### 1. Analyze
+
+Get all unresolved comments for PR
+
+```bash
+gh pr status
+bin/get-pr-comments PR_NUMBER
+```
+
+### 2. Plan
+
+Create a TodoWrite list of all unresolved items grouped by type.
+
+### 3. Implement (PARALLEL)
+
+Spawn a pr-comment-resolver agent for each unresolved item in parallel.
+
+So if there are 3 comments, it will spawn 3 pr-comment-resolver agents in parallel. Like this:
+
+1. Task pr-comment-resolver(comment1)
+2. Task pr-comment-resolver(comment2)
+3. Task pr-comment-resolver(comment3)
+
+Always run all in parallel subagents/Tasks for each Todo item.
+
+### 4. Commit & Resolve
+
+- Commit changes
+- Run bin/resolve-pr-thread THREAD_ID_1
+- Push to remote
+
+Last, check bin/get-pr-comments PR_NUMBER again to see if all comments are resolved. They should be, if not, repeat the process from 1.

--- a/bin/get-pr-comments
+++ b/bin/get-pr-comments
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Fetches all review comments for a given PR number
+# Usage: bin/get-pr-comments PR_NUMBER
+
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: bin/get-pr-comments PR_NUMBER}"
+
+# Get the repo from git remote
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+
+echo "## PR #${PR_NUMBER} Review Comments"
+echo ""
+
+# Get review comments (inline code comments)
+gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate --jq '
+  .[] | select(.position != null or .line != null) |
+  "### Thread ID: \(.id)\n" +
+  "**File:** \(.path)\n" +
+  "**Line:** \(.line // .original_line // "N/A")\n" +
+  "**Author:** \(.user.login)\n" +
+  "**Created:** \(.created_at)\n" +
+  "**In reply to:** \(.in_reply_to_id // "top-level")\n\n" +
+  "\(.body)\n\n---\n"
+'
+
+echo ""
+echo "## PR #${PR_NUMBER} Issue Comments"
+echo ""
+
+# Get issue-level comments (general PR comments)
+gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --jq '
+  .[] |
+  "### Comment ID: \(.id)\n" +
+  "**Author:** \(.user.login)\n" +
+  "**Created:** \(.created_at)\n\n" +
+  "\(.body)\n\n---\n"
+'

--- a/bin/resolve-pr-thread
+++ b/bin/resolve-pr-thread
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Resolves a PR review thread by marking it as resolved
+# Usage: bin/resolve-pr-thread THREAD_ID
+#
+# Note: THREAD_ID here is the GraphQL node ID of the review thread.
+# This script uses the GitHub GraphQL API to resolve the thread.
+
+set -euo pipefail
+
+THREAD_ID="${1:?Usage: bin/resolve-pr-thread THREAD_ID}"
+
+# First, we need to find the GraphQL thread node ID from the REST comment ID
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+# Try to resolve using the node_id from the comment
+NODE_ID=$(gh api "repos/${REPO}/pulls/comments/${THREAD_ID}" --jq '.node_id' 2>/dev/null || echo "")
+
+if [ -z "$NODE_ID" ]; then
+  echo "Could not find comment with ID ${THREAD_ID}. It may already be resolved or the ID is invalid."
+  exit 1
+fi
+
+# Get the pull request review thread ID from the comment
+THREAD_NODE_ID=$(gh api graphql -f query='
+  query($nodeId: ID!) {
+    node(id: $nodeId) {
+      ... on PullRequestReviewComment {
+        pullRequestReviewThread {
+          id
+          isResolved
+        }
+      }
+    }
+  }
+' -f nodeId="$NODE_ID" --jq '.data.node.pullRequestReviewThread.id' 2>/dev/null || echo "")
+
+if [ -z "$THREAD_NODE_ID" ]; then
+  echo "Could not find review thread for comment ${THREAD_ID}."
+  exit 1
+fi
+
+# Check if already resolved
+IS_RESOLVED=$(gh api graphql -f query='
+  query($nodeId: ID!) {
+    node(id: $nodeId) {
+      ... on PullRequestReviewComment {
+        pullRequestReviewThread {
+          isResolved
+        }
+      }
+    }
+  }
+' -f nodeId="$NODE_ID" --jq '.data.node.pullRequestReviewThread.isResolved' 2>/dev/null || echo "false")
+
+if [ "$IS_RESOLVED" = "true" ]; then
+  echo "Thread ${THREAD_ID} is already resolved."
+  exit 0
+fi
+
+# Resolve the thread
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread {
+        isResolved
+      }
+    }
+  }
+' -f threadId="$THREAD_NODE_ID" --jq '.data.resolveReviewThread.thread.isResolved' > /dev/null
+
+echo "Thread ${THREAD_ID} has been resolved."


### PR DESCRIPTION
## Summary

- Adds .claude/commands/resolve_pr_parallel.md project-level slash command for resolving PR review comments in parallel using Claude Code agents
- Adds bin/get-pr-comments script to fetch all review and issue comments for a PR via gh api
- Adds bin/resolve-pr-thread script to resolve PR review threads via GitHub GraphQL API

## Test plan

- [ ] Run bin/get-pr-comments <PR_NUMBER> against an existing PR to verify comment fetching
- [ ] Run bin/resolve-pr-thread <THREAD_ID> against a review thread to verify resolution
- [ ] Use /resolve_pr_parallel in Claude Code to verify the full workflow

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added workflow documentation for parallel PR comment resolution process with four steps: analyze, plan, implement concurrently, and commit with verification
  * Added utility script to fetch and format GitHub pull request comments with full metadata
  * Added utility script to resolve PR review threads via GraphQL API with error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->