### PR TITLE
fix(expo): show event savers on My Scene feed

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -259,7 +259,6 @@ function FollowingFeedContent() {
       })
       .map((event) => ({
         ...event,
-        eventFollows: [],
         comments: [],
         eventToLists: [],
         lists: [],


### PR DESCRIPTION
## Summary

- Stop overwriting `eventFollows` with `[]` in the Following (My Scene) tab
- The backend already fetches and enriches eventFollows data per event — we were discarding it client-side, so saver avatars never appeared on scene cards

## Context

`getEventById` (`packages/backend/convex/model/events.ts:570-593`) already queries eventFollows and batch-fetches follower user data. The Following tab was zeroing out `eventFollows` along with `comments`, `eventToLists`, and `lists` — likely an early optimization that threw away useful data along with unused data.

## Test plan

- [ ] Open My Scene tab
- [ ] Verify event cards now show stacked avatars for users who saved the event (not just the creator)
- [ ] Verify "via ListName" attribution still works correctly alongside saver avatars

Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show event saver avatars on the My Scene (Following) feed by keeping the backend’s eventFollows data. Removed the client-side override that set eventFollows to an empty array, so scene cards now display savers correctly.

<sup>Written for commit 3f49ca920b0d8428014e8f24719d52275953ae2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal optimization to the following feed data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->