### PR TITLE
fix: always sync username from Clerk webhooks

### DIFF
--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -801,12 +801,6 @@ export const syncFromClerk = internalMutation({
     };
 
     if (existing) {
-      // Only update username if the user doesn't already have one
-      if (existing.username && existing.username.trim() !== "") {
-        const { username: _, ...userDataWithoutUsername } = userData;
-        await ctx.db.patch(existing._id, userDataWithoutUsername);
-        return;
-      }
       await ctx.db.patch(existing._id, userData);
     } else {
       await ctx.db.insert("users", {


### PR DESCRIPTION
## Summary

- Previously, the `syncFromClerk` mutation had a special case that skipped updating the `username` field for existing users who already had a username set. This meant any username changes made in Clerk were silently ignored, causing the Convex database to drift out of sync with Clerk.
- This fix removes that special case so all user fields, including `username`, are always updated from Clerk webhook data.

## Test plan

- [ ] Change a username in Clerk dashboard and verify it syncs to Convex via the webhook
- [ ] Verify new user creation still works correctly
- [ ] Verify existing users without a username still get their username set on sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always update `username` from Clerk webhooks in `syncFromClerk` so Convex stays in sync with Clerk. Removes the guard that skipped username updates for existing users.

<sup>Written for commit 13a2861a1c2c29066559c5c662b32b551db3ffb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User profile usernames now correctly synchronize with account provider data when updates occur, ensuring user information stays in sync across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
