### PR TITLE
chore: gitignore .claude/worktrees and settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ dist/
 
 # turbo
 .turbo
+
+# claude code
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
Ignore Claude Code worktree directories and local settings file.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.claude/worktrees/` and `.claude/settings.local.json` to `.gitignore` to prevent committing local Claude Code artifacts and keep the repo clean.

<sup>Written for commit c8ebece8ed864b7875ec3a0ba696c04beff14406. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
