### PR TITLE
feat: add worktree lifecycle scripts for isolated parallel development

### DIFF
--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -5,7 +5,12 @@ set -euo pipefail
 # Tears down a worktree session: kills processes, deletes Convex deployment, removes worktree.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CURRENT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve to main worktree (first entry is always the main repo)
+REPO_ROOT="$(git -C "$CURRENT_ROOT" worktree list --porcelain | head -1 | sed 's/worktree //')"
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$CURRENT_ROOT"
+fi
 
 usage() {
   echo "Usage: bin/worktree-down <name> [--keep-deployment]"
@@ -106,32 +111,32 @@ else
     echo "--- SAFETY: deployment '$DEPLOYMENT' matches the main repo's deployment."
     echo "   Refusing to delete the main deployment."
     DEPLOYMENT=""
-  fi
-
-  echo "--- Deleting Convex deployment: $DEPLOYMENT"
-  # Source token from the worktree's .env.local
-  CONVEX_TEAM_ACCESS_TOKEN=$(grep '^CONVEX_TEAM_ACCESS_TOKEN=' "$WT_ENV" 2>/dev/null | cut -d= -f2- | sed 's/"//g' || true)
-
-  if [[ -n "$CONVEX_TEAM_ACCESS_TOKEN" ]]; then
-    # Slug is the part after "dev:" prefix
-    DEPLOYMENT_SLUG="${DEPLOYMENT#dev:}"
-    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-      -X POST "https://api.convex.dev/v1/deployments/${DEPLOYMENT_SLUG}/delete" \
-      -H "Authorization: Bearer $CONVEX_TEAM_ACCESS_TOKEN" \
-      2>/dev/null || echo "000")
-
-    if [[ "$HTTP_STATUS" == "200" ]]; then
-      echo "  Convex deployment deleted successfully."
-      CONVEX_DELETED=true
-    else
-      echo "  Warning: Convex API returned HTTP $HTTP_STATUS."
-      echo "  You may need to delete the deployment manually."
-      echo "  Dashboard: https://dashboard.convex.dev"
-    fi
   else
-    echo "  CONVEX_TEAM_ACCESS_TOKEN not set — cannot delete deployment via API."
-    echo "  Please delete '$DEPLOYMENT' manually:"
-    echo "  https://dashboard.convex.dev"
+    echo "--- Deleting Convex deployment: $DEPLOYMENT"
+    # Source token from the worktree's .env.local
+    CONVEX_TEAM_ACCESS_TOKEN=$(grep '^CONVEX_TEAM_ACCESS_TOKEN=' "$WT_ENV" 2>/dev/null | cut -d= -f2- | sed 's/"//g' || true)
+
+    if [[ -n "$CONVEX_TEAM_ACCESS_TOKEN" ]]; then
+      # Slug is the part after "dev:" prefix
+      DEPLOYMENT_SLUG="${DEPLOYMENT#dev:}"
+      HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST "https://api.convex.dev/v1/deployments/${DEPLOYMENT_SLUG}/delete" \
+        -H "Authorization: Bearer $CONVEX_TEAM_ACCESS_TOKEN" \
+        2>/dev/null || echo "000")
+
+      if [[ "$HTTP_STATUS" == "200" ]]; then
+        echo "  Convex deployment deleted successfully."
+        CONVEX_DELETED=true
+      else
+        echo "  Warning: Convex API returned HTTP $HTTP_STATUS."
+        echo "  You may need to delete the deployment manually."
+        echo "  Dashboard: https://dashboard.convex.dev"
+      fi
+    else
+      echo "  CONVEX_TEAM_ACCESS_TOKEN not set — cannot delete deployment via API."
+      echo "  Please delete '$DEPLOYMENT' manually:"
+      echo "  https://dashboard.convex.dev"
+    fi
   fi
 fi
 

--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: bin/worktree-down <name> [--keep-deployment]
+# Tears down a worktree session: kills processes, deletes Convex deployment, removes worktree.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  echo "Usage: bin/worktree-down <name> [--keep-deployment]"
+  echo ""
+  echo "Tears down a parallel dev environment created by worktree-up:"
+  echo "  - Kills dev processes running from the worktree"
+  echo "  - Deletes the Convex dev deployment (requires CONVEX_TEAM_ACCESS_TOKEN)"
+  echo "  - Removes the git worktree and branch"
+  echo ""
+  echo "Options:"
+  echo "  --keep-deployment   Skip Convex deployment deletion"
+  exit 1
+}
+
+# --- Parse args ---
+NAME=""
+KEEP_DEPLOYMENT=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-deployment) KEEP_DEPLOYMENT=true; shift ;;
+    --help|-h) usage ;;
+    -*) echo "Unknown option: $1"; usage ;;
+    *) NAME="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "Error: worktree name is required."
+  usage
+fi
+
+WT_PATH="$REPO_ROOT/.claude/worktrees/$NAME"
+BRANCH="$NAME"
+
+if [[ ! -d "$WT_PATH" ]]; then
+  echo "Error: worktree not found at $WT_PATH"
+  exit 1
+fi
+
+echo "==> Tearing down worktree '$NAME' at $WT_PATH"
+
+# --- 1. Kill dev server processes ---
+echo "--- Killing dev processes..."
+WT_ENV="$WT_PATH/.env.local"
+
+if [[ -f "$WT_ENV" ]]; then
+  # Kill processes on the worktree's Next.js port
+  WT_PORT=$(grep '^PORT=' "$WT_ENV" | tail -1 | cut -d= -f2- | sed 's/"//g' || true)
+  if [[ -n "$WT_PORT" ]]; then
+    PORT_PID=$(lsof -ti :"$WT_PORT" 2>/dev/null || true)
+    if [[ -n "$PORT_PID" ]]; then
+      echo "  Killing process on Next.js port $WT_PORT (PID: $PORT_PID)"
+      kill "$PORT_PID" 2>/dev/null || true
+    fi
+  fi
+
+  # Kill processes on the worktree's Expo port
+  WT_EXPO_PORT=$(grep '^EXPO_PORT=' "$WT_ENV" | tail -1 | cut -d= -f2- | sed 's/"//g' || true)
+  if [[ -n "$WT_EXPO_PORT" ]]; then
+    EXPO_PID=$(lsof -ti :"$WT_EXPO_PORT" 2>/dev/null || true)
+    if [[ -n "$EXPO_PID" ]]; then
+      echo "  Killing process on Expo port $WT_EXPO_PORT (PID: $EXPO_PID)"
+      kill "$EXPO_PID" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# Kill node/convex processes whose CWD is inside the worktree
+PIDS=$(lsof +D "$WT_PATH" 2>/dev/null | awk 'NR>1{print $1, $2}' | grep -iE '^(node|bun|next|convex|expo)' | awk '{print $2}' | sort -u || true)
+if [[ -n "$PIDS" ]]; then
+  echo "  Killing dev PIDs: $PIDS"
+  echo "$PIDS" | xargs kill 2>/dev/null || true
+  sleep 1
+  echo "$PIDS" | xargs kill -9 2>/dev/null || true
+else
+  echo "  No dev processes found."
+fi
+
+# --- 2. Delete Convex deployment ---
+DEPLOYMENT=""
+CONVEX_DELETED=false
+
+if [[ -f "$WT_ENV" ]]; then
+  # Extract deployment name, stripping double quotes and trailing comments
+  DEPLOYMENT=$(grep '^CONVEX_DEPLOYMENT=' "$WT_ENV" | tail -1 | cut -d= -f2- | sed 's/"//g; s/ *#.*//')
+fi
+
+if [[ "$KEEP_DEPLOYMENT" == "true" ]]; then
+  echo "--- Skipping Convex deployment deletion (--keep-deployment)"
+elif [[ -z "$DEPLOYMENT" ]]; then
+  echo "--- No CONVEX_DEPLOYMENT found in .env.local, skipping deletion."
+else
+  # Production safeguard: refuse to delete non-dev deployments
+  if [[ ! "$DEPLOYMENT" =~ ^dev: ]]; then
+    echo "ERROR: Deployment '$DEPLOYMENT' does not start with 'dev:' prefix."
+    echo "Refusing to delete what may be a production deployment."
+    echo "If this is safe to delete, do it manually at https://dashboard.convex.dev"
+    exit 1
+  fi
+
+  echo "--- Deleting Convex deployment: $DEPLOYMENT"
+  # Source token from the worktree's .env.local
+  CONVEX_TEAM_ACCESS_TOKEN=$(grep '^CONVEX_TEAM_ACCESS_TOKEN=' "$WT_ENV" 2>/dev/null | cut -d= -f2- | sed 's/"//g' || true)
+
+  if [[ -n "$CONVEX_TEAM_ACCESS_TOKEN" ]]; then
+    # Slug is the part after "dev:" prefix
+    DEPLOYMENT_SLUG="${DEPLOYMENT#dev:}"
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+      -X POST "https://api.convex.dev/v1/deployments/${DEPLOYMENT_SLUG}/delete" \
+      -H "Authorization: Bearer $CONVEX_TEAM_ACCESS_TOKEN" \
+      2>/dev/null || echo "000")
+
+    if [[ "$HTTP_STATUS" == "200" ]]; then
+      echo "  Convex deployment deleted successfully."
+      CONVEX_DELETED=true
+    else
+      echo "  Warning: Convex API returned HTTP $HTTP_STATUS."
+      echo "  You may need to delete the deployment manually."
+      echo "  Dashboard: https://dashboard.convex.dev"
+    fi
+  else
+    echo "  CONVEX_TEAM_ACCESS_TOKEN not set — cannot delete deployment via API."
+    echo "  Please delete '$DEPLOYMENT' manually:"
+    echo "  https://dashboard.convex.dev"
+  fi
+fi
+
+# --- 3. Remove worktree ---
+echo "--- Removing git worktree..."
+cd "$REPO_ROOT"
+git worktree remove "$WT_PATH" --force
+
+# --- 4. Clean up branch ---
+echo "--- Cleaning up branch..."
+if git rev-parse --verify "$BRANCH" &>/dev/null; then
+  git branch -D "$BRANCH" 2>/dev/null || echo "  Could not delete branch $BRANCH (may need manual cleanup)"
+else
+  echo "  Branch $BRANCH not found (already cleaned up)"
+fi
+
+# --- 5. Print summary ---
+echo ""
+echo "============================================="
+echo " Worktree '$NAME' torn down."
+echo "============================================="
+echo ""
+echo " Worktree removed:  $WT_PATH"
+echo " Branch deleted:    $BRANCH"
+if [[ "$KEEP_DEPLOYMENT" == "true" ]]; then
+  echo " Convex deployment: KEPT ($DEPLOYMENT)"
+elif [[ "$CONVEX_DELETED" == "true" ]]; then
+  echo " Convex deployment: DELETED ($DEPLOYMENT)"
+elif [[ -n "$DEPLOYMENT" ]]; then
+  echo " Convex deployment: NEEDS MANUAL DELETION ($DEPLOYMENT)"
+  echo "                    https://dashboard.convex.dev"
+else
+  echo " Convex deployment: N/A"
+fi
+echo "============================================="

--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -43,12 +43,15 @@ if [[ -z "$NAME" ]]; then
 fi
 
 WT_PATH="$REPO_ROOT/.claude/worktrees/$NAME"
-BRANCH="$NAME"
+BRANCH=""
 
 if [[ ! -d "$WT_PATH" ]]; then
   echo "Error: worktree not found at $WT_PATH"
   exit 1
 fi
+
+# Read the actual checked-out branch before removing the worktree.
+BRANCH=$(git -C "$WT_PATH" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
 echo "==> Tearing down worktree '$NAME' at $WT_PATH"
 
@@ -147,7 +150,9 @@ git worktree remove "$WT_PATH" --force
 
 # --- 4. Clean up branch ---
 echo "--- Cleaning up branch..."
-if git rev-parse --verify "$BRANCH" &>/dev/null; then
+if [[ -z "$BRANCH" ]]; then
+  echo "  No local branch checked out in worktree (detached HEAD or already unavailable)"
+elif git rev-parse --verify "$BRANCH" &>/dev/null; then
   git branch -D "$BRANCH" 2>/dev/null || echo "  Could not delete branch $BRANCH (may need manual cleanup)"
 else
   echo "  Branch $BRANCH not found (already cleaned up)"
@@ -160,7 +165,11 @@ echo " Worktree '$NAME' torn down."
 echo "============================================="
 echo ""
 echo " Worktree removed:  $WT_PATH"
-echo " Branch deleted:    $BRANCH"
+if [[ -n "$BRANCH" ]]; then
+  echo " Branch deleted:    $BRANCH"
+else
+  echo " Branch deleted:    N/A"
+fi
 if [[ "$KEEP_DEPLOYMENT" == "true" ]]; then
   echo " Convex deployment: KEPT ($DEPLOYMENT)"
 elif [[ "$CONVEX_DELETED" == "true" ]]; then

--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -97,13 +97,15 @@ if [[ "$KEEP_DEPLOYMENT" == "true" ]]; then
   echo "--- Skipping Convex deployment deletion (--keep-deployment)"
 elif [[ -z "$DEPLOYMENT" ]]; then
   echo "--- No CONVEX_DEPLOYMENT found in .env.local, skipping deletion."
+elif [[ "$DEPLOYMENT" != dev:* ]]; then
+  echo "--- SAFETY: deployment '$DEPLOYMENT' is not a dev deployment. Refusing to delete."
 else
-  # Production safeguard: refuse to delete non-dev deployments
-  if [[ ! "$DEPLOYMENT" =~ ^dev: ]]; then
-    echo "ERROR: Deployment '$DEPLOYMENT' does not start with 'dev:' prefix."
-    echo "Refusing to delete what may be a production deployment."
-    echo "If this is safe to delete, do it manually at https://dashboard.convex.dev"
-    exit 1
+  # Safety: refuse to delete the main repo's deployment
+  MAIN_DEPLOYMENT=$(grep '^CONVEX_DEPLOYMENT=' "$REPO_ROOT/.env.local" 2>/dev/null | cut -d= -f2- | sed 's/"//g; s/ *#.*//' || true)
+  if [[ "$DEPLOYMENT" == "$MAIN_DEPLOYMENT" ]]; then
+    echo "--- SAFETY: deployment '$DEPLOYMENT' matches the main repo's deployment."
+    echo "   Refusing to delete the main deployment."
+    DEPLOYMENT=""
   fi
 
   echo "--- Deleting Convex deployment: $DEPLOYMENT"

--- a/bin/worktree-list
+++ b/bin/worktree-list
@@ -5,7 +5,12 @@ set -euo pipefail
 # Lists all worktrees created by worktree-up with their port assignments and Convex deployments.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CURRENT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Resolve to main worktree (first entry is always the main repo)
+REPO_ROOT="$(git -C "$CURRENT_ROOT" worktree list --porcelain | head -1 | sed 's/worktree //')"
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT="$CURRENT_ROOT"
+fi
 
 usage() {
   echo "Usage: bin/worktree-list"
@@ -37,8 +42,8 @@ if [[ ${#WT_DIRS[@]} -eq 0 ]]; then
 fi
 
 # Print header
-printf "%-25s %-25s %-10s %-12s %s\n" "NAME" "BRANCH" "NEXT.JS" "EXPO" "CONVEX DEPLOYMENT"
-printf "%-25s %-25s %-10s %-12s %s\n" "----" "------" "-------" "----" "-----------------"
+printf "%-25s %-25s %-10s %-12s %-16s %s\n" "NAME" "BRANCH" "NEXT.JS" "EXPO" "PROCESS STATUS" "CONVEX DEPLOYMENT"
+printf "%-25s %-25s %-10s %-12s %-16s %s\n" "----" "------" "-------" "----" "--------------" "-----------------"
 
 for wt_dir in "${WT_DIRS[@]}"; do
   if [[ ! -d "$wt_dir" ]]; then
@@ -58,10 +63,19 @@ for wt_dir in "${WT_DIRS[@]}"; do
     deployment=""
   fi
 
-  printf "%-25s %-25s %-10s %-12s %s\n" \
+  # Check process status by probing the Next.js and Expo ports
+  status="stopped"
+  if [[ -n "$port" ]] && lsof -ti :"$port" >/dev/null 2>&1; then
+    status="running"
+  elif [[ -n "$expo_port" ]] && lsof -ti :"$expo_port" >/dev/null 2>&1; then
+    status="running"
+  fi
+
+  printf "%-25s %-25s %-10s %-12s %-16s %s\n" \
     "$name" \
     "$branch" \
     "${port:-N/A}" \
     "${expo_port:-N/A}" \
+    "$status" \
     "${deployment:-N/A}"
 done

--- a/bin/worktree-list
+++ b/bin/worktree-list
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: bin/worktree-list
+# Lists all worktrees created by worktree-up with their port assignments and Convex deployments.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  echo "Usage: bin/worktree-list"
+  echo ""
+  echo "Lists all worktrees in .claude/worktrees/ with their port assignments"
+  echo "and Convex deployment information."
+  exit 1
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+fi
+
+WT_BASE="$REPO_ROOT/.claude/worktrees"
+
+if [[ ! -d "$WT_BASE" ]]; then
+  echo "No worktrees found."
+  exit 0
+fi
+
+# Check if any worktree directories exist
+shopt -s nullglob
+WT_DIRS=("$WT_BASE"/*)
+shopt -u nullglob
+
+if [[ ${#WT_DIRS[@]} -eq 0 ]]; then
+  echo "No worktrees found."
+  exit 0
+fi
+
+# Print header
+printf "%-25s %-25s %-10s %-12s %s\n" "NAME" "BRANCH" "NEXT.JS" "EXPO" "CONVEX DEPLOYMENT"
+printf "%-25s %-25s %-10s %-12s %s\n" "----" "------" "-------" "----" "-----------------"
+
+for wt_dir in "${WT_DIRS[@]}"; do
+  if [[ ! -d "$wt_dir" ]]; then
+    continue
+  fi
+
+  name=$(basename "$wt_dir")
+  branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "N/A")
+
+  if [[ -f "$wt_dir/.env.local" ]]; then
+    port=$(grep '^PORT=' "$wt_dir/.env.local" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/"//g' || true)
+    expo_port=$(grep '^EXPO_PORT=' "$wt_dir/.env.local" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/"//g' || true)
+    deployment=$(grep '^CONVEX_DEPLOYMENT=' "$wt_dir/.env.local" 2>/dev/null | tail -1 | cut -d= -f2- | sed 's/"//g; s/ *#.*//' || true)
+  else
+    port=""
+    expo_port=""
+    deployment=""
+  fi
+
+  printf "%-25s %-25s %-10s %-12s %s\n" \
+    "$name" \
+    "$branch" \
+    "${port:-N/A}" \
+    "${expo_port:-N/A}" \
+    "${deployment:-N/A}"
+done

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -6,19 +6,16 @@ set -euo pipefail
 # Expo port, and environment configuration.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Find .env.local: try this repo first, then the main worktree
+# Always resolve to the main worktree root (not a worktree we may be running from)
+MAIN_WORKTREE=$(git -C "$SCRIPT_DIR" worktree list --porcelain | head -1 | sed 's/worktree //')
+REPO_ROOT="${MAIN_WORKTREE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Find .env.local from main worktree root
 MAIN_ENV="$REPO_ROOT/.env.local"
-if [[ ! -f "$MAIN_ENV" ]]; then
-  MAIN_WORKTREE=$(git -C "$REPO_ROOT" worktree list --porcelain | head -1 | sed 's/worktree //')
-  if [[ -n "$MAIN_WORKTREE" && -f "$MAIN_WORKTREE/.env.local" ]]; then
-    MAIN_ENV="$MAIN_WORKTREE/.env.local"
-  fi
-fi
 
 # Find packages/backend/.env.local from main repo
-MAIN_BACKEND_ENV="$(dirname "$MAIN_ENV")/packages/backend/.env.local"
+MAIN_BACKEND_ENV="$REPO_ROOT/packages/backend/.env.local"
 
 usage() {
   echo "Usage: bin/worktree-up <name> [--branch BRANCH] [--port PORT] [--expo-port PORT] [--no-data]"
@@ -74,7 +71,7 @@ if [[ -n "$BRANCH_REF" ]]; then
   git -C "$REPO_ROOT" fetch origin "$BRANCH_REF" 2>/dev/null || true
 
   # Check if this branch is already checked out in another worktree
-  EXISTING_WT=$(git -C "$REPO_ROOT" worktree list --porcelain | grep -B1 "branch refs/heads/$BRANCH_REF" | head -1 | sed 's/worktree //' || true)
+  EXISTING_WT=$(git -C "$REPO_ROOT" worktree list --porcelain | grep -B2 "branch refs/heads/$BRANCH_REF" | head -1 | sed 's/worktree //' || true)
   if [[ -n "$EXISTING_WT" ]]; then
     echo "Error: branch '$BRANCH_REF' is already checked out at: $EXISTING_WT"
     echo "Close that worktree first (bin/worktree-down), or use the existing one."
@@ -133,7 +130,7 @@ echo "--- Creating git worktree..."
 cd "$REPO_ROOT"
 if [[ -n "$BRANCH_REF" ]]; then
   # Check out existing branch (e.g. a PR branch)
-  git worktree add "$WT_PATH" -b "$NAME" "origin/$BRANCH_REF"
+  git worktree add "$WT_PATH" "$BRANCH_REF"
   BRANCH="$BRANCH_REF"
 else
   # Create new branch from HEAD
@@ -166,8 +163,10 @@ npx convex deployment create "dev/wt-$NAME" --type dev --select
 
 # Extract new values from packages/backend/.env.local (last occurrence wins)
 BACKEND_ENV="$WT_PATH/packages/backend/.env.local"
-NEW_DEPLOYMENT=$(tail -r "$BACKEND_ENV" | grep -m1 '^CONVEX_DEPLOYMENT=' | cut -d= -f2- | sed 's/"//g' | sed 's/ *#.*//')
-NEW_URL=$(tail -r "$BACKEND_ENV" | grep -m1 '^CONVEX_URL=' | cut -d= -f2- | sed 's/"//g')
+# Use awk to reverse lines (portable across macOS and Linux, unlike tail -r or tac)
+_reverse() { awk '{a[NR]=$0} END {for(i=NR;i>=1;i--) print a[i]}' "$1"; }
+NEW_DEPLOYMENT=$(_reverse "$BACKEND_ENV" | grep -m1 '^CONVEX_DEPLOYMENT=' | cut -d= -f2- | sed 's/"//g' | sed 's/ *#.*//')
+NEW_URL=$(_reverse "$BACKEND_ENV" | grep -m1 '^CONVEX_URL=' | cut -d= -f2- | sed 's/"//g')
 
 # Clean up backend .env.local: remove old values, keep only new ones
 sed -i.bak '/^CONVEX_DEPLOYMENT=/d; /^CONVEX_URL=/d' "$BACKEND_ENV" && rm -f "${BACKEND_ENV}.bak"
@@ -203,8 +202,8 @@ if [[ -n "$TEAM_TOKEN" && -n "$DEPLOYMENT_SLUG" ]]; then
     -H "Authorization: Bearer $TEAM_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"name\": \"wt-$NAME\"}")
-  DEPLOY_KEY=$(echo "$DEPLOY_KEY_RESPONSE" | sed 's/.*"deployKey":"\([^"]*\)".*/\1/')
-  if [[ -n "$DEPLOY_KEY" && "$DEPLOY_KEY" != "$DEPLOY_KEY_RESPONSE" ]]; then
+  DEPLOY_KEY=$(echo "$DEPLOY_KEY_RESPONSE" | jq -r '.deployKey // empty')
+  if [[ -n "$DEPLOY_KEY" ]]; then
     echo "" >> "$WT_ENV"
     echo "# Deploy key pins all convex CLI commands to this specific deployment" >> "$WT_ENV"
     echo "CONVEX_DEPLOY_KEY=$DEPLOY_KEY" >> "$WT_ENV"

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: bin/worktree-up <name> [--port PORT] [--expo-port PORT] [--no-data]
+# Usage: bin/worktree-up <name> [--branch BRANCH] [--port PORT] [--expo-port PORT] [--no-data]
 # Creates an isolated worktree with its own Convex dev deployment, Next.js port,
 # Expo port, and environment configuration.
 
@@ -21,7 +21,7 @@ fi
 MAIN_BACKEND_ENV="$(dirname "$MAIN_ENV")/packages/backend/.env.local"
 
 usage() {
-  echo "Usage: bin/worktree-up <name> [--port PORT] [--expo-port PORT] [--no-data]"
+  echo "Usage: bin/worktree-up <name> [--branch BRANCH] [--port PORT] [--expo-port PORT] [--no-data]"
   echo ""
   echo "Creates a parallel dev environment in a git worktree with:"
   echo "  - Isolated Convex dev deployment"
@@ -30,6 +30,7 @@ usage() {
   echo "  - Data snapshot from main deployment"
   echo ""
   echo "Options:"
+  echo "  --branch BRANCH   Check out an existing branch instead of creating a new one"
   echo "  --port PORT       Specify the Next.js dev server port (default: auto-assign)"
   echo "  --expo-port PORT  Specify the Expo dev server port (default: auto-assign)"
   echo "  --no-data         Skip data snapshot from main deployment"
@@ -45,8 +46,10 @@ NAME=""
 PORT=""
 EXPO_PORT=""
 NO_DATA=false
+BRANCH_REF=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --branch) BRANCH_REF="$2"; shift 2 ;;
     --port) PORT="$2"; shift 2 ;;
     --expo-port) EXPO_PORT="$2"; shift 2 ;;
     --no-data) NO_DATA=true; shift ;;
@@ -62,7 +65,24 @@ if [[ -z "$NAME" ]]; then
 fi
 
 WT_PATH="$REPO_ROOT/.claude/worktrees/$NAME"
-BRANCH="$NAME"
+
+# Determine branch: use --branch if provided, otherwise create new branch from HEAD
+if [[ -n "$BRANCH_REF" ]]; then
+  BRANCH="$BRANCH_REF"
+  # Fetch the branch from origin
+  echo "--- Fetching branch $BRANCH_REF from origin..."
+  git -C "$REPO_ROOT" fetch origin "$BRANCH_REF" 2>/dev/null || true
+
+  # Check if this branch is already checked out in another worktree
+  EXISTING_WT=$(git -C "$REPO_ROOT" worktree list --porcelain | grep -B1 "branch refs/heads/$BRANCH_REF" | head -1 | sed 's/worktree //' || true)
+  if [[ -n "$EXISTING_WT" ]]; then
+    echo "Error: branch '$BRANCH_REF' is already checked out at: $EXISTING_WT"
+    echo "Close that worktree first (bin/worktree-down), or use the existing one."
+    exit 1
+  fi
+else
+  BRANCH="$NAME"
+fi
 
 # --- Check preconditions ---
 if [[ -d "$WT_PATH" ]]; then
@@ -111,7 +131,14 @@ echo "==> Creating worktree '$NAME' at $WT_PATH (Next.js port $PORT, Expo port $
 # --- 1. Create worktree ---
 echo "--- Creating git worktree..."
 cd "$REPO_ROOT"
-git worktree add "$WT_PATH" -b "$BRANCH"
+if [[ -n "$BRANCH_REF" ]]; then
+  # Check out existing branch (e.g. a PR branch)
+  git worktree add "$WT_PATH" -b "$NAME" "origin/$BRANCH_REF"
+  BRANCH="$BRANCH_REF"
+else
+  # Create new branch from HEAD
+  git worktree add "$WT_PATH" -b "$BRANCH"
+fi
 
 # --- 2. Install dependencies ---
 echo "--- Installing dependencies..."

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: bin/worktree-up <name> [--port PORT] [--expo-port PORT] [--no-data]
+# Creates an isolated worktree with its own Convex dev deployment, Next.js port,
+# Expo port, and environment configuration.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Find .env.local: try this repo first, then the main worktree
+MAIN_ENV="$REPO_ROOT/.env.local"
+if [[ ! -f "$MAIN_ENV" ]]; then
+  MAIN_WORKTREE=$(git -C "$REPO_ROOT" worktree list --porcelain | head -1 | sed 's/worktree //')
+  if [[ -n "$MAIN_WORKTREE" && -f "$MAIN_WORKTREE/.env.local" ]]; then
+    MAIN_ENV="$MAIN_WORKTREE/.env.local"
+  fi
+fi
+
+# Find packages/backend/.env.local from main repo
+MAIN_BACKEND_ENV="$(dirname "$MAIN_ENV")/packages/backend/.env.local"
+
+usage() {
+  echo "Usage: bin/worktree-up <name> [--port PORT] [--expo-port PORT] [--no-data]"
+  echo ""
+  echo "Creates a parallel dev environment in a git worktree with:"
+  echo "  - Isolated Convex dev deployment"
+  echo "  - Unique Next.js port (auto-assigned from 3400+ if not specified)"
+  echo "  - Unique Expo port (auto-assigned from 8181+ if not specified)"
+  echo "  - Data snapshot from main deployment"
+  echo ""
+  echo "Options:"
+  echo "  --port PORT       Specify the Next.js dev server port (default: auto-assign)"
+  echo "  --expo-port PORT  Specify the Expo dev server port (default: auto-assign)"
+  echo "  --no-data         Skip data snapshot from main deployment"
+  echo ""
+  echo "Prerequisites:"
+  echo "  CONVEX_TEAM_ACCESS_TOKEN must be in .env.local for deploy key creation."
+  echo "  Get it from https://dashboard.convex.dev → Settings → Team Access Tokens."
+  exit 1
+}
+
+# --- Parse args ---
+NAME=""
+PORT=""
+EXPO_PORT=""
+NO_DATA=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --expo-port) EXPO_PORT="$2"; shift 2 ;;
+    --no-data) NO_DATA=true; shift ;;
+    --help|-h) usage ;;
+    -*) echo "Unknown option: $1"; usage ;;
+    *) NAME="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "Error: worktree name is required."
+  usage
+fi
+
+WT_PATH="$REPO_ROOT/.claude/worktrees/$NAME"
+BRANCH="$NAME"
+
+# --- Check preconditions ---
+if [[ -d "$WT_PATH" ]]; then
+  echo "Error: worktree path already exists: $WT_PATH"
+  exit 1
+fi
+
+if ! [[ -f "$MAIN_ENV" ]]; then
+  echo "Error: main repo .env.local not found at $MAIN_ENV"
+  echo "Please set up the main repo first."
+  exit 1
+fi
+
+# --- Auto-assign Next.js port if not specified ---
+if [[ -z "$PORT" ]]; then
+  PORT=3400
+  while IFS= read -r wt_line; do
+    wt_dir="${wt_line#worktree }"
+    if [[ -f "$wt_dir/.env.local" ]]; then
+      existing_port=$(grep -o '^PORT=[0-9]*' "$wt_dir/.env.local" 2>/dev/null | cut -d= -f2 || true)
+      if [[ -n "$existing_port" && "$existing_port" -ge "$PORT" ]]; then
+        PORT=$((existing_port + 1))
+      fi
+    fi
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain | grep '^worktree ')
+  echo "Auto-assigned Next.js port: $PORT"
+fi
+
+# --- Auto-assign Expo port if not specified ---
+if [[ -z "$EXPO_PORT" ]]; then
+  EXPO_PORT=8181
+  while IFS= read -r wt_line; do
+    wt_dir="${wt_line#worktree }"
+    if [[ -f "$wt_dir/.env.local" ]]; then
+      existing_port=$(grep -o '^EXPO_PORT=[0-9]*' "$wt_dir/.env.local" 2>/dev/null | cut -d= -f2 || true)
+      if [[ -n "$existing_port" && "$existing_port" -ge "$EXPO_PORT" ]]; then
+        EXPO_PORT=$((existing_port + 1))
+      fi
+    fi
+  done < <(git -C "$REPO_ROOT" worktree list --porcelain | grep '^worktree ')
+  echo "Auto-assigned Expo port: $EXPO_PORT"
+fi
+
+echo "==> Creating worktree '$NAME' at $WT_PATH (Next.js port $PORT, Expo port $EXPO_PORT, branch $BRANCH)"
+
+# --- 1. Create worktree ---
+echo "--- Creating git worktree..."
+cd "$REPO_ROOT"
+git worktree add "$WT_PATH" -b "$BRANCH"
+
+# --- 2. Install dependencies ---
+echo "--- Installing dependencies..."
+cd "$WT_PATH"
+pnpm install --ignore-scripts
+
+# --- 3. Seed .env.local from main repo ---
+echo "--- Seeding .env.local from main repo..."
+cp "$MAIN_ENV" "$WT_PATH/.env.local"
+WT_ENV="$WT_PATH/.env.local"
+
+# --- 4. Seed packages/backend/.env.local from main repo ---
+echo "--- Seeding packages/backend/.env.local..."
+if [[ -f "$MAIN_BACKEND_ENV" ]]; then
+  cp "$MAIN_BACKEND_ENV" "$WT_PATH/packages/backend/.env.local"
+else
+  echo "  Warning: main repo packages/backend/.env.local not found at $MAIN_BACKEND_ENV"
+  echo "  Convex CLI may not have project context."
+fi
+
+# --- 5. Create Convex deployment and pin it with a deploy key ---
+echo "--- Creating Convex dev deployment..."
+cd "$WT_PATH/packages/backend"
+npx convex deployment create "dev/wt-$NAME" --type dev --select
+
+# Extract new values from packages/backend/.env.local (last occurrence wins)
+BACKEND_ENV="$WT_PATH/packages/backend/.env.local"
+NEW_DEPLOYMENT=$(tail -r "$BACKEND_ENV" | grep -m1 '^CONVEX_DEPLOYMENT=' | cut -d= -f2- | sed 's/"//g' | sed 's/ *#.*//')
+NEW_URL=$(tail -r "$BACKEND_ENV" | grep -m1 '^CONVEX_URL=' | cut -d= -f2- | sed 's/"//g')
+
+# Clean up backend .env.local: remove old values, keep only new ones
+sed -i.bak '/^CONVEX_DEPLOYMENT=/d; /^CONVEX_URL=/d' "$BACKEND_ENV" && rm -f "${BACKEND_ENV}.bak"
+echo "CONVEX_DEPLOYMENT=$NEW_DEPLOYMENT" >> "$BACKEND_ENV"
+echo "CONVEX_URL=$NEW_URL" >> "$BACKEND_ENV"
+
+# --- 6. Propagate Convex vars to root .env.local ---
+echo "--- Updating root .env.local with new Convex deployment..."
+sed -i.bak '/^CONVEX_DEPLOYMENT=/d; /^NEXT_PUBLIC_CONVEX_URL=/d; /^EXPO_PUBLIC_CONVEX_URL=/d; /^CONVEX_URL=/d' "$WT_ENV" && rm -f "${WT_ENV}.bak"
+# Also remove double-quoted versions
+sed -i.bak '/^CONVEX_DEPLOYMENT="/d; /^NEXT_PUBLIC_CONVEX_URL="/d; /^EXPO_PUBLIC_CONVEX_URL="/d; /^CONVEX_URL="/d' "$WT_ENV" && rm -f "${WT_ENV}.bak"
+echo "" >> "$WT_ENV"
+echo "# Worktree Convex deployment" >> "$WT_ENV"
+echo "CONVEX_DEPLOYMENT=$NEW_DEPLOYMENT" >> "$WT_ENV"
+echo "NEXT_PUBLIC_CONVEX_URL=$NEW_URL" >> "$WT_ENV"
+echo "EXPO_PUBLIC_CONVEX_URL=$NEW_URL" >> "$WT_ENV"
+echo "CONVEX_URL=$NEW_URL" >> "$WT_ENV"
+
+# Extract deployment slug for deploy key creation
+DEPLOYMENT_SLUG=$(echo "$NEW_DEPLOYMENT" | sed 's/^dev://')
+
+# --- 7. Create deploy key ---
+TEAM_TOKEN=$(grep '^CONVEX_TEAM_ACCESS_TOKEN=' "$WT_ENV" 2>/dev/null | cut -d= -f2- | sed 's/"//g' || true)
+if [[ -z "$TEAM_TOKEN" ]]; then
+  # Also try without quotes prefix
+  TEAM_TOKEN=$(grep '^CONVEX_TEAM_ACCESS_TOKEN="' "$WT_ENV" 2>/dev/null | cut -d= -f2- | sed 's/"//g' || true)
+fi
+
+if [[ -n "$TEAM_TOKEN" && -n "$DEPLOYMENT_SLUG" ]]; then
+  echo "--- Creating deploy key to pin convex CLI to this deployment..."
+  DEPLOY_KEY_RESPONSE=$(curl -s -X POST \
+    "https://api.convex.dev/v1/deployments/$DEPLOYMENT_SLUG/create_deploy_key" \
+    -H "Authorization: Bearer $TEAM_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"wt-$NAME\"}")
+  DEPLOY_KEY=$(echo "$DEPLOY_KEY_RESPONSE" | sed 's/.*"deployKey":"\([^"]*\)".*/\1/')
+  if [[ -n "$DEPLOY_KEY" && "$DEPLOY_KEY" != "$DEPLOY_KEY_RESPONSE" ]]; then
+    echo "" >> "$WT_ENV"
+    echo "# Deploy key pins all convex CLI commands to this specific deployment" >> "$WT_ENV"
+    echo "CONVEX_DEPLOY_KEY=$DEPLOY_KEY" >> "$WT_ENV"
+    echo "  Deploy key created and saved to .env.local"
+  else
+    echo "  Warning: failed to create deploy key. convex dev may target the wrong deployment."
+    echo "  Response: $DEPLOY_KEY_RESPONSE"
+  fi
+else
+  echo "  Warning: missing CONVEX_TEAM_ACCESS_TOKEN or deployment slug, skipping deploy key."
+  echo "  Get a token from https://dashboard.convex.dev → Settings → Team Access Tokens."
+fi
+
+# --- 8. Set worktree ports ---
+echo "--- Setting worktree ports..."
+sed -i.bak '/^PORT=/d; /^EXPO_PORT=/d' "$WT_ENV" && rm -f "${WT_ENV}.bak"
+echo "" >> "$WT_ENV"
+echo "# Worktree ports" >> "$WT_ENV"
+echo "PORT=$PORT" >> "$WT_ENV"
+echo "EXPO_PORT=$EXPO_PORT" >> "$WT_ENV"
+
+# --- 9. Copy env vars from main Convex deployment to worktree deployment ---
+echo "--- Copying env vars from main deployment..."
+MAIN_BACKEND_DIR="$(dirname "$MAIN_ENV")/packages/backend"
+MAIN_ENV_VARS=$(cd "$MAIN_BACKEND_DIR" && npx convex env list 2>/dev/null || true)
+cd "$WT_PATH/packages/backend"
+if [[ -n "$MAIN_ENV_VARS" ]]; then
+  while IFS='=' read -r key value; do
+    if [[ -n "$key" && -n "$value" ]]; then
+      npx convex env set "$key" "$value" 2>/dev/null || echo "  Warning: failed to set $key"
+    fi
+  done <<< "$MAIN_ENV_VARS"
+  echo "  Env vars copied."
+else
+  echo "  Warning: could not read env vars from main deployment."
+fi
+
+# --- 10. Push schema, functions, and auth config to Convex ---
+echo "--- Pushing schema and functions to Convex deployment..."
+cd "$WT_PATH/packages/backend"
+npx convex dev --once
+
+# --- 11. Snapshot main deployment data into worktree ---
+if [[ "$NO_DATA" == "true" ]]; then
+  echo "--- Skipping data snapshot (--no-data)"
+else
+  echo "--- Exporting data from main deployment..."
+  SNAPSHOT_PATH="/tmp/convex-snapshot-$NAME.zip"
+  cd "$MAIN_BACKEND_DIR"
+  npx convex export --path "$SNAPSHOT_PATH"
+  echo "--- Importing data into worktree deployment..."
+  cd "$WT_PATH/packages/backend"
+  npx convex import --replace-all "$SNAPSHOT_PATH" -y
+  rm -f "$SNAPSHOT_PATH"
+fi
+
+# --- 12. Print summary ---
+DEPLOYMENT=$(grep '^CONVEX_DEPLOYMENT=' "$WT_ENV" | tail -1 | cut -d= -f2- | sed 's/"//g; s/ *#.*//')
+
+echo ""
+echo "============================================="
+echo " Worktree '$NAME' is ready!"
+echo "============================================="
+echo ""
+echo " Path:        $WT_PATH"
+echo " Branch:      $BRANCH"
+echo " Next.js:     port $PORT"
+echo " Expo:        port $EXPO_PORT"
+echo " Convex:      $DEPLOYMENT"
+echo ""
+echo " Start dev servers:"
+echo "   cd $WT_PATH"
+echo "   pnpm dev:backend                                              # Convex"
+echo "   cd apps/web && pnpm with-env next dev --turbopack --port $PORT  # Next.js"
+echo "   cd apps/expo && pnpm with-env expo start --port $EXPO_PORT     # Expo"
+echo ""
+echo " Tear down when done:"
+echo "   bin/worktree-down $NAME"
+echo "============================================="

--- a/docs/brainstorms/2026-04-08-worktree-scripts-requirements.md
+++ b/docs/brainstorms/2026-04-08-worktree-scripts-requirements.md
@@ -1,0 +1,146 @@
+---
+date: 2026-04-08
+topic: worktree-scripts
+---
+
+# Worktree Lifecycle Scripts for soonlist-turbo
+
+## Problem Frame
+
+Developers working on soonlist-turbo need isolated parallel environments for feature work, code review, and AI agent sessions. Today, worktrees are created ad-hoc without isolated Convex deployments, port management, or proper cleanup -- leading to port collisions, shared mutable backend state, and orphaned resources.
+
+The goal is three scripts (`bin/worktree-up`, `bin/worktree-down`, `bin/worktree-list`) that give each worktree a fully isolated dev stack: its own Convex deployment, unique Next.js and Expo ports, and clean teardown.
+
+Reference implementation: `~/ez-pilot-app/bin/worktree-up` and `~/ez-pilot-app/bin/worktree-down`.
+
+```
+                    bin/worktree-up <name>
+                           |
+          +----------------+----------------+
+          |                |                |
+    git worktree     pnpm install     copy .env.local
+     add (branch)                     from main repo
+          |                                 |
+          |                    create Convex dev deployment
+          |                    (dev/wt-NAME) + deploy key
+          |                                 |
+          |                    rewrite Convex vars in
+          |                    worktree .env.local
+          |                                 |
+          +----------------+----------------+
+                           |
+              auto-assign ports (Next.js 3400+,
+              Expo 8181+) scanning existing worktrees
+                           |
+              copy Convex env vars from main deployment
+                           |
+              push schema + functions (convex dev --once)
+                           |
+              snapshot data (export main -> import worktree)
+                           |
+              print summary: path, branch, ports,
+              Convex deployment, dev server commands
+
+
+                    bin/worktree-down <name>
+                           |
+          +----------------+----------------+
+          |                |                |
+    kill dev procs   delete Convex    remove worktree
+    (Next.js, Expo,  deployment via   + delete branch
+     Convex on       API (curl)
+     assigned ports)
+          |
+    print teardown summary
+
+
+                    bin/worktree-list
+                           |
+              scan .claude/worktrees/*/
+              read each .env.local for ports + deployment
+              show table: name, branch, ports, Convex slug
+```
+
+## Requirements
+
+**Worktree Creation (`bin/worktree-up`)**
+
+- R1. Create a git worktree at `REPO_ROOT/.claude/worktrees/NAME` on a new branch `NAME`
+- R2. Run `pnpm install` in the worktree (use `--ignore-scripts` to avoid hook failures in worktrees)
+- R3. Copy `.env.local` from the main repo root (resolve via `git worktree list --porcelain` if running from a worktree)
+- R4. Create a Convex dev deployment named `dev/wt-NAME` using `pnpm convex deployment create` from `packages/backend/`, then rewrite all Convex-related vars in the worktree's root `.env.local`: `CONVEX_DEPLOYMENT`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, and `CONVEX_URL` (sed-delete then append pattern)
+- R4a. Update `packages/backend/.env.local` in the worktree (file already exists in this repo) with the new `CONVEX_DEPLOYMENT` and `CONVEX_URL` so the Convex CLI targets the correct deployment when run from that directory
+- R5. Create a deploy key for the new deployment via Convex API and save as `CONVEX_DEPLOY_KEY` in `.env.local` -- this pins all Convex CLI commands to the worktree's deployment
+- R6. Auto-assign a unique Next.js port (starting at 3400) by scanning existing worktree `.env.local` files; save as `PORT` in `.env.local`
+- R7. Auto-assign a unique Expo port (starting at 8181) by scanning existing worktree `.env.local` files; save as `EXPO_PORT` in `.env.local`
+- R8. Allow explicit port overrides via `--port PORT` and `--expo-port PORT` flags
+- R9. Copy Convex environment variables from the main deployment to the new deployment using `pnpm convex env list` / `pnpm convex env set`
+- R10. Push schema and functions to the new deployment with `pnpm convex dev --once` (run from `packages/backend/`)
+- R11. Export data from the main Convex deployment and import into the worktree deployment by default; skip with `--no-data` flag
+- R12. Print a summary showing: worktree path, branch, Next.js port, Expo port, Convex deployment name, and exact commands to start dev servers
+
+**Worktree Teardown (`bin/worktree-down`)**
+
+- R13. Kill dev processes running from the worktree: processes on the assigned Next.js port, Expo port, and any node/convex processes with CWD inside the worktree
+- R14. Delete the Convex deployment via API using auth token (see Dependencies); support `--keep-deployment` flag to skip
+- R15. Remove the git worktree (`git worktree remove --force`) and delete the branch (`git branch -D`)
+- R16. Print a teardown summary showing what was cleaned up and what needs manual attention
+
+**Worktree Listing (`bin/worktree-list`)**
+
+- R17. Scan `REPO_ROOT/.claude/worktrees/*/` and read each worktree's `.env.local` to extract port assignments and Convex deployment name
+- R18. Display a formatted table: name, branch, Next.js port, Expo port, Convex deployment
+
+**Cross-cutting**
+
+- R19. All scripts use `pnpm` (not `bun`) for package management and Convex CLI invocation
+- R20. Convex CLI commands must run from `packages/backend/` since that's where `convex/` lives in this monorepo
+- R21. All scripts must be `bash` with `set -euo pipefail` and include `--help` usage text
+
+## Success Criteria
+
+- A developer can run `bin/worktree-up feature-x` and get a fully isolated environment with no manual steps
+- Two worktrees can run dev servers simultaneously without port collisions (both Next.js and Expo)
+- Two worktrees can run separate iOS simulators in parallel (unique Expo ports)
+- `bin/worktree-down feature-x` leaves no orphaned processes, branches, or Convex deployments
+- `bin/worktree-list` shows all active worktrees with their port assignments at a glance
+
+## Scope Boundaries
+
+- No automatic dev server startup -- scripts set up the environment and print commands
+- No Vercel preview deployment integration
+- No CI/CD integration -- these are local development scripts only
+- No worktree "refresh" or "sync" command (pull latest main into worktree) -- out of scope for v1
+- No management of iOS simulator instances themselves -- only Expo port isolation
+
+## Key Decisions
+
+- **Data snapshot on by default**: Matches reference pattern; `--no-data` flag to skip for speed
+- **Two port ranges**: Next.js starts at 3400, Expo starts at 8181 -- avoids defaults (3000, 8081) and EasyPilot's range (3200+) for same-machine multi-project development
+- **Expo port stored as `EXPO_PORT`**: Expo reads `--port` flag at startup, so the summary prints the right `expo start --port $EXPO_PORT` command
+- **Convex CLI runs from `packages/backend/`**: Unlike the reference (root-level Convex), this monorepo has Convex in a sub-package -- all `convex` commands must `cd packages/backend/` first
+- **Dual `.env.local` management**: Root `.env.local` has app env vars (read by Next.js/Expo via `dotenv -e ../../.env.local`); `packages/backend/.env.local` has Convex CLI vars. Both must be updated with the worktree's deployment info
+- **Convex vars to rewrite**: `CONVEX_DEPLOYMENT`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, and `CONVEX_URL` in root; `CONVEX_DEPLOYMENT` and `CONVEX_URL` in `packages/backend/.env.local`
+
+## Dependencies / Assumptions
+
+- **Convex CLI >= 1.34.0 required**: The current pinned version (1.31.2) does not have the `deployment create` subcommand. The catalog pin in `pnpm-workspace.yaml` must be bumped before these scripts will work.
+- **Auth for Convex API**: R5 and R14 use Convex HTTP API endpoints (documented in OpenAPI spec). Requires `CONVEX_TEAM_ACCESS_TOKEN` in `.env.local` (must be provisioned -- same approach as EasyPilot reference). Scripts warn and skip if missing.
+- `pnpm convex` works from `packages/backend/` to invoke the workspace's Convex CLI
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None -- all product decisions are resolved)
+
+### Deferred to Planning
+
+- [Affects R4, R20][Technical] `deployment create --select` writes to whichever `.env.local` is in CWD. Since we run from `packages/backend/`, it writes there -- then the script must also propagate the new URL vars to root `.env.local`. Follow the same sed-delete-then-append pattern as the reference.
+- [Affects R5, R14][Technical] Use `CONVEX_TEAM_ACCESS_TOKEN` for API auth, same as the reference. Add it to `.env.local` with a setup instruction. Fall back to warning if missing (reference pattern).
+- [Affects R11][Technical] For data export/import, `cd` between main and worktree `packages/backend/` dirs -- same pattern as reference. Each dir's `.env.local` targets the right deployment.
+- [Affects R4][Prerequisite] Bump Convex CLI to latest (>= 1.34.0) in `pnpm-workspace.yaml` catalog before implementation.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/brainstorms/2026-04-08-worktree-scripts-requirements.md
+++ b/docs/brainstorms/2026-04-08-worktree-scripts-requirements.md
@@ -13,7 +13,7 @@ The goal is three scripts (`bin/worktree-up`, `bin/worktree-down`, `bin/worktree
 
 Reference implementation: `~/ez-pilot-app/bin/worktree-up` and `~/ez-pilot-app/bin/worktree-down`.
 
-```
+```text
                     bin/worktree-up <name>
                            |
           +----------------+----------------+
@@ -136,10 +136,10 @@ Reference implementation: `~/ez-pilot-app/bin/worktree-up` and `~/ez-pilot-app/b
 
 ### Deferred to Planning
 
-- [Affects R4, R20][Technical] `deployment create --select` writes to whichever `.env.local` is in CWD. Since we run from `packages/backend/`, it writes there -- then the script must also propagate the new URL vars to root `.env.local`. Follow the same sed-delete-then-append pattern as the reference.
-- [Affects R5, R14][Technical] Use `CONVEX_TEAM_ACCESS_TOKEN` for API auth, same as the reference. Add it to `.env.local` with a setup instruction. Fall back to warning if missing (reference pattern).
-- [Affects R11][Technical] For data export/import, `cd` between main and worktree `packages/backend/` dirs -- same pattern as reference. Each dir's `.env.local` targets the right deployment.
-- [Affects R4][Prerequisite] Bump Convex CLI to latest (>= 1.34.0) in `pnpm-workspace.yaml` catalog before implementation.
+- [Affects R4, R20] **Technical:** `deployment create --select` writes to whichever `.env.local` is in CWD. Since we run from `packages/backend/`, it writes there -- then the script must also propagate the new URL vars to root `.env.local`. Follow the same sed-delete-then-append pattern as the reference.
+- [Affects R5, R14] **Technical:** Use `CONVEX_TEAM_ACCESS_TOKEN` for API auth, same as the reference. Add it to `.env.local` with a setup instruction. Fall back to warning if missing (reference pattern).
+- [Affects R11] **Technical:** For data export/import, `cd` between main and worktree `packages/backend/` dirs -- same pattern as reference. Each dir's `.env.local` targets the right deployment.
+- [Affects R4] **Prerequisite:** Bump Convex CLI to latest (>= 1.34.0) in `pnpm-workspace.yaml` catalog before implementation.
 
 ## Next Steps
 

--- a/docs/plans/2026-04-08-001-feat-worktree-lifecycle-scripts-plan.md
+++ b/docs/plans/2026-04-08-001-feat-worktree-lifecycle-scripts-plan.md
@@ -1,0 +1,339 @@
+---
+title: "feat: Add worktree lifecycle scripts for isolated parallel development"
+type: feat
+status: completed
+date: 2026-04-08
+origin: docs/brainstorms/2026-04-08-worktree-scripts-requirements.md
+deepened: 2026-04-08
+---
+
+# feat: Add worktree lifecycle scripts for isolated parallel development
+
+## Overview
+
+Add three bash scripts (`bin/worktree-up`, `bin/worktree-down`, `bin/worktree-list`) that create, destroy, and list fully isolated parallel dev environments. Each worktree gets its own Convex deployment, unique Next.js and Expo ports, and clean teardown. Adapted from the proven reference implementation at `~/ez-pilot-app/bin/`.
+
+## Problem Frame
+
+Developers and AI agents working on soonlist-turbo create worktrees ad-hoc without isolated Convex deployments, port management, or cleanup -- leading to port collisions, shared mutable backend state, and orphaned resources. 24 worktrees already exist across `.claude/worktrees/` and `.cursor/worktrees/`. (See origin: `docs/brainstorms/2026-04-08-worktree-scripts-requirements.md`)
+
+## Requirements Trace
+
+- R1-R3: Git worktree creation, pnpm install, env file copying
+- R4-R5: Convex deployment creation, deploy key pinning, dual .env.local management
+- R6-R8: Port auto-assignment (Next.js 3400+, Expo 8181+) with explicit overrides
+- R9-R11: Convex env var copying, schema push, data snapshot
+- R12: Summary output with dev server commands
+- R13-R16: Process killing, deployment deletion, worktree removal, teardown summary
+- R17-R18: Worktree listing with formatted table
+- R19-R21: Cross-cutting (pnpm, packages/backend/ CWD, bash conventions)
+
+## Scope Boundaries
+
+- No automatic dev server startup -- scripts print commands only
+- No Vercel preview deployment integration
+- No CI/CD integration -- local development scripts only
+- No worktree "refresh" or "sync" command
+- No iOS simulator instance management -- only Expo port isolation
+- Production safeguard: scripts must never touch the production Convex deployment
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Reference implementation**: `~/ez-pilot-app/bin/worktree-up` (249 lines), `~/ez-pilot-app/bin/worktree-down` (152 lines) -- proven patterns for all steps
+- **Existing `bin/` scripts**: `bin/get-pr-comments`, `bin/resolve-pr-thread` -- use `#!/usr/bin/env bash`, `set -euo pipefail`, positional arg validation
+- **Dual `.env.local` architecture**:
+  - Root `.env.local`: ~50 vars including `CONVEX_DEPLOYMENT`, `CONVEX_URL`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL` plus all Clerk/Stripe/Sentry/etc keys
+  - `packages/backend/.env.local`: Only `CONVEX_DEPLOYMENT` (with trailing `# team: ...` comment) and `CONVEX_URL`
+- **`with-env` pattern**: Both `apps/web` and `apps/expo` use `"with-env": "dotenv -e ../../.env.local --"` to load root env vars
+- **Convex CLI invocation**: `packages/backend/package.json` has `"dev": "convex dev"` -- CLI runs from that directory and reads its own `.env.local`
+- **Env validation**: `apps/web/env.ts` validates `NEXT_PUBLIC_CONVEX_URL` via Zod; `apps/expo/src/utils/config.ts` reads `EXPO_PUBLIC_CONVEX_URL` directly
+
+### Institutional Learnings
+
+- Never deploy to production without explicit user approval -- worktree teardown must safeguard against deleting the production deployment
+
+## Key Technical Decisions
+
+- **Convex CLI upgrade required**: Bump from 1.31.2 to latest in `pnpm-workspace.yaml` catalog. `deployment create` subcommand does not exist in 1.31.2 (see origin)
+- **Dual .env.local management**: `deployment create --select` writes to `packages/backend/.env.local` (its CWD). Script then extracts new values and propagates to root `.env.local` using sed-delete-then-append (same as reference)
+- **Auth token**: Use `CONVEX_TEAM_ACCESS_TOKEN` from root `.env.local` for Convex API calls (deploy key creation, deployment deletion). Warn and skip gracefully if missing
+- **Data export/import**: `cd` between main and worktree `packages/backend/` dirs. Each dir's `.env.local` targets the right deployment automatically
+- **Port ranges**: Next.js 3400+, Expo 8181+ -- avoids defaults (3000, 8081) and EasyPilot's range (3200+) for same-machine multi-project dev
+- **Convex vars to rewrite**: Root: `CONVEX_DEPLOYMENT`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, `CONVEX_URL`. Backend: `CONVEX_DEPLOYMENT`, `CONVEX_URL`
+- **Sed pattern for backend .env.local**: Must handle trailing `# team: ...` comment that Convex CLI appends to `CONVEX_DEPLOYMENT`
+- **Quote handling**: Root `.env.local` uses double-quoted values (e.g., `CONVEX_DEPLOYMENT="dev:lovable-camel-478"`). All extraction logic must strip double quotes before using values. When writing back to root, match the unquoted format used by the reference pattern (dotenv-cli handles both). Backend `.env.local` uses unquoted values with trailing comments -- different extraction logic needed
+- **Backend .env.local seeding**: `packages/backend/.env.local` is gitignored and won't exist in a fresh worktree. Must copy it from the main repo's `packages/backend/.env.local` before running `convex deployment create --select`, so the CLI has project context
+- **Port scan scope**: Scan all git worktrees (via `git worktree list --porcelain`) for port assignments, not just `.claude/worktrees/` -- matches reference implementation and catches ports from Cursor worktrees too
+- **Convex URL propagation**: `deployment create --select` writes `CONVEX_DEPLOYMENT` and `CONVEX_URL` to `packages/backend/.env.local`. The `CONVEX_URL` value is then used to set all three URL vars in root `.env.local` (`NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, `CONVEX_URL`) -- do not try to extract `NEXT_PUBLIC_*` from backend's `.env.local`
+- **Slug definition**: "Slug" means the deployment identifier used in API URLs (e.g., `lovable-camel-478`). Extracted from `CONVEX_DEPLOYMENT` by stripping the `dev:` prefix and any trailing `# team: ...` comments
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does `deployment create --select` write?** To `packages/backend/.env.local` (its CWD). Script extracts new values from there, then propagates to root.
+- **Auth token source?** `CONVEX_TEAM_ACCESS_TOKEN` in root `.env.local`, same as reference. Must be provisioned by developer.
+- **Data export/import approach?** `cd` between main/worktree `packages/backend/` directories, same pattern as reference.
+- **How to invoke Convex CLI from packages/backend/?** `cd "$WT_PATH/packages/backend" && npx convex <command>`. Using `npx` since it resolves the workspace dependency.
+
+### Deferred to Implementation
+
+- Exact latest Convex CLI version number (use `npm view convex version` at implementation time)
+- Whether `CONVEX_DEPLOY_KEY` should also be written to `packages/backend/.env.local` or only root (test during implementation)
+- Whether `convex export`/`convex import` accept `--path` flag in the upgraded version (verify at implementation time)
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+worktree-up <name> [--port P] [--expo-port E] [--no-data]
+│
+├─ 1. Resolve REPO_ROOT and MAIN_ENV (git worktree list --porcelain fallback)
+├─ 2. Validate: name required, path doesn't exist, MAIN_ENV exists
+├─ 3. Auto-assign ports: scan ALL git worktrees' .env.local for PORT= and EXPO_PORT=
+│     Next.js: max(existing, 3399) + 1    Expo: max(existing, 8180) + 1
+├─ 4. git worktree add "$WT_PATH" -b "$NAME"
+├─ 5. pnpm install --ignore-scripts (from $WT_PATH)
+├─ 6. cp "$MAIN_ENV" "$WT_PATH/.env.local"
+│     cp main repo's packages/backend/.env.local -> "$WT_PATH/packages/backend/.env.local"
+│     (seeds Convex CLI with project context -- file is gitignored, won't exist otherwise)
+├─ 7. cd "$WT_PATH/packages/backend"
+│     npx convex deployment create "dev/wt-$NAME" --type dev --select
+│     (writes new CONVEX_DEPLOYMENT + CONVEX_URL to packages/backend/.env.local)
+├─ 8. Extract CONVEX_URL from packages/backend/.env.local (strip quotes/comments)
+│     Propagate to root .env.local: sed-delete + append for all 4 Convex vars
+│     Use extracted URL for NEXT_PUBLIC_CONVEX_URL, EXPO_PUBLIC_CONVEX_URL, CONVEX_URL
+├─ 9. Deploy key: POST /v1/deployments/{slug}/create_deploy_key
+│     Save CONVEX_DEPLOY_KEY to root .env.local
+├─10. Write PORT and EXPO_PORT to root .env.local
+├─11. Copy Convex env vars: npx convex env list (main) -> npx convex env set (worktree)
+├─12. Push schema: cd packages/backend && npx convex dev --once
+├─13. Data snapshot (unless --no-data):
+│     Export from main packages/backend/ -> /tmp/convex-snapshot-$NAME.zip
+│     Import into worktree packages/backend/ with --replace-all -y
+└─14. Print summary
+
+worktree-down <name> [--keep-deployment]
+│
+├─ 1. Validate: name required, WT_PATH exists
+├─ 2. Kill processes: lsof -ti :$PORT, lsof -ti :$EXPO_PORT, lsof +D for node/convex
+├─ 3. Delete Convex deployment (unless --keep-deployment):
+│     Extract slug, POST /v1/deployments/{slug}/delete
+│     Production safeguard: refuse if deployment name doesn't start with "dev:"
+├─ 4. git worktree remove --force, git branch -D
+└─ 5. Print summary
+
+worktree-list
+│
+├─ Scan .claude/worktrees/*/​.env.local
+├─ Extract: NAME, PORT, EXPO_PORT, CONVEX_DEPLOYMENT
+└─ Print formatted table with column headers
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Bump Convex CLI version**
+
+**Goal:** Upgrade Convex CLI to latest (>= 1.34.0) so `deployment create` subcommand is available.
+
+**Requirements:** R4 prerequisite
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `pnpm-workspace.yaml` (catalog pin for `convex`)
+
+**Approach:**
+- Run `npm view convex version` to get latest version
+- Update the `convex:` line in the `catalog:` section of `pnpm-workspace.yaml`
+- Run `pnpm install` to update lockfile
+- Verify `npx convex deployment --help` works from `packages/backend/`
+
+**Patterns to follow:**
+- Existing catalog version pin format in `pnpm-workspace.yaml`
+
+**Test expectation:** none -- pure dependency version bump. Verified by checking `npx convex deployment --help` output.
+
+**Verification:**
+- From `packages/backend/`: `npx convex deployment --help` shows the `create` subcommand
+
+---
+
+- [ ] **Unit 2: bin/worktree-up**
+
+**Goal:** Create the main worktree setup script that produces a fully isolated dev environment.
+
+**Requirements:** R1, R2, R3, R4, R4a, R5, R6, R7, R8, R9, R10, R11, R12, R19, R20, R21
+
+**Dependencies:** Unit 1 (Convex CLI upgrade)
+
+**Files:**
+- Create: `bin/worktree-up`
+
+**Approach:**
+
+The script follows the reference implementation's structure with these soonlist-specific adaptations:
+
+1. **Repo root and main env resolution** -- same pattern as reference (`git worktree list --porcelain` fallback)
+2. **Arg parsing** -- add `--expo-port PORT` and `--no-data` flags beyond reference's `--port PORT`
+3. **Dual port auto-assignment** -- scan all git worktrees (via `git worktree list --porcelain`, same as reference) for both `PORT=` (starting 3400) and `EXPO_PORT=` (starting 8181). Use the reference's scan-and-increment loop, duplicated for each port var
+4. **Git worktree + pnpm install** -- `git worktree add "$WT_PATH" -b "$NAME"` then `cd "$WT_PATH" && pnpm install --ignore-scripts`
+5. **Env file seeding** -- copy root `.env.local` to worktree root AND copy main repo's `packages/backend/.env.local` to worktree's `packages/backend/.env.local` (gitignored file, won't exist in fresh worktree -- needed so Convex CLI has project context)
+6. **Convex deployment creation** -- `cd "$WT_PATH/packages/backend" && npx convex deployment create "dev/wt-$NAME" --type dev --select`. This writes new `CONVEX_DEPLOYMENT` and `CONVEX_URL` to `packages/backend/.env.local`. Extract values from last occurrence in that file, stripping any double quotes and trailing `# team: ...` comments
+7. **Propagate Convex vars to root .env.local** -- sed-delete then append for `CONVEX_DEPLOYMENT`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, `CONVEX_URL`. All three URL vars get the same value (the `CONVEX_URL` extracted from backend's `.env.local`). Strip double quotes from existing root values before comparing/replacing
+8. **Deploy key creation** -- same Convex API call as reference; save `CONVEX_DEPLOY_KEY` to root `.env.local`
+9. **Port vars** -- sed-delete then append `PORT=$PORT` and `EXPO_PORT=$EXPO_PORT` to root `.env.local`
+10. **Convex env vars** -- copy from main deployment to worktree deployment (cd between `packages/backend/` dirs)
+11. **Schema push** -- `cd "$WT_PATH/packages/backend" && npx convex dev --once`
+12. **Data snapshot** -- unless `--no-data`: export from main `packages/backend/`, import into worktree `packages/backend/` with `--replace-all -y`
+13. **Summary** -- print path, branch, ports, Convex deployment, and exact dev server commands:
+    - `cd $WT_PATH && pnpm dev:backend` (Convex)
+    - `cd $WT_PATH/apps/web && pnpm with-env next dev --turbopack --port $PORT` (Next.js)
+    - `cd $WT_PATH/apps/expo && pnpm with-env expo start --port $EXPO_PORT` (Expo)
+    - `bin/worktree-down $NAME` (teardown)
+
+**Production safeguard (worktree-down only):** The `dev:` prefix check applies to deployment deletion in worktree-down, not to worktree-up creation.
+
+**Patterns to follow:**
+- Reference `~/ez-pilot-app/bin/worktree-up` for overall structure, error handling, and messaging
+- Existing `bin/` scripts for shebang and `set -euo pipefail`
+- Sed-delete-then-append pattern from reference lines 111-117 for env var deduplication
+
+**Test scenarios:**
+- Happy path: `bin/worktree-up test-feature` creates worktree, installs deps, creates Convex deployment, assigns ports 3400/8181 (first worktree), prints summary
+- Happy path: Second worktree `bin/worktree-up test-feature-2` assigns ports 3401/8182
+- Edge case: Running from inside an existing worktree still finds main repo's `.env.local` via `git worktree list --porcelain`
+- Edge case: `--port 3500 --expo-port 8200` overrides auto-assignment
+- Edge case: `--no-data` skips the data export/import step
+- Error path: Worktree name already exists -- exits with clear error
+- Error path: Main `.env.local` missing -- exits with clear error
+- Error path: `CONVEX_TEAM_ACCESS_TOKEN` missing -- warns but continues (deploy key skipped)
+- Integration: After setup, `cd $WT_PATH/packages/backend && npx convex env list` shows copied env vars
+- Integration: Root `.env.local` contains all 4 rewritten Convex vars pointing to new deployment
+- Integration: `packages/backend/.env.local` contains new `CONVEX_DEPLOYMENT` and `CONVEX_URL`
+- Edge case: Root `.env.local` contains double-quoted values (e.g., `CONVEX_DEPLOYMENT="dev:slug"`) -- extraction strips quotes correctly
+- Edge case: `packages/backend/.env.local` does not exist in fresh worktree -- script copies it from main repo before running Convex CLI
+- Edge case: Partial setup failure (e.g., schema push fails) -- worktree-down can still clean up the partial worktree
+
+**Verification:**
+- Running the script produces a working worktree where `npx convex dev --once` succeeds from `packages/backend/`
+- Root `.env.local` has correct `CONVEX_DEPLOYMENT`, `NEXT_PUBLIC_CONVEX_URL`, `EXPO_PUBLIC_CONVEX_URL`, `CONVEX_URL`
+- `packages/backend/.env.local` has correct `CONVEX_DEPLOYMENT` and `CONVEX_URL`
+- Ports are unique and do not conflict with other worktrees or defaults (3000, 8081) or EasyPilot (3200+)
+
+---
+
+- [ ] **Unit 3: bin/worktree-down**
+
+**Goal:** Create the teardown script that cleanly destroys a worktree and its associated resources.
+
+**Requirements:** R13, R14, R15, R16, R19, R20, R21
+
+**Dependencies:** Unit 2 (worktree-up creates the environments this tears down)
+
+**Files:**
+- Create: `bin/worktree-down`
+
+**Approach:**
+
+Follow the reference `~/ez-pilot-app/bin/worktree-down` structure with these adaptations:
+
+1. **Arg parsing** -- name required, `--keep-deployment` flag, `--help` flag
+2. **Process killing** -- kill by Next.js port (`lsof -ti :$PORT`), by Expo port (`lsof -ti :$EXPO_PORT`), then by CWD (`lsof +D "$WT_PATH"` filtering for node/convex/next/expo processes). Read both `PORT` and `EXPO_PORT` from worktree's `.env.local`
+3. **Convex deployment deletion** (unless `--keep-deployment`):
+   - Extract `CONVEX_DEPLOYMENT` from worktree's root `.env.local`, stripping double quotes and trailing `# team: ...` comments
+   - **Production safeguard**: Refuse to delete if deployment name does not start with `dev:` -- print error and exit
+   - Extract slug: the part after `dev:` prefix (e.g., `dev:wt-foo-123` -> `wt-foo-123`). This is the deployment identifier used in API URLs
+   - Source `CONVEX_TEAM_ACCESS_TOKEN` from worktree's `.env.local` (copied from root during setup)
+   - `POST /v1/deployments/{slug}/delete` with bearer token
+   - Handle success (200), failure (non-200), and missing token cases
+4. **Git cleanup** -- `git worktree remove "$WT_PATH" --force` then `git branch -D "$BRANCH"`
+5. **Summary** -- report what was cleaned up: worktree removed, branch deleted, deployment deleted/kept/needs-manual-deletion
+
+**Patterns to follow:**
+- Reference `~/ez-pilot-app/bin/worktree-down` for process killing logic, API call pattern, and summary format
+- Existing `bin/` scripts for conventions
+
+**Test scenarios:**
+- Happy path: `bin/worktree-down test-feature` kills processes, deletes deployment, removes worktree, deletes branch
+- Happy path: `--keep-deployment` skips Convex deletion, reports "KEPT"
+- Edge case: No dev processes running -- "No dev processes found" message, continues
+- Edge case: Worktree `.env.local` has no `CONVEX_DEPLOYMENT` -- skips deletion with warning
+- Error path: Worktree name doesn't exist -- exits with "worktree not found" error
+- Error path: `CONVEX_TEAM_ACCESS_TOKEN` missing -- warns, reports "NEEDS MANUAL DELETION"
+- Error path: Convex API returns non-200 -- warns with HTTP status, reports "NEEDS MANUAL DELETION"
+- Security: Deployment name not starting with `dev:` -- refuses to delete, exits with error
+- Edge case: `CONVEX_DEPLOYMENT` value has double quotes and trailing comment -- extraction handles both correctly
+- Edge case: Partial worktree (no .env.local) -- exits with clear error about missing env file
+
+**Verification:**
+- After running, the worktree directory no longer exists
+- The git branch no longer exists (`git branch --list $NAME` returns empty)
+- No processes remain on the worktree's assigned ports
+- The Convex deployment is deleted (verify via Convex dashboard or API)
+
+---
+
+- [ ] **Unit 4: bin/worktree-list**
+
+**Goal:** Create a listing script that shows all active worktrees with their port assignments and Convex deployments.
+
+**Requirements:** R17, R18, R19, R21
+
+**Dependencies:** Unit 2 (worktree-up creates the environments this lists)
+
+**Files:**
+- Create: `bin/worktree-list`
+
+**Approach:**
+
+1. Scan `REPO_ROOT/.claude/worktrees/*/` directories
+2. For each directory that has a `.env.local`, extract:
+   - Name (directory basename)
+   - Current git branch (`git -C "$dir" branch --show-current`)
+   - `PORT` value
+   - `EXPO_PORT` value
+   - `CONVEX_DEPLOYMENT` value (strip trailing comments)
+3. Print a formatted table with column headers using `printf` for alignment
+4. If no worktrees found, print "No worktrees found"
+
+**Patterns to follow:**
+- Simple directory scan pattern (avoid parsing `git worktree list --porcelain` since `.claude/worktrees/` is a known, stable location)
+
+**Test scenarios:**
+- Happy path: Two worktrees exist -- table shows both with correct ports and deployments
+- Edge case: No worktrees exist -- prints "No worktrees found"
+- Edge case: Worktree directory exists but `.env.local` is missing -- skips or shows "N/A" for missing values
+- Edge case: `.env.local` exists but missing `PORT` or `EXPO_PORT` keys -- shows "N/A" for those columns
+
+**Verification:**
+- After creating two worktrees with worktree-up, worktree-list shows both with correct data
+- After tearing down one with worktree-down, worktree-list shows only the remaining one
+
+## System-Wide Impact
+
+- **Interaction graph:** Scripts interact with Convex API (deployment creation/deletion, deploy key), git (worktree management), and the filesystem (.env.local files). No callback or middleware concerns.
+- **Error propagation:** Each step has explicit error handling with warnings for non-critical failures (missing token, API errors) and hard exits for critical failures (missing env file, existing worktree name). Script uses `set -euo pipefail` for fail-fast on unexpected errors.
+- **State lifecycle risks:** Partial setup (e.g., Convex deployment created but script fails at schema push) leaves orphaned resources. Mitigation: worktree-down can clean up partial setups. The deploy key pins the CLI to the correct deployment, preventing accidental cross-deployment operations.
+- **API surface parity:** These scripts complement but do not replace the existing `.cursor/worktrees.json` which only runs `npm install`. The new scripts are a superset. No existing tooling is broken.
+- **Unchanged invariants:** The main repo's `.env.local`, `packages/backend/.env.local`, and all production/preview deployments are never modified by these scripts. Only worktree-local copies are changed.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Convex CLI upgrade may introduce breaking changes | Pin to specific version, test `convex dev --once` from packages/backend/ before proceeding |
+| `deployment create --select` may write unexpected vars | Extract values from last occurrence in file (reference pattern handles this) |
+| `CONVEX_TEAM_ACCESS_TOKEN` not provisioned | Scripts warn and skip deploy key/deletion gracefully; include setup instructions in summary |
+| Data snapshot may be slow for large deployments | `--no-data` flag available; summary notes estimated time if large |
+| Production deployment accidentally targeted | Explicit `dev:` prefix check before any deletion; refuse and exit if non-dev deployment detected |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-08-worktree-scripts-requirements.md](docs/brainstorms/2026-04-08-worktree-scripts-requirements.md)
+- Reference implementation: `~/ez-pilot-app/bin/worktree-up`, `~/ez-pilot-app/bin/worktree-down`
+- Convex API: OpenAPI spec for deployment management endpoints
+- Related code: `packages/backend/package.json` (Convex CLI scripts), `apps/web/package.json` and `apps/expo/package.json` (`with-env` pattern)

--- a/docs/plans/2026-04-08-001-feat-worktree-lifecycle-scripts-plan.md
+++ b/docs/plans/2026-04-08-001-feat-worktree-lifecycle-scripts-plan.md
@@ -88,7 +88,7 @@ Developers and AI agents working on soonlist-turbo create worktrees ad-hoc witho
 
 > *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
 
-```
+```text
 worktree-up <name> [--port P] [--expo-port E] [--no-data]
 │
 ├─ 1. Resolve REPO_ROOT and MAIN_ENV (git worktree list --porcelain fallback)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ catalogs:
       specifier: ^8.2.2
       version: 8.2.2
     convex:
-      specifier: 1.31.2
-      version: 1.31.2
+      specifier: 1.34.1
+      version: 1.34.1
     convex-helpers:
       specifier: ^0.1.89
       version: 0.1.109
@@ -623,10 +623,10 @@ importers:
         version: 0.13.0(expo@55.0.0-preview.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       convex:
         specifier: 'catalog:'
-        version: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       convex-helpers:
         specifier: 'catalog:'
-        version: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
       expo:
         specifier: 'catalog:'
         version: 55.0.0-preview.12(@babel/core@7.28.5)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.0-preview.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -921,7 +921,7 @@ importers:
         version: 0.2.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       convex:
         specifier: 'catalog:'
-        version: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
@@ -1066,16 +1066,16 @@ importers:
         version: 6.36.7(next@15.1.9(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@convex-dev/aggregate':
         specifier: ^0.1.24
-        version: 0.1.25(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.1.25(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))
       '@convex-dev/migrations':
         specifier: 'catalog:'
-        version: 0.2.9(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.2.9(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))
       '@convex-dev/workflow':
         specifier: 'catalog:'
-        version: 0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)))(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))
       '@convex-dev/workpool':
         specifier: 'catalog:'
-        version: 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.2.19(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))
       '@soonlist/cal':
         specifier: workspace:*
         version: link:../cal
@@ -1087,7 +1087,7 @@ importers:
         version: 3.1.22(react@19.2.0)(solid-js@1.9.10)(svelte@4.2.20)(vue@3.5.26(typescript@5.9.3))(zod@3.25.76)
       convex:
         specifier: 'catalog:'
-        version: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       langfuse:
         specifier: 'catalog:'
         version: 3.38.6
@@ -2404,152 +2404,158 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
-  '@esbuild/aix-ppc64@0.25.4':
-    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.4':
-    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.4':
-    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.4':
-    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.4':
-    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.4':
-    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.4':
-    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.4':
-    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.4':
-    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.4':
-    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.4':
-    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.4':
-    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.4':
-    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.4':
-    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.4':
-    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.4':
-    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.4':
-    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.4':
-    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.4':
-    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.4':
-    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.4':
-    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.4':
-    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -5962,8 +5968,8 @@ packages:
       zod:
         optional: true
 
-  convex@1.31.2:
-    resolution: {integrity: sha512-RFuJOwlL2bM5X63egvBI5ZZZH6wESREpAbHsLjODxzDeJuewTLKrEnbvHV/NWp1uJYpgEFJziuGHmZ0tnAmmJg==}
+  convex@1.34.1:
+    resolution: {integrity: sha512-ooyFnZVVq0u6b5zt0Ptq8QB2ixhf/2vXe+PIcUtdtrs0lq/TwpkmmruHdqkFmWgMd6N+Tmfy8AGkz6QnZUYZBA==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -6433,8 +6439,8 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.25.4:
-    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10687,6 +10693,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -12069,25 +12087,25 @@ snapshots:
       eventemitter3: 5.0.1
       preact: 10.28.2
 
-  '@convex-dev/aggregate@0.1.25(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/aggregate@0.1.25(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))':
     dependencies:
-      convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      convex: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
 
-  '@convex-dev/migrations@0.2.9(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/migrations@0.2.9(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))':
     dependencies:
-      convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      convex: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
 
-  '@convex-dev/workflow@0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/workflow@0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)))(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+      '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))
       async-channel: 0.2.0
-      convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+      convex: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
+      convex-helpers: 0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
 
-  '@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))':
     dependencies:
-      convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+      convex: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
+      convex-helpers: 0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -12196,79 +12214,82 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@esbuild/aix-ppc64@0.25.4':
+  '@esbuild/aix-ppc64@0.27.0':
     optional: true
 
-  '@esbuild/android-arm64@0.25.4':
+  '@esbuild/android-arm64@0.27.0':
     optional: true
 
-  '@esbuild/android-arm@0.25.4':
+  '@esbuild/android-arm@0.27.0':
     optional: true
 
-  '@esbuild/android-x64@0.25.4':
+  '@esbuild/android-x64@0.27.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.4':
+  '@esbuild/darwin-arm64@0.27.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.4':
+  '@esbuild/darwin-x64@0.27.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.4':
+  '@esbuild/freebsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.4':
+  '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.4':
+  '@esbuild/linux-arm64@0.27.0':
     optional: true
 
-  '@esbuild/linux-arm@0.25.4':
+  '@esbuild/linux-arm@0.27.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.4':
+  '@esbuild/linux-ia32@0.27.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.4':
+  '@esbuild/linux-loong64@0.27.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.4':
+  '@esbuild/linux-mips64el@0.27.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.4':
+  '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.4':
+  '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.4':
+  '@esbuild/linux-s390x@0.27.0':
     optional: true
 
-  '@esbuild/linux-x64@0.25.4':
+  '@esbuild/linux-x64@0.27.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.4':
+  '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.4':
+  '@esbuild/netbsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.4':
+  '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.4':
+  '@esbuild/openbsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.4':
+  '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.4':
+  '@esbuild/sunos-x64@0.27.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.4':
+  '@esbuild/win32-arm64@0.27.0':
     optional: true
 
-  '@esbuild/win32-x64@0.25.4':
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
@@ -14281,7 +14302,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -16381,21 +16402,25 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76):
+  convex-helpers@0.1.109(convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
-      convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      convex: 1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       react: 19.2.0
       typescript: 5.9.3
       zod: 3.25.76
 
-  convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
+  convex@1.34.1(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10):
     dependencies:
-      esbuild: 0.25.4
+      esbuild: 0.27.0
       prettier: 3.7.4
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       '@clerk/clerk-react': 5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   cookie-signature@1.0.7: {}
 
@@ -16889,33 +16914,34 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.25.4:
+  esbuild@0.27.0:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.4
-      '@esbuild/android-arm': 0.25.4
-      '@esbuild/android-arm64': 0.25.4
-      '@esbuild/android-x64': 0.25.4
-      '@esbuild/darwin-arm64': 0.25.4
-      '@esbuild/darwin-x64': 0.25.4
-      '@esbuild/freebsd-arm64': 0.25.4
-      '@esbuild/freebsd-x64': 0.25.4
-      '@esbuild/linux-arm': 0.25.4
-      '@esbuild/linux-arm64': 0.25.4
-      '@esbuild/linux-ia32': 0.25.4
-      '@esbuild/linux-loong64': 0.25.4
-      '@esbuild/linux-mips64el': 0.25.4
-      '@esbuild/linux-ppc64': 0.25.4
-      '@esbuild/linux-riscv64': 0.25.4
-      '@esbuild/linux-s390x': 0.25.4
-      '@esbuild/linux-x64': 0.25.4
-      '@esbuild/netbsd-arm64': 0.25.4
-      '@esbuild/netbsd-x64': 0.25.4
-      '@esbuild/openbsd-arm64': 0.25.4
-      '@esbuild/openbsd-x64': 0.25.4
-      '@esbuild/sunos-x64': 0.25.4
-      '@esbuild/win32-arm64': 0.25.4
-      '@esbuild/win32-ia32': 0.25.4
-      '@esbuild/win32-x64': 0.25.4
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
 
   escalade@3.2.0: {}
 
@@ -19006,19 +19032,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       https-proxy-agent: 7.0.6
       metro-core: 0.83.3
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-config@0.83.3:
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -21924,6 +21937,11 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - apps/*
   - packages/*
   - tooling/*
+  - "!.claude/worktrees/**"
 
 catalog:
   # Dev tooling

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   typescript: ~5.9.2
 
   # Backend
-  convex: 1.31.2
+  convex: 1.34.1
   "@convex-dev/migrations": ^0.2.9
   "@convex-dev/workflow": ^0.2.4
   "@convex-dev/workpool": ^0.2.10


### PR DESCRIPTION
## Summary

Adds three worktree lifecycle scripts (`bin/worktree-up`, `bin/worktree-down`, `bin/worktree-list`) that give each git worktree a fully isolated dev stack: its own Convex deployment, unique Next.js and Expo ports, env var propagation, data snapshot, and clean teardown. Also bumps Convex CLI to 1.34.1 and excludes worktree directories from the pnpm workspace.

## Changes

### New Scripts
- **`bin/worktree-up`** — creates an isolated worktree with Convex deployment, deploy key, port assignment, env var copying, schema push, and data snapshot
- **`bin/worktree-down`** — tears down a worktree: kills dev processes, deletes Convex deployment (with safety guards), removes worktree and branch
- **`bin/worktree-list`** — lists active worktrees with branch, ports, process status, and deployment info

### Key Features
- Auto-assigns Next.js (3400+) and Expo (8181+) ports by scanning existing worktrees
- Safety guards: refuses to delete non-dev or main-repo deployments
- `--branch` flag to check out existing branches (e.g., PR branches)
- `--no-data` flag to skip data snapshot
- `--keep-deployment` flag to preserve Convex deployment on teardown
- Cross-platform: uses portable awk instead of BSD-only `tail -r`
- Works correctly when run from inside a worktree (resolves main repo root)

### Infrastructure
- Bumped Convex CLI from 1.31.2 to 1.34.1 in pnpm-workspace catalog
- Added `!.claude/worktrees/**` exclusion to pnpm-workspace.yaml
- Brainstorm requirements doc and implementation plan

## Files Changed

| File | Description |
|------|-------------|
| `bin/worktree-up` | New: 285-line script for worktree creation |
| `bin/worktree-down` | New: 174-line script for worktree teardown |
| `bin/worktree-list` | New: 81-line script for listing worktrees |
| `pnpm-workspace.yaml` | Convex bump + worktree exclusion |
| `pnpm-lock.yaml` | Lock file updates for Convex 1.34.1 |
| `docs/brainstorms/...` | Requirements document |
| `docs/plans/...` | Implementation plan |

## Test Plan

- [ ] Run `bin/worktree-up test-wt` and verify isolated Convex deployment is created
- [ ] Verify auto-assigned ports don't collide with existing worktrees
- [ ] Run `bin/worktree-list` and verify all columns display correctly
- [ ] Run `bin/worktree-down test-wt` and verify clean teardown
- [ ] Test `--branch` flag with an existing remote branch
- [ ] Test `--no-data` flag skips data snapshot
- [ ] Verify scripts work when run from inside a worktree (not just main repo)
- [ ] Verify `pnpm install` still works with the workspace exclusion

## Notes

- This is a fresh branch created for clean AI code review
- Original branch: `brainstorm-worktree-scripts-fresh`
- Includes fixes from first round of review feedback (safety guard fall-through, cross-platform compat, repo root resolution)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three worktree lifecycle scripts to create fully isolated parallel dev environments per git worktree, each with its own Convex deployment and unique Next.js/Expo ports. Also bumps `convex` CLI to 1.34.1 and excludes worktree dirs from the `pnpm` workspace.

- New Features
  - bin/worktree-up — creates a worktree with its own Convex dev deployment, deploy key, env propagation, and auto-assigned ports; supports `--branch`, `--port`, `--expo-port`, `--no-data`.
  - bin/worktree-down — kills dev processes, safely deletes the worktree’s Convex deployment (or `--keep-deployment`), and removes the worktree and branch.
  - bin/worktree-list — lists worktrees with branch, Next.js/Expo ports, process status, and Convex deployment.
  - Auto-assigns ports by scanning existing worktrees; resolves repo root when run inside a worktree; includes safety guards to avoid non-dev or main deployments.

- Bug Fixes
  - worktree-down now reads the actual checked-out branch from the worktree before removal, ensuring the correct branch is deleted and handling detached HEAD cases.

<sup>Written for commit 8e2b403c485a1b54e214cbbc176502cfbe7d401c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds three CLI commands to create, list, and tear down isolated development worktrees.
  * Auto-assigns unique Next/Expo ports, shows process status, and prints ready/start commands.
  * Creates per-worktree dev deployments, propagates env/config, optionally snapshots/restores data, and supports keeping deployments on teardown.

* **Documentation**
  * Added planning and requirements docs for worktree lifecycle scripts.

* **Chores**
  * Updated workspace configuration and dependency catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->