### PR TITLE
feat(expo): event savers dialog with two-tier display

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -142,10 +142,8 @@ function MyFeedContent() {
     const events = groupedEvents.map((group) => ({
       event: {
         ...group.event,
-        eventFollows: [],
         comments: [],
         eventToLists: [],
-        lists: [],
       },
       // Server-computed count (already shows just similar events, not including primary)
       similarEvents: Array(group.similarEventsCount).fill({

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -261,7 +261,6 @@ function FollowingFeedContent() {
         ...event,
         comments: [],
         eventToLists: [],
-        lists: [],
       }));
   }, [events, stableTimestamp, selectedSegment]);
 

--- a/apps/expo/src/components/EventSaversDialog.tsx
+++ b/apps/expo/src/components/EventSaversDialog.tsx
@@ -1,0 +1,235 @@
+import React, { useCallback } from "react";
+import {
+  FlatList,
+  Modal,
+  Share,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Image as ExpoImage } from "expo-image";
+import { router } from "expo-router";
+
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
+
+import { List, ShareIcon, User } from "~/components/icons";
+import { logError } from "~/utils/errorLogging";
+import { UserProfileFlair } from "./UserProfileFlair";
+
+interface UserForDisplay {
+  id: string;
+  username: string;
+  displayName?: string | null;
+  userImage?: string | null;
+}
+
+interface EventSaversDialogProps {
+  visible: boolean;
+  onClose: () => void;
+  eventId: string;
+  creator: UserForDisplay;
+  savers: UserForDisplay[];
+  lists: Doc<"lists">[];
+  currentUserId?: string;
+}
+
+export function EventSaversDialog({
+  visible,
+  onClose,
+  eventId: _eventId,
+  creator,
+  savers,
+  lists,
+  currentUserId,
+}: EventSaversDialogProps) {
+  const insets = useSafeAreaInsets();
+
+  // Combine creator with savers, deduplicate by id
+  const allUsers: UserForDisplay[] = [creator];
+  for (const saver of savers) {
+    if (!allUsers.some((u) => u.id === saver.id)) {
+      allUsers.push(saver);
+    }
+  }
+
+  const handleUserPress = useCallback(
+    (user: UserForDisplay) => {
+      onClose();
+      if (currentUserId && user.id === currentUserId) {
+        router.push("/settings/account");
+      } else {
+        router.push(`/${user.username}`);
+      }
+    },
+    [currentUserId, onClose],
+  );
+
+  const handleListPress = useCallback(
+    (list: Doc<"lists">) => {
+      onClose();
+      if (list.slug) {
+        router.push(`/list/${list.slug}`);
+      }
+    },
+    [onClose],
+  );
+
+  const handleShareList = useCallback(
+    async (listName: string, listSlug?: string) => {
+      const shareUrl = listSlug
+        ? `https://soonlist.com/list/${listSlug}`
+        : "https://soonlist.com";
+      try {
+        await Share.share({
+          message: `Check out ${listName} on Soonlist`,
+          url: shareUrl,
+        });
+      } catch (error) {
+        logError("Error sharing list", error);
+      }
+    },
+    [],
+  );
+
+  const avatarSize = 36;
+
+  const renderUserRow = useCallback(
+    (user: UserForDisplay, isCreator: boolean) => (
+      <TouchableOpacity
+        key={user.id}
+        onPress={() => handleUserPress(user)}
+        className="flex-row items-center px-4 py-3"
+        activeOpacity={0.7}
+      >
+        <UserProfileFlair username={user.username} size="sm">
+          {user.userImage ? (
+            <ExpoImage
+              source={{ uri: user.userImage }}
+              style={{
+                width: avatarSize,
+                height: avatarSize,
+                borderRadius: 9999,
+              }}
+              contentFit="cover"
+              contentPosition="center"
+              cachePolicy="disk"
+              transition={100}
+              recyclingKey={`dialog-saver-${user.id}`}
+            />
+          ) : (
+            <View
+              style={{
+                width: avatarSize,
+                height: avatarSize,
+                borderRadius: 9999,
+                backgroundColor: "#E0D9FF",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <User size={avatarSize * 0.6} color="#627496" />
+            </View>
+          )}
+        </UserProfileFlair>
+        <View className="ml-3 flex-1">
+          <Text className="text-base font-semibold text-neutral-1">
+            {user.displayName || user.username}
+          </Text>
+          {isCreator ? (
+            <Text className="text-sm font-semibold text-interactive-1">
+              Captured
+            </Text>
+          ) : (
+            <Text className="text-sm text-neutral-2">Saved</Text>
+          )}
+        </View>
+      </TouchableOpacity>
+    ),
+    [handleUserPress],
+  );
+
+  const renderListRow = useCallback(
+    (list: Doc<"lists">) => (
+      <View
+        key={list._id}
+        className="flex-row items-center justify-between px-4 py-3"
+      >
+        <TouchableOpacity
+          className="flex-1 flex-row items-center gap-3"
+          onPress={() => handleListPress(list)}
+          activeOpacity={0.7}
+        >
+          <View className="h-10 w-10 items-center justify-center rounded-full bg-interactive-2">
+            <List size={20} color="#5A32FB" />
+          </View>
+          <Text
+            className="flex-1 text-base font-semibold text-neutral-1"
+            numberOfLines={1}
+          >
+            {list.name}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() =>
+            void handleShareList(list.name, list.slug ?? undefined)
+          }
+          className="ml-2 rounded-full p-2"
+          activeOpacity={0.7}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <ShareIcon size={18} color="#5A32FB" />
+        </TouchableOpacity>
+      </View>
+    ),
+    [handleListPress, handleShareList],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      presentationStyle="pageSheet"
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
+        <View className="flex-row items-center justify-between border-b border-neutral-4 px-4 py-3">
+          <Text className="text-lg font-bold text-neutral-1">Event Savers</Text>
+          <TouchableOpacity onPress={onClose} activeOpacity={0.7}>
+            <Text className="text-base font-semibold text-interactive-1">
+              Done
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <FlatList
+          data={[]}
+          renderItem={null}
+          contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+          ListHeaderComponent={
+            <View>
+              {/* Saved By Section */}
+              <Text className="px-4 pb-1 pt-4 text-xs font-semibold uppercase tracking-wider text-neutral-2">
+                Saved By
+              </Text>
+              {allUsers.map((user) =>
+                renderUserRow(user, user.id === creator.id),
+              )}
+
+              {/* Appears On Section — only if there are non-personal lists */}
+              {lists.length > 0 && (
+                <>
+                  <Text className="px-4 pb-1 pt-4 text-xs font-semibold uppercase tracking-wider text-neutral-2">
+                    Appears On
+                  </Text>
+                  {lists.map((list) => renderListRow(list))}
+                </>
+              )}
+            </View>
+          }
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -18,6 +18,7 @@ import { router } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 
 import type { api } from "@soonlist/backend/convex/_generated/api";
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { getTimezoneAbbreviation } from "@soonlist/cal";
 
@@ -46,6 +47,7 @@ import { setEventCache } from "~/utils/eventCache";
 import { getEventEmoji } from "~/utils/eventEmoji";
 import { collapseSimilarEvents } from "~/utils/similarEvents";
 import { EventMenu } from "./EventMenu";
+import { EventSaversDialog } from "./EventSaversDialog";
 import { EventStats } from "./EventStats";
 import { UserProfileFlair } from "./UserProfileFlair";
 
@@ -71,7 +73,7 @@ interface UserForDisplay {
   userImage?: string | null;
 }
 
-// Stacked avatars component for showing multiple users who saved an event
+// Two-tier event savers display: rich inline (≤2 items) or overflow → dialog (>2 items)
 function EventSaversRow({
   creator,
   savers,
@@ -79,7 +81,7 @@ function EventSaversRow({
   eventId,
   currentUserId,
   sourceListName,
-  additionalSourceCount,
+  lists,
 }: {
   creator: UserForDisplay;
   savers: UserForDisplay[];
@@ -87,12 +89,11 @@ function EventSaversRow({
   eventId: string;
   currentUserId?: string;
   sourceListName?: string;
-  additionalSourceCount?: number;
+  lists?: Doc<"lists">[];
 }) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const isOwnEvent = currentUserId === creator.id;
+  const [dialogVisible, setDialogVisible] = useState(false);
 
-  // Combine creator with savers, deduplicate by id, and limit to first 2
+  // Combine creator with savers, deduplicate by id
   const allUsers: UserForDisplay[] = [creator];
   for (const saver of savers) {
     if (!allUsers.some((u) => u.id === saver.id)) {
@@ -100,11 +101,15 @@ function EventSaversRow({
     }
   }
 
+  // Filter non-personal lists
+  const nonPersonalLists = (lists ?? []).filter((l) => !l.isSystemList);
+  const listCount = nonPersonalLists.length;
+  const itemCount = allUsers.length + listCount;
+
   const displayUsers = allUsers.slice(0, 2);
-  const remainingCount = allUsers.length - displayUsers.length;
+  const remainingUserCount = allUsers.length - displayUsers.length;
 
   const handleUserPress = (user: UserForDisplay) => {
-    // If clicking on yourself, go to account settings
     if (currentUserId && user.id === currentUserId) {
       router.push("/settings/account");
     } else {
@@ -112,16 +117,84 @@ function EventSaversRow({
     }
   };
 
+  const handleListPress = (list: Doc<"lists">) => {
+    if (list.slug) {
+      router.push(`/list/${list.slug}`);
+    }
+  };
+
   const avatarSize = iconSize * 1.1;
   const overlap = avatarSize * 0.3;
 
-  // Render individual tappable name
+  // Render stacked avatars
+  const renderAvatars = (users: UserForDisplay[]) => (
+    <View
+      className="flex-row items-center"
+      style={{
+        width: avatarSize + (users.length - 1) * (avatarSize - overlap),
+      }}
+    >
+      {users.map((user, index) => (
+        <Pressable
+          key={user.id}
+          onPress={() =>
+            itemCount > 2 ? setDialogVisible(true) : handleUserPress(user)
+          }
+          hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+          style={{
+            position: index === 0 ? "relative" : "absolute",
+            left: index * (avatarSize - overlap),
+            zIndex: users.length - index,
+          }}
+        >
+          <UserProfileFlair username={user.username} size="xs">
+            {user.userImage ? (
+              <ExpoImage
+                source={{ uri: user.userImage }}
+                style={{
+                  width: avatarSize,
+                  height: avatarSize,
+                  borderRadius: 9999,
+                  borderWidth: 2,
+                  borderColor: "white",
+                }}
+                contentFit="cover"
+                contentPosition="center"
+                cachePolicy="disk"
+                transition={100}
+                recyclingKey={`${eventId}-saver-${user.id}`}
+              />
+            ) : (
+              <View
+                style={{
+                  width: avatarSize,
+                  height: avatarSize,
+                  borderRadius: 9999,
+                  borderWidth: 2,
+                  borderColor: "white",
+                  backgroundColor: "#E0D9FF",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <User size={avatarSize * 0.6} color="#627496" />
+              </View>
+            )}
+          </UserProfileFlair>
+        </Pressable>
+      ))}
+    </View>
+  );
+
+  // Render tappable name
   const renderTappableName = (user: UserForDisplay, isLast: boolean) => {
     const displayName = user.displayName || user.username || "unknown";
     return (
       <Pressable
         key={user.id}
-        onPress={() => handleUserPress(user)}
+        onPress={() =>
+          itemCount > 2 ? setDialogVisible(true) : handleUserPress(user)
+        }
         hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
       >
         <Text className="text-xs text-neutral-2">
@@ -132,183 +205,125 @@ function EventSaversRow({
     );
   };
 
-  // Collapsed view
-  if (!isExpanded) {
-    return (
-      <View className="mx-auto mt-1 flex-row items-center gap-1">
-        {/* Stacked avatars */}
-        <View
-          className="flex-row items-center"
-          style={{
-            width:
-              avatarSize + (displayUsers.length - 1) * (avatarSize - overlap),
-          }}
+  // Render tappable list name for inline display
+  const renderInlineListName = () => {
+    if (nonPersonalLists.length === 1 && nonPersonalLists[0]) {
+      const list = nonPersonalLists[0];
+      return (
+        <Pressable
+          onPress={() => handleListPress(list)}
+          hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
         >
-          {displayUsers.map((user, index) => (
-            <Pressable
-              key={user.id}
-              onPress={() => handleUserPress(user)}
-              hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-              style={{
-                position: index === 0 ? "relative" : "absolute",
-                left: index * (avatarSize - overlap),
-                zIndex: displayUsers.length - index,
-              }}
-            >
-              <UserProfileFlair username={user.username} size="xs">
-                {user.userImage ? (
-                  <ExpoImage
-                    source={{ uri: user.userImage }}
-                    style={{
-                      width: avatarSize,
-                      height: avatarSize,
-                      borderRadius: 9999,
-                      borderWidth: 2,
-                      borderColor: "white",
-                    }}
-                    contentFit="cover"
-                    contentPosition="center"
-                    cachePolicy="disk"
-                    transition={100}
-                    recyclingKey={`${eventId}-saver-${user.id}`}
-                  />
-                ) : (
-                  <View
-                    style={{
-                      width: avatarSize,
-                      height: avatarSize,
-                      borderRadius: 9999,
-                      borderWidth: 2,
-                      borderColor: "white",
-                      backgroundColor: "#E0D9FF",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <User size={avatarSize * 0.6} color="#627496" />
-                  </View>
-                )}
-              </UserProfileFlair>
-            </Pressable>
-          ))}
+          <View className="flex-row items-center">
+            <Text className="text-xs text-neutral-2"> via </Text>
+            <List size={11} color="#5A32FB" />
+            <Text className="text-xs font-semibold text-interactive-1">
+              {" "}
+              {list.name}
+            </Text>
+          </View>
+        </Pressable>
+      );
+    }
+    // Fallback to sourceListName if lists data isn't available yet
+    if (sourceListName && nonPersonalLists.length === 0) {
+      return (
+        <View className="flex-row items-center">
+          <Text className="text-xs text-neutral-2"> via </Text>
+          <List size={11} color="#5A32FB" />
+          <Text className="text-xs font-semibold text-interactive-1">
+            {" "}
+            {sourceListName}
+          </Text>
         </View>
+      );
+    }
+    return null;
+  };
 
-        {/* Names and source attribution */}
-        <View className="flex-row flex-wrap items-center">
-          {isOwnEvent && sourceListName ? (
-            // Own event: show "Shared to [list] Name"
-            <View className="flex-row items-center">
-              <Text className="text-xs text-neutral-2">Shared to </Text>
-              <List size={11} color="#5A32FB" />
-              <Text className="text-xs font-semibold text-interactive-1">
-                {" "}
-                {sourceListName}
-              </Text>
-              {additionalSourceCount && additionalSourceCount > 0 ? (
-                <Text className="text-xs text-neutral-2">
-                  {" "}
-                  +{additionalSourceCount} more
+  // Build overflow text for >2 items
+  const renderOverflowText = () => {
+    const parts: React.ReactNode[] = [];
+
+    // Names (up to 2)
+    displayUsers.forEach((user, index) => {
+      const displayName = user.displayName || user.username || "unknown";
+      if (index > 0) parts.push(", ");
+      parts.push(displayName);
+    });
+
+    // +N more people
+    if (remainingUserCount > 0) {
+      parts.push(` +${remainingUserCount} more`);
+    }
+
+    // List count or single list name
+    if (listCount === 1 && nonPersonalLists[0]) {
+      parts.push(
+        <View key="list" className="flex-row items-center">
+          <Text className="text-xs text-neutral-2"> via </Text>
+          <List size={11} color="#5A32FB" />
+          <Text className="text-xs font-semibold text-interactive-1">
+            {" "}
+            {nonPersonalLists[0].name}
+          </Text>
+        </View>,
+      );
+    } else if (listCount > 1) {
+      parts.push(
+        <Text key="listcount" className="text-xs text-neutral-2">
+          {" "}
+          · {listCount} lists
+        </Text>,
+      );
+    }
+
+    return parts;
+  };
+
+  // Overflow view (>2 items) — entire row tappable to open dialog
+  if (itemCount > 2) {
+    return (
+      <>
+        <Pressable
+          onPress={() => setDialogVisible(true)}
+          className="mx-auto mt-1 flex-row items-center gap-1"
+        >
+          {renderAvatars(displayUsers)}
+          <View className="flex-row flex-wrap items-center">
+            {renderOverflowText().map((part, i) =>
+              typeof part === "string" ? (
+                <Text key={i} className="text-xs text-neutral-2">
+                  {part}
                 </Text>
-              ) : null}
-            </View>
-          ) : (
-            <>
-              {displayUsers.map((user, index) =>
-                renderTappableName(
-                  user,
-                  index === displayUsers.length - 1 && remainingCount === 0,
-                ),
-              )}
-              {remainingCount > 0 && (
-                <Pressable
-                  onPress={() => setIsExpanded(true)}
-                  hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-                >
-                  <Text className="text-xs text-interactive-1">
-                    +{remainingCount} more
-                  </Text>
-                </Pressable>
-              )}
-              {sourceListName ? (
-                <View className="flex-row items-center">
-                  <Text className="text-xs text-neutral-2"> via </Text>
-                  <List size={11} color="#5A32FB" />
-                  <Text className="text-xs font-semibold text-interactive-1">
-                    {" "}
-                    {sourceListName}
-                  </Text>
-                  {additionalSourceCount && additionalSourceCount > 0 ? (
-                    <Text className="text-xs text-neutral-2">
-                      {" "}
-                      +{additionalSourceCount} more
-                    </Text>
-                  ) : null}
-                </View>
-              ) : null}
-            </>
-          )}
-        </View>
-      </View>
+              ) : (
+                part
+              ),
+            )}
+          </View>
+        </Pressable>
+        <EventSaversDialog
+          visible={dialogVisible}
+          onClose={() => setDialogVisible(false)}
+          eventId={eventId}
+          creator={creator}
+          savers={savers}
+          lists={nonPersonalLists}
+          currentUserId={currentUserId}
+        />
+      </>
     );
   }
 
-  // Expanded view - show all users in a vertical list
+  // Rich inline view (≤2 items) — linked names and list names
   return (
-    <View className="mx-auto mt-1">
-      <TouchableOpacity
-        onPress={() => setIsExpanded(false)}
-        className="mb-2 items-center"
-        activeOpacity={0.7}
-      >
-        <Text className="text-xs text-interactive-1">Hide</Text>
-      </TouchableOpacity>
-      <View className="space-y-2">
-        {allUsers.map((user) => (
-          <TouchableOpacity
-            key={user.id}
-            onPress={() => handleUserPress(user)}
-            className="flex-row items-center py-1"
-            activeOpacity={0.7}
-          >
-            <UserProfileFlair username={user.username} size="xs">
-              {user.userImage ? (
-                <ExpoImage
-                  source={{ uri: user.userImage }}
-                  style={{
-                    width: avatarSize,
-                    height: avatarSize,
-                    borderRadius: 9999,
-                    borderWidth: 2,
-                    borderColor: "white",
-                  }}
-                  contentFit="cover"
-                  contentPosition="center"
-                  cachePolicy="disk"
-                  transition={100}
-                  recyclingKey={`${eventId}-saver-expanded-${user.id}`}
-                />
-              ) : (
-                <View
-                  style={{
-                    width: avatarSize,
-                    height: avatarSize,
-                    borderRadius: 9999,
-                    borderWidth: 2,
-                    borderColor: "white",
-                    backgroundColor: "#E0D9FF",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <User size={avatarSize * 0.6} color="#627496" />
-                </View>
-              )}
-            </UserProfileFlair>
-            <Text className="ml-2 text-xs text-neutral-2">
-              {user.displayName || user.username}
-            </Text>
-          </TouchableOpacity>
-        ))}
+    <View className="mx-auto mt-1 flex-row items-center gap-1">
+      {renderAvatars(displayUsers)}
+      <View className="flex-row flex-wrap items-center">
+        {displayUsers.map((user, index) =>
+          renderTappableName(user, index === displayUsers.length - 1),
+        )}
+        {renderInlineListName()}
       </View>
     </View>
   );
@@ -747,7 +762,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
               eventId={event.id}
               currentUserId={currentUser?.id}
               sourceListName={sourceListName}
-              additionalSourceCount={additionalSourceCount}
+              lists={event.lists}
             />
           ) : sourceListName ? (
             <View className="mx-auto mt-1 flex-row items-center">

--- a/docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md
+++ b/docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md
@@ -1,0 +1,125 @@
+---
+date: 2026-04-08
+topic: event-savers-dialog
+---
+
+# Event Savers Dialog
+
+## Problem Frame
+
+The `EventSaversRow` on feed cards shows a compact row of stacked avatars and truncated names when multiple people have saved an event. The current experience has several gaps:
+
+- **Names are truncated** — tiny `text-xs` display names don't show who actually saved the event
+- **Lists aren't linked** — source list names appear as plain text with no tap target to navigate to the list or share it
+- **Unclear affordances** — avatars and names are tappable (to profiles), but nothing visually signals this; the overall row feels inert
+- **No way to see all savers** — the "+N more" expand only triggers at 3+ savers, which rarely happens
+- **You + 1 other person** — when you've saved an event and one other person has too, you see 2 profile icons with no context about who they are or how they found the event; the compact row doesn't help you discover the other person or their list
+
+This feature adds a native-feeling pageSheet dialog that opens when users tap the saver area (2+ savers), showing each saver with their full name, the list they saved the event to (tappable), and share actions — making profiles, lists, and provenance properly discoverable.
+
+## User Flow
+
+```
+Feed Card — Inline (≤2 items: 1 person + 1 list)
+┌─────────────────────────────────────────┐
+│  👤 Jaron  ✨ via Capture               │
+│  ───── or ─────                         │
+│  👤 Sarah  via "Weekend Plans"          │
+│       ↑ tappable    ↑ tappable          │
+└─────────────────────────────────────────┘
+
+Feed Card — Overflow (>2 items) → entire row tappable to dialog
+
+  2 people, 1 list:
+    👤👤 Jaron, Sarah via "Portland Events"
+
+  2 people, 2 lists:
+    👤👤 Jaron, Sarah · 2 lists
+
+  3 people, 1 list:
+    👤👤 Jaron, Sarah +1 more · 1 list
+
+  3 people, 3 lists:
+    👤👤 Jaron, Sarah +1 more · 3 lists
+         │
+         ▼
+┌─────────────────────────────┐
+│  Event Savers          Done │
+│─────────────────────────────│
+│  👤 Jaron Heard             │
+│     ✨ via Capture     [↗]  │
+│                             │
+│  👤 Sarah Kim               │
+│     via "Weekend Plans" [↗] │
+│                             │
+│  👤 Alex Chen               │
+│     via Save           [↗]  │
+└─────────────────────────────┘
+    ├── Tap user → profile
+    ├── Tap list name → list view
+    └── Tap [↗] → native share sheet
+```
+
+## Requirements
+
+**Rich Inline Row (≤2 items)**
+- R1. When total items (people + lists) ≤ 2, show a rich inline row with linked names and linked list names
+- R2. User names are tappable → navigate to profile
+- R3. List names are tappable → navigate to list view
+- R4. Creator shows "Captured" with visual emphasis; other savers show "Saved"
+
+**Dialog Trigger & Overflow (>2 items)**
+- R5. When total items > 2, show an overflow inline row: prioritize names (show up to 2), then "+N more" for additional people, then list count (e.g., "· 2 lists") or single list name if only 1 list. Entire row tappable to open dialog.
+- R6. Modal uses the same `presentationStyle="pageSheet"` + `animationType="slide"` pattern as `FollowedListsModal`
+- R7. Modal has a "Done" button to dismiss, and supports swipe-to-dismiss
+
+**Dialog Content — Two Sections**
+- R8. "Saved By" section: each row shows avatar (with `UserProfileFlair`), full display name, and role label
+- R9. Creator (`events.userId` matches): "Captured" with visual emphasis; all others: "Saved"
+- R10. Tapping a user's avatar or name navigates to their profile
+- R11. "Appears On" section: all non-personal lists the event belongs to (from `eventToLists`), each with list name and share button
+- R12. Tapping a list name navigates to the list view
+- R13. Each list row has a share button that triggers `Share.share()` for that list
+
+**Share Actions**
+- R14. List share buttons use `Share.share()` for the list URL
+- R15. Reuse existing `Share.share()` patterns from `useEventActions` and `FollowedListsModal`
+
+**Data**
+- R16. Fetch all non-personal lists for the event via `eventToLists` (filter out `isSystemList: true` lists)
+- R17. Support multiple lists per event (not just a single `sourceListName`)
+- R18. Creator is always listed first in the "Saved By" section
+
+## Success Criteria
+
+- Users can discover all savers and the lists events appear on from any feed card
+- "via Capture" clearly distinguishes original captures from list saves
+- Every user name, list name, and share button is tappable and functional
+- Dialog feels native (pageSheet, swipe-to-dismiss, smooth transitions)
+- No new dependencies — reuses existing modal, share, and navigation patterns
+
+## Scope Boundaries
+
+- **In scope:** Mobile (Expo) only
+- **Out of scope:** Web event cards, new Convex tables or schema changes, list follow/unfollow actions from the dialog, analytics/tracking for dialog interactions (can add later)
+- **Out of scope:** Changing the collapsed saver display (avatars + names on the card itself)
+
+## Key Decisions
+
+- **Two-tier display:** Rich inline for simple cases (≤2 items), pageSheet dialog for overflow — avoids unnecessary modals while ensuring discoverability
+- **2-item inline threshold:** Max 1 person + 1 list inline; anything more triggers dialog to prevent crowding
+- **pageSheet modal over bottom sheet:** Matches `FollowedListsModal` pattern, feels native on iOS, no new dependencies
+- **Overflow copy pattern:** Names prioritized over lists; show up to 2 names, "+N more" for extra people, "· N lists" or "via [List Name]" for list context
+- **"Captured" labeling:** Distinguishes creators from savers — makes event provenance visible
+- **Event-level lists (not per-saver):** Show lists the event appears on as a separate "Appears On" section, not per-saver. Avoids unreliable data inference from cross-referencing `eventToLists` with list ownership.
+- **Filter personal lists:** System/personal lists (`isSystemList: true`) are excluded from the "Appears On" section — they're internal and confusing to show
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R16][Needs research] How to efficiently fetch all non-personal lists for an event in the feed query? May need a new Convex query.
+- [Affects R9][Technical] What visual treatment for "Captured" — accent color, small icon, or subtle badge? Should be determined during implementation with design iteration.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-08-001-feat-event-savers-dialog-plan.md
+++ b/docs/plans/2026-04-08-001-feat-event-savers-dialog-plan.md
@@ -1,0 +1,262 @@
+---
+title: "feat: Event Savers Dialog with Rich Inline Row"
+type: feat
+status: active
+date: 2026-04-08
+origin: docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md
+---
+
+# feat: Event Savers Dialog with Rich Inline Row
+
+## Overview
+
+Replace the current `EventSaversRow` inline expand/collapse with a two-tier display: a rich inline row for simple cases (≤2 items) and a native pageSheet dialog for overflow (>2 items). The dialog shows two sections — "Saved By" (users with profile links) and "Appears On" (event-level lists with share buttons). This makes user profiles, lists, and event provenance properly discoverable from feed cards.
+
+This is a **frontend-only change** — `getEventById()` already returns full list data for every event. No new backend queries or enrichment needed.
+
+## Problem Frame
+
+The current `EventSaversRow` shows stacked avatars with truncated names. Names are tiny, lists aren't linked, affordances are unclear, and the "+N more" expand rarely triggers. When you've saved an event and one other person has too, the 2-icon row provides no context about who they are or how they found the event. (see origin: `docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md`)
+
+## Requirements Trace
+
+- R1-R3. Rich inline row with linked names/lists (≤2 items)
+- R4. Creator shows "Captured" with emphasis; others show "Saved"
+- R5. Overflow row: names prioritized, "+N more", list count — tappable to dialog
+- R6-R7. PageSheet modal with Done + swipe-to-dismiss
+- R8-R10. Dialog "Saved By" section: avatar, full name, role, tappable to profile
+- R11-R13. Dialog "Appears On" section: non-personal lists with share buttons
+- R14-R15. Share actions reuse existing patterns
+- R16-R18. Event-level list data from `eventToLists`, filter personal lists
+
+## Scope Boundaries
+
+- **In scope:** Mobile (Expo) only
+- **Out of scope:** Web event cards, schema changes, list follow/unfollow in dialog, analytics, per-saver list attribution
+- **Out of scope:** Changing the 1-saver inline display
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/expo/src/components/UserEventsList.tsx` — `EventSaversRow` (lines 75-315), `UserEventListItem` (lines 338+)
+- `apps/expo/src/components/FollowedListsModal.tsx` — pageSheet modal pattern: `presentationStyle="pageSheet"`, `animationType="slide"`, FlatList content, share buttons
+- `apps/expo/src/components/UserProfileFlair.tsx` — avatar emoji badge wrapper
+- `apps/expo/src/hooks/useEventActions.ts` — `handleShare()` with PostHog tracking
+- `packages/backend/convex/model/events.ts` — `getEventById()` (line 554+) already returns `{ ...event, user, eventFollows, comments, eventToLists, lists }` where `lists` is full `Doc<"lists">[]` including `isSystemList` field
+- `packages/backend/convex/feeds.ts` — `queryFeed()` calls `getEventById()` per feed entry (line 81), so every event already has its full lists array
+- `packages/backend/convex/schema.ts` — `lists` table has `isSystemList: v.optional(v.boolean())` and `systemListType` fields
+
+### Key Data Discovery
+
+**`getEventById()` already returns all needed list data.** The feed query calls `getEventById()` for every event, which fetches `eventToLists` entries and resolves each to a full list document. The client already has the `lists` array with `isSystemList` field — no new backend enrichment or query is needed. `listCount` can be computed client-side: `event.lists.filter(l => !l.isSystemList).length`.
+
+### External References
+
+No external research needed — strong local patterns exist for modals, sharing, and navigation.
+
+## Key Technical Decisions
+
+- **Frontend-only implementation:** `getEventById()` already returns full `lists` data. Compute `listCount` client-side from `event.lists.filter(l => !l.isSystemList)`. No new Convex queries needed.
+- **Event-level lists, not per-saver:** `eventToLists` doesn't track who added the event. Showing lists as a separate "Appears On" section avoids unreliable attribution inference. (see origin)
+- **Filter personal/system lists:** Every creator's event auto-adds to their personal list. Filter `isSystemList === true` (noting it's `v.optional(v.boolean())` — treat undefined as false).
+- **Reuse `FollowedListsModal` pattern:** Same `presentationStyle="pageSheet"` + `animationType="slide"` + FlatList. Extract into a new `EventSaversDialog` component.
+- **Item counting for threshold:** Count people (creator + savers) + non-personal lists. If ≤2, rich inline. If >2, overflow → dialog.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How to get list data for the dialog?** Already available — `getEventById()` returns full `lists` array. No new query needed.
+- **How does the inline row know the list count?** Compute client-side from `event.lists.filter(l => !l.isSystemList).length`.
+- **Priority: creator label vs list?** Creator always shows "Captured". They appear in the "Saved By" section, not "Appears On". Personal lists are filtered. No overlap.
+- **Share behavior for "Saved By" rows?** No per-row share buttons in "Saved By" section. Share buttons only appear on list rows in "Appears On".
+
+### Deferred to Implementation
+
+- Visual treatment for "Captured" label (accent color, icon, or badge) — determine during design iteration
+- Whether the overflow inline row should show avatar stacking or a simpler layout — try existing stacking first
+- Dialog navigation behavior: should the dialog dismiss before navigating to a profile or list, or stay open? Follow `FollowedListsModal` pattern (likely dismiss first)
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+Data flow (no backend changes needed):
+  Feed query (existing)
+    → getEventById() already returns event.lists (full Doc<"lists">[])
+    → Pass event.lists through to EventSaversRow
+
+  Client-side computation:
+    nonPersonalLists = event.lists.filter(l => !l.isSystemList)
+    listCount = nonPersonalLists.length
+    itemCount = people.length + listCount
+
+  Inline display logic:
+    if itemCount <= 2 → rich inline (linked names, linked list name if 1 list)
+    if itemCount > 2  → overflow row (names + "+N more" + "· N lists") → tappable
+
+  Dialog (uses same event.lists data, no extra query):
+    → EventSaversDialog renders:
+       Section 1: "Saved By" — avatar + name + Captured/Saved
+       Section 2: "Appears On" — nonPersonalLists with list name + share button
+       States: loading (N/A — data already available), empty (hide section), error (N/A)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Create `EventSaversDialog` component**
+
+**Goal:** Build the pageSheet modal that shows "Saved By" and "Appears On" sections.
+
+**Requirements:** R6, R7, R8, R9, R10, R11, R12, R13, R14, R15
+
+**Dependencies:** None
+
+**Files:**
+- Create: `apps/expo/src/components/EventSaversDialog.tsx`
+- Test: `apps/expo/src/components/__tests__/EventSaversDialog.test.tsx`
+
+**Approach:**
+- React Native `Modal` with `presentationStyle="pageSheet"` and `animationType="slide"` (follow `FollowedListsModal` pattern)
+- Props: `visible`, `onClose`, `eventId`, `creator`, `savers`, `lists` (non-personal, pre-filtered), `currentUserId`
+- Two sections rendered in a `ScrollView` or `SectionList`:
+  - **"Saved By"**: Creator first (with "Captured" label + visual emphasis), then savers (with "Saved" label). Each row: `UserProfileFlair`-wrapped avatar + full display name + role label. Tappable → dismiss dialog then navigate to profile.
+  - **"Appears On"**: Non-personal lists passed as prop. Each row: list icon + list name (tappable → dismiss then navigate to list view) + share button (triggers `Share.share()` for list URL). If empty, hide the section entirely.
+- "Done" button in header to dismiss
+- Swipe-to-dismiss handled natively by `pageSheet` presentation
+
+**Patterns to follow:**
+- `apps/expo/src/components/FollowedListsModal.tsx` — modal structure, header, FlatList, dismiss-before-navigate pattern
+- `apps/expo/src/components/UserEventsList.tsx` lines 255-314 — expanded saver row rendering (avatar + name)
+- `apps/expo/src/hooks/useEventActions.ts` — share event pattern
+- `apps/expo/src/components/FollowedListsModal.tsx` `handleShareList()` — share list pattern
+
+**Test scenarios:**
+- Happy path: Dialog renders with 2 savers + 2 lists, both sections visible
+- Happy path: Tapping user name dismisses dialog and navigates to profile route
+- Happy path: Tapping list name dismisses dialog and navigates to list route
+- Happy path: Share button triggers `Share.share()` with list URL
+- Edge case: No lists (empty lists prop) — "Appears On" section hidden entirely
+- Edge case: Creator is the only saver — "Saved By" shows just one row with "Captured"
+- Edge case: Creator is current user — profile tap goes to settings instead
+
+**Verification:**
+- Dialog opens as pageSheet with slide animation
+- Both sections render correctly
+- All tap targets navigate correctly after dismissing dialog
+- Share works for lists
+- Swipe-to-dismiss and Done button both close the dialog
+
+---
+
+- [ ] **Unit 2: Refactor `EventSaversRow` for two-tier display**
+
+**Goal:** Replace the current inline expand/collapse with the two-tier display: rich inline (≤2 items) with linked names/lists, overflow row (>2 items) that opens the dialog.
+
+**Requirements:** R1, R2, R3, R4, R5, R18
+
+**Dependencies:** Unit 1 (EventSaversDialog)
+
+**Files:**
+- Modify: `apps/expo/src/components/UserEventsList.tsx` (EventSaversRow component, lines 75-315)
+- Test: `apps/expo/src/components/__tests__/UserEventsList.test.tsx`
+
+**Approach:**
+- Remove the `isExpanded` state and inline expanded view (lines 92, 255-314)
+- Add `lists` (full list docs from event data) to component props
+- Compute client-side: `nonPersonalLists = lists.filter(l => !l.isSystemList)`, `listCount = nonPersonalLists.length`, `itemCount = allUsers.length + listCount`
+- **Rich inline (itemCount ≤ 2):**
+  - Show all users with tappable names (navigate to profile)
+  - If 1 non-personal list: show tappable list name (navigate to list view)
+  - Creator shows "Captured" label with visual emphasis
+  - Others show "Saved" label
+- **Overflow (itemCount > 2):**
+  - Show up to 2 names + "+N more" for extra people
+  - Show "· N lists" count or single list name if only 1
+  - Entire row tappable → opens `EventSaversDialog`
+- Add `visible` state for dialog, render `EventSaversDialog` conditionally with `nonPersonalLists` passed as prop
+- For 1 saver with 0 lists (itemCount=1): keep current simple display (no dialog trigger)
+- **Fallback:** If `lists` is undefined/null, treat as empty array (listCount=0)
+
+**Patterns to follow:**
+- Current `EventSaversRow` avatar stacking and name rendering (preserve visual style)
+- `renderTappableName()` helper (line 119-133) — extend for list name tapping
+
+**Test scenarios:**
+- Happy path: 1 person + 0 lists (itemCount=1) → simple inline, no dialog trigger
+- Happy path: 1 person + 1 list (itemCount=2) → rich inline with linked name + linked list
+- Happy path: 2 people + 1 list (itemCount=3) → overflow row: "Jaron, Sarah via Portland Events" tappable
+- Happy path: 3 people + 2 lists (itemCount=5) → overflow: "Jaron, Sarah +1 more · 2 lists" tappable
+- Happy path: Tapping overflow row opens EventSaversDialog
+- Edge case: Creator is the current user → "Captured" label still shown, profile tap goes to settings
+- Edge case: 2 people + 0 lists (itemCount=2) → rich inline, names only, no list reference
+- Edge case: `lists` prop is undefined → treated as 0 lists
+- Edge case: List has `isSystemList: undefined` → treated as non-system (shown)
+- Integration: Dialog receives correct props (creator, savers, nonPersonalLists)
+
+**Verification:**
+- Inline displays correctly for all threshold cases
+- Overflow triggers dialog
+- Names and lists are tappable with correct navigation
+- No more inline expand/collapse behavior
+
+---
+
+- [ ] **Unit 3: Wire up data flow from feed to components**
+
+**Goal:** Pass `event.lists` from the feed query through to `EventSaversRow`.
+
+**Requirements:** R1, R5, R17
+
+**Dependencies:** Unit 2 (refactored EventSaversRow)
+
+**Files:**
+- Modify: `apps/expo/src/components/UserEventsList.tsx` (UserEventListItem props, data extraction)
+- Modify: `apps/expo/src/app/(tabs)/feed/index.tsx` (if feed screen needs adjustment)
+- Modify: `apps/expo/src/app/(tabs)/discover.tsx` (if discover screen needs adjustment)
+
+**Approach:**
+- Add `lists` to `UserEventListItem` props (type: array of list docs)
+- Extract `lists` from the event data (already returned by `getEventById()`)
+- Pass through to `EventSaversRow`
+- Verify all feed screens (My Scene, Discover, profile/following) pass the data correctly
+- The `sourceListName` prop can be kept for backward compatibility or deprecated in favor of computing from `lists`
+
+**Patterns to follow:**
+- Current `sourceListName` extraction pattern in `UserEventListItem` (line 1242-1243)
+- How `eventFollows` / `savers` are currently passed through
+
+**Test scenarios:**
+- Happy path: `event.lists` flows from feed data → UserEventListItem → EventSaversRow
+- Happy path: All feed screens (feed, discover, following) pass lists correctly
+- Edge case: `event.lists` undefined/null → treated as empty array
+- Edge case: Grouped feed events also receive lists data
+
+**Verification:**
+- The two-tier display works correctly across all feed screens
+- No regressions in existing event card behavior
+
+## System-Wide Impact
+
+- **Interaction graph:** `EventSaversRow` → new `EventSaversDialog`. No new backend queries — uses existing `getEventById()` data.
+- **Error propagation:** No new failure modes — all data is already fetched by the feed query. If `lists` is missing, degrade gracefully (listCount=0).
+- **State lifecycle risks:** Dialog uses data already in memory (no lazy loading). No cache coherence issues.
+- **API surface parity:** Web event cards are out of scope. No shared API changes.
+- **Unchanged invariants:** Current event saving, following, and list management behavior is not modified. Backend is untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `event.lists` might not be passed through all feed screen paths | Verify data flow in discover, feed, and following screens during Unit 3 |
+| Overflow copy gets too long for narrow screens | Truncate with ellipsis; test on small devices |
+| `isSystemList` is `v.optional(v.boolean())` — undefined vs false | Treat both undefined and false as "not system" (show in "Appears On") |
+| Dialog navigation + dismiss timing | Follow `FollowedListsModal` pattern: dismiss first, then navigate |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md](docs/brainstorms/2026-04-08-event-savers-dialog-requirements.md)
+- Related code: `apps/expo/src/components/UserEventsList.tsx`, `apps/expo/src/components/FollowedListsModal.tsx`
+- Related code: `packages/backend/convex/model/events.ts` (`getEventById` line 554+), `packages/backend/convex/feeds.ts`


### PR DESCRIPTION
## Summary

- Add `EventSaversDialog` — pageSheet modal with "Saved By" and "Appears On" sections
- Refactor `EventSaversRow` — two-tier display: rich inline (≤2 items) with linked names/lists, overflow (>2 items) opens dialog
- Wire `event.lists` from existing feed data through to components — zero backend changes

## Details

When multiple people save an event, the current inline display shows truncated names with no linked lists. This PR replaces the expand/collapse pattern with:

**Rich inline (≤2 items):** Shows tappable user names → profile, tappable list names → list view. Creator shows "Captured" label.

**Overflow dialog (>2 items):** Names + "+N more" + "· N lists" → opens pageSheet with:
- "Saved By" section: creator first with "Captured" emphasis, others show "Saved"
- "Appears On" section: non-personal lists with share buttons

Key discovery during planning: `getEventById()` already returns full list data, so this is entirely frontend — no new Convex queries needed.

## Test plan

- [ ] Verify rich inline displays correctly for 1 person + 1 list
- [ ] Verify overflow row shows for 2+ people or multiple lists
- [ ] Verify tapping overflow opens pageSheet dialog
- [ ] Verify "Saved By" section shows correct labels (Captured vs Saved)
- [ ] Verify "Appears On" shows non-personal lists with share buttons
- [ ] Verify navigation: tap user → profile, tap list → list view
- [ ] Verify share button works on list rows
- [ ] Verify swipe-to-dismiss and Done button close dialog

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — frontend-only UI change with no new API calls or data mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-tier savers display to Expo cards and a new pageSheet dialog. Inline shows up to two names/lists; overflow opens an “Event Savers” dialog with clear people and list context.

- **New Features**
  - `EventSaversDialog` (pageSheet): “Saved By” (creator first, labeled “Captured”; others “Saved”) and “Appears On” (non‑personal lists) with share buttons. Tappable names → profiles; lists → list view; Done and swipe-to-dismiss.
  - Rich inline row (≤2 items): tappable names and a single linked “via [List]”. For overflow (>2), show up to 2 names, “+N more”, and “· N lists”; tapping opens the dialog.

- **Bug Fixes**
  - Feed and Following screens no longer strip `event.eventFollows` and `event.lists`, ensuring the two-tier display and dialog have the data they need.

<sup>Written for commit 94b02d43fc619e6910caec0f23494bc670f4ce9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Event Savers Dialog to view all users who saved an event and lists where it appears.
  * Redesigned event savers display with intelligent two-tier UI: shows inline details for events with few savers, opens a modal when there are many.
  * Added ability to share event lists directly from the Event Savers dialog with one-tap profile navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->