### PR TITLE
fix: simplify AI year inference to prevent 2027 date bug

### DIFF
--- a/packages/cal/src/prompts.ts
+++ b/packages/cal/src/prompts.ts
@@ -335,9 +335,9 @@ The system using the output requires specific date and time formatting.
 - Always include seconds in the time, even if they're 00.
 - Always provide both startTime and endTime.
 
-**Year Inference (when no year is specified):**
-- All dates MUST fall between ${minDate} and ${maxDate}.
-- Only use a year outside this window if a year is explicitly stated in the source text. This is extremely rare — double-check before doing so.
+**Year Inference:**
+- If no year is explicitly stated: You MUST infer a year that places the date between ${minDate} and ${maxDate}.
+- If a year IS explicitly stated: Use that exact year. This is the ONLY time a date can fall outside the ${minDate} to ${maxDate} window.
 
 ** Time Inference (when a start or end time is not explicitly stated):**
 - If start time is not explicitly stated, infer a reasonable start time based on the event type and context (e.g., 19:00:00 for an evening concert, 10:00:00 for a morning workshop).


### PR DESCRIPTION
## Summary

Fixes a recurring bug where the AI event parser assigns 2027 dates instead of 2026 when parsing event flyers that don't specify a year. Simplifies the year inference prompt rules and removes a "March 15, 2027" example that was priming the model to output the wrong year.

## Changes

### Bug Fix
- Replaced 3 confusing year inference rules with 2 clear rules: inferred years must fall within the date window, explicit years can override
- Removed the `"March 15, 2027"` example that was teaching the model 2027 is valid
- Bumped prompt version to `v2026.03.30.2`

## Files Changed

- `packages/cal/src/prompts.ts` — Simplified year inference section, updated version strings

## Context

20 events across 7 users were affected by this bug. A data migration was run to fix production data. This PR addresses the root cause in the AI prompt.

## Test Plan

- [ ] Capture an event from a flyer with no year — should default to 2026
- [ ] Capture an event with an explicit future year — should respect the stated year
- [ ] Monitor for any new 2027 events over the next few days

## Notes

- Fresh branch for clean AI code review
- Original branch: claude/fix-event-year-parsing-SvNKA-fresh

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where events without a year were parsed as 2027 instead of 2026 by simplifying year inference to a strict date window and honoring explicit years only. Removes the “March 15, 2027” example and bumps the prompt version to `v2026.03.30.2` in `packages/cal/src/prompts.ts`.

<sup>Written for commit f53c31febb53235a8712a8bae70695b67b5c3d74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

