### PR TITLE
fix(cal): compute event year deterministically to kill 2027 bug

### DIFF
--- a/packages/backend/convex/model/aiHelpers.ts
+++ b/packages/backend/convex/model/aiHelpers.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
+import { Temporal } from "@js-temporal/polyfill";
 import { waitUntil } from "@vercel/functions";
 import { generateObject, GenerateObjectResult } from "ai";
 import { ConvexError } from "convex/values";
@@ -13,6 +14,7 @@ import {
   getPrompt,
   getSystemMessage,
   getSystemMessageMetadata,
+  normalizeEventYear,
 } from "@soonlist/cal";
 
 import type { ActionCtx } from "../_generated/server";
@@ -571,7 +573,28 @@ export async function fetchAndProcessEvent({
   const generatedEvent = event.object;
   const generatedMetadata = EventMetadataSchema.parse(metadata.object);
 
-  const eventObject = { ...generatedEvent, eventMetadata: generatedMetadata };
+  // Deterministically compute the year from the MM-DD the model extracted.
+  // The model is unreliable at enforcing a year window in the prompt (see
+  // migrations/fix2027Dates.ts and fix2027FeedDates.ts for the history);
+  // this replaces the year whenever the source did not explicitly state one.
+  const today = Temporal.Now.instant()
+    .toZonedDateTimeISO(input.timezone)
+    .toPlainDate();
+  const normalized = normalizeEventYear(
+    {
+      startDate: generatedEvent.startDate,
+      endDate: generatedEvent.endDate,
+      hasExplicitYear: generatedEvent.hasExplicitYear ?? false,
+    },
+    today,
+  );
+
+  const eventObject = {
+    ...generatedEvent,
+    startDate: normalized.startDate,
+    endDate: normalized.endDate,
+    eventMetadata: generatedMetadata,
+  };
 
   const events = addCommonAddToCalendarProps([eventObject]);
   const response = `${

--- a/packages/backend/convex/model/aiHelpers.ts
+++ b/packages/backend/convex/model/aiHelpers.ts
@@ -11,6 +11,7 @@ import {
   addCommonAddToCalendarProps,
   EventMetadataSchema,
   EventSchema,
+  formatOffsetAsIANASoft,
   getPrompt,
   getSystemMessage,
   getSystemMessageMetadata,
@@ -578,7 +579,7 @@ export async function fetchAndProcessEvent({
   // migrations/fix2027Dates.ts and fix2027FeedDates.ts for the history);
   // this replaces the year whenever the source did not explicitly state one.
   const today = Temporal.Now.instant()
-    .toZonedDateTimeISO(input.timezone)
+    .toZonedDateTimeISO(formatOffsetAsIANASoft(input.timezone))
     .toPlainDate();
   const normalized = normalizeEventYear(
     {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@convex-dev/migrations": "catalog:",
     "@convex-dev/workflow": "catalog:",
     "@convex-dev/workpool": "catalog:",
+    "@js-temporal/polyfill": "catalog:",
     "@soonlist/cal": "workspace:*",
     "@vercel/functions": "catalog:",
     "ai": "catalog:",

--- a/packages/cal/src/index.ts
+++ b/packages/cal/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./normalizeEventYear";
 export * from "./prompts";
 export * from "./similarEvents";
 export * from "./utils";

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -10,9 +10,15 @@ import { Temporal } from "@js-temporal/polyfill";
  * it extract MM-DD and report whether the source explicitly stated a year.
  * If not, we compute the year ourselves: the soonest future instance of the
  * MM-DD relative to the current date in the user's timezone.
+ *
+ * Leap-day (Feb 29) inputs are handled by scanning forward for the next year
+ * in which the date actually exists, rather than silently clamping to Feb 28.
+ * Events that span a year boundary (e.g. New Year's Eve shows that end on
+ * Jan 1) are handled by advancing the end-date year until it is >= start.
  */
 
 const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MAX_YEAR_OFFSET = 4;
 
 interface NormalizeInput {
   startDate: string;
@@ -27,63 +33,111 @@ interface NormalizeOutput {
 
 /**
  * Compute the deterministic year for an MM-DD relative to today.
- * Returns today's year if the MM-DD falls on or after today's MM-DD,
- * otherwise the next year (i.e., the soonest future instance).
+ * Scans forward up to MAX_YEAR_OFFSET years and returns the first year where
+ * the MM-DD is a valid calendar date (handles Feb 29 in non-leap years) and
+ * the resulting date is on or after today. Throws for truly invalid
+ * month/day combinations (e.g. 13-40, 02-30) that cannot be satisfied in any
+ * year within the window.
  */
 export function pickYearForMonthDay(
   month: number,
   day: number,
   today: Temporal.PlainDate,
 ): number {
-  const candidate = Temporal.PlainDate.from({
-    year: today.year,
-    month,
-    day,
-  });
-  return Temporal.PlainDate.compare(candidate, today) >= 0
-    ? today.year
-    : today.year + 1;
+  for (let offset = 0; offset <= MAX_YEAR_OFFSET; offset++) {
+    const year = today.year + offset;
+    try {
+      const candidate = Temporal.PlainDate.from(
+        { year, month, day },
+        { overflow: "reject" },
+      );
+      if (Temporal.PlainDate.compare(candidate, today) >= 0) {
+        return year;
+      }
+    } catch {
+      // Invalid combination for this year (e.g. Feb 29 in non-leap year); try next.
+    }
+  }
+  throw new Error(`Invalid month/day combination: ${month}-${day}`);
+}
+
+/**
+ * Try to construct a PlainDate for `month`/`day` starting at `startYear` and
+ * scanning forward up to MAX_YEAR_OFFSET years with overflow:"reject". Returns
+ * the first valid PlainDate, or throws if none of the candidate years accept
+ * the month/day.
+ */
+function pickValidDate(
+  startYear: number,
+  month: number,
+  day: number,
+): Temporal.PlainDate {
+  for (let offset = 0; offset <= MAX_YEAR_OFFSET; offset++) {
+    try {
+      return Temporal.PlainDate.from(
+        { year: startYear + offset, month, day },
+        { overflow: "reject" },
+      );
+    } catch {
+      // Try next year.
+    }
+  }
+  throw new Error(`Invalid month/day combination: ${month}-${day}`);
 }
 
 /**
  * Normalize event start/end dates.
  *
- * - If `hasExplicitYear` is true, trust the model's year and return the dates
- *   unchanged (this is the only path that can produce dates outside the
- *   upcoming-year window, e.g. "March 15, 2028").
+ * - If `hasExplicitYear` is true, trust the model's year. Still apply the
+ *   end-after-start check so NYE-style events (end < start) get their end
+ *   advanced by one year.
  * - Otherwise, replace the year on `startDate` with the soonest future year
  *   for its MM-DD, and compute `endDate` so that it remains >= startDate
  *   (handling events that span a year boundary, e.g. a late-night New Year's
  *   Eve show that ends Jan 1).
  *
- * The function preserves the YYYY-MM-DD shape and throws on malformed input,
- * which should never happen because the schema has already validated it.
+ * The function preserves the YYYY-MM-DD shape. Construction uses
+ * overflow:"reject" so Feb 29 is never silently clamped to Feb 28; instead the
+ * year is advanced until the date exists. Throws on malformed input, which
+ * should never happen because the schema has already validated it.
  */
 export function normalizeEventYear(
   input: NormalizeInput,
   today: Temporal.PlainDate,
 ): NormalizeOutput {
   if (input.hasExplicitYear) {
-    return { startDate: input.startDate, endDate: input.endDate };
+    const start = parseDate(input.startDate);
+    const end = parseDate(input.endDate);
+    const startPd = Temporal.PlainDate.from(
+      { year: start.year, month: start.month, day: start.day },
+      { overflow: "reject" },
+    );
+    const endPd = Temporal.PlainDate.from(
+      { year: end.year, month: end.month, day: end.day },
+      { overflow: "reject" },
+    );
+    const adjustedEnd =
+      Temporal.PlainDate.compare(endPd, startPd) < 0
+        ? endPd.add({ years: 1 })
+        : endPd;
+    return {
+      startDate: startPd.toString(),
+      endDate: adjustedEnd.toString(),
+    };
   }
 
   const start = parseDate(input.startDate);
   const end = parseDate(input.endDate);
 
   const startYear = pickYearForMonthDay(start.month, start.day, today);
-  const normalizedStart = Temporal.PlainDate.from({
-    year: startYear,
-    month: start.month,
-    day: start.day,
-  });
+  const normalizedStart = Temporal.PlainDate.from(
+    { year: startYear, month: start.month, day: start.day },
+    { overflow: "reject" },
+  );
 
-  let normalizedEnd = Temporal.PlainDate.from({
-    year: startYear,
-    month: end.month,
-    day: end.day,
-  });
+  let normalizedEnd = pickValidDate(startYear, end.month, end.day);
   if (Temporal.PlainDate.compare(normalizedEnd, normalizedStart) < 0) {
-    normalizedEnd = normalizedEnd.add({ years: 1 });
+    normalizedEnd = pickValidDate(normalizedEnd.year + 1, end.month, end.day);
   }
 
   return {

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -1,0 +1,109 @@
+import { Temporal } from "@js-temporal/polyfill";
+
+/**
+ * Deterministically pick the year for event dates that the model extracted
+ * without an explicit year in the source text or image.
+ *
+ * The model is unreliable at enforcing date-window constraints in the prompt
+ * (this caused the recurring "2027 date" bug — see migrations/fix2027Dates.ts
+ * and migrations/fix2027FeedDates.ts). Instead of trusting the model, we have
+ * it extract MM-DD and report whether the source explicitly stated a year.
+ * If not, we compute the year ourselves: the soonest future instance of the
+ * MM-DD relative to the current date in the user's timezone.
+ */
+
+const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+interface NormalizeInput {
+  startDate: string;
+  endDate: string;
+  hasExplicitYear: boolean;
+}
+
+interface NormalizeOutput {
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * Compute the deterministic year for an MM-DD relative to today.
+ * Returns today's year if the MM-DD falls on or after today's MM-DD,
+ * otherwise the next year (i.e., the soonest future instance).
+ */
+export function pickYearForMonthDay(
+  month: number,
+  day: number,
+  today: Temporal.PlainDate,
+): number {
+  const candidate = Temporal.PlainDate.from({
+    year: today.year,
+    month,
+    day,
+  });
+  return Temporal.PlainDate.compare(candidate, today) >= 0
+    ? today.year
+    : today.year + 1;
+}
+
+/**
+ * Normalize event start/end dates.
+ *
+ * - If `hasExplicitYear` is true, trust the model's year and return the dates
+ *   unchanged (this is the only path that can produce dates outside the
+ *   upcoming-year window, e.g. "March 15, 2028").
+ * - Otherwise, replace the year on `startDate` with the soonest future year
+ *   for its MM-DD, and compute `endDate` so that it remains >= startDate
+ *   (handling events that span a year boundary, e.g. a late-night New Year's
+ *   Eve show that ends Jan 1).
+ *
+ * The function preserves the YYYY-MM-DD shape and throws on malformed input,
+ * which should never happen because the schema has already validated it.
+ */
+export function normalizeEventYear(
+  input: NormalizeInput,
+  today: Temporal.PlainDate,
+): NormalizeOutput {
+  if (input.hasExplicitYear) {
+    return { startDate: input.startDate, endDate: input.endDate };
+  }
+
+  const start = parseDate(input.startDate);
+  const end = parseDate(input.endDate);
+
+  const startYear = pickYearForMonthDay(start.month, start.day, today);
+  const normalizedStart = Temporal.PlainDate.from({
+    year: startYear,
+    month: start.month,
+    day: start.day,
+  });
+
+  let normalizedEnd = Temporal.PlainDate.from({
+    year: startYear,
+    month: end.month,
+    day: end.day,
+  });
+  if (Temporal.PlainDate.compare(normalizedEnd, normalizedStart) < 0) {
+    normalizedEnd = normalizedEnd.add({ years: 1 });
+  }
+
+  return {
+    startDate: normalizedStart.toString(),
+    endDate: normalizedEnd.toString(),
+  };
+}
+
+function parseDate(value: string): {
+  year: number;
+  month: number;
+  day: number;
+} {
+  const match = DATE_REGEX.exec(value);
+  if (!match) {
+    throw new Error(`Expected YYYY-MM-DD, got: ${value}`);
+  }
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}

--- a/packages/cal/src/prompts.ts
+++ b/packages/cal/src/prompts.ts
@@ -388,7 +388,7 @@ Common pitfalls (avoid):
 - Guessing platform; when unsure, use "unknown".
 `;
 
-const formatOffsetAsIANASoft = (offset: string) => {
+export const formatOffsetAsIANASoft = (offset: string) => {
   const timezone = soft(offset)[0];
   return timezone?.iana || Intl.DateTimeFormat().resolvedOptions().timeZone;
 };

--- a/packages/cal/src/prompts.ts
+++ b/packages/cal/src/prompts.ts
@@ -188,6 +188,12 @@ export const EventSchema = z.object({
     .describe(
       "End time in 24-hour format HH:MM:SS (e.g., 14:30:00 for 2:30 PM). Always include seconds, even if they're 00.",
     ),
+  hasExplicitYear: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true ONLY if the source text or image explicitly states a 4-digit year for the event (e.g., 'March 15, 2028' or 'Summer 2027'). Omit or set to false in every other case, including when the year is merely implied by recency, context, or your own guess. When false, any placeholder year you pick for startDate/endDate will be discarded and replaced downstream with the soonest future year that matches the month and day.",
+    ),
   timeZone: z.string().describe("Timezone in IANA format."),
   location: z.string().describe("Location of the event."),
   // eventMetadata: EventMetadataSchema,
@@ -294,15 +300,8 @@ export const systemMessage = (schema?: string) =>
  * Generates the main event extraction prompt text.
  * @param date - Current date in YYYY-MM-DD format (e.g., "2026-01-20")
  * @param timezone - IANA timezone identifier (e.g., "America/Los_Angeles")
- * @param minDate - Earliest valid date in YYYY-MM-DD format (e.g., "2025-11-20")
- * @param maxDate - Latest valid date in YYYY-MM-DD format (e.g., "2026-11-20")
  */
-export const getText = (
-  date: string,
-  timezone: string,
-  minDate: string,
-  maxDate: string,
-) => `# CONTEXT
+export const getText = (date: string, timezone: string) => `# CONTEXT
 The current date is ${date}, and the default timezone is ${timezone} unless specified otherwise.
 
 ## YOUR JOB
@@ -335,9 +334,10 @@ The system using the output requires specific date and time formatting.
 - Always include seconds in the time, even if they're 00.
 - Always provide both startTime and endTime.
 
-**Year Inference:**
-- If no year is explicitly stated: You MUST infer a year that places the date between ${minDate} and ${maxDate}.
-- If a year IS explicitly stated: Use that exact year. This is the ONLY time a date can fall outside the ${minDate} to ${maxDate} window.
+**Year Inference (read carefully):**
+- Set \`hasExplicitYear\` to true ONLY when the source text or image literally contains a 4-digit year tied to the event (e.g., "March 15, 2028", "Summer 2027", "NYE 2026/2027"). Recency, context, or your own best guess DO NOT count as explicit.
+- When \`hasExplicitYear\` is false, the year you write into \`startDate\`/\`endDate\` does not matter — pick the current year as a placeholder. The system will replace it downstream with the soonest future year that matches the month and day, so DO NOT try to reason about whether the event has "already passed this year".
+- When \`hasExplicitYear\` is true, use the exact year stated. Never invent a year just to satisfy recency.
 
 ** Time Inference (when a start or end time is not explicitly stated):**
 - If start time is not explicitly stated, infer a reasonable start time based on the event type and context (e.g., 19:00:00 for an evening concert, 10:00:00 for a morning workshop).
@@ -398,28 +398,25 @@ export const getPrompt = (
 ) => {
   const timezoneIANA = formatOffsetAsIANASoft(timezone);
   const now = Temporal.Now.instant().toZonedDateTimeISO(timezoneIANA);
-  const currentDate = now.toPlainDate();
-  const date = currentDate.toString();
-  const minDate = currentDate.subtract({ months: 2 }).toString();
-  const maxDate = currentDate.add({ months: 10 }).toString();
+  const date = now.toPlainDate().toString();
 
   return {
-    text: getText(date, timezoneIANA, minDate, maxDate),
+    text: getText(date, timezoneIANA),
     textMetadata: getTextMetadata(),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };
 
 export const getSystemMessage = () => {
   return {
     text: systemMessage(),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };
 
 export const getSystemMessageMetadata = () => {
   return {
     text: systemMessage(eventMetadataSchemaAsText),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,6 +1076,9 @@ importers:
       '@convex-dev/workpool':
         specifier: 'catalog:'
         version: 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+      '@js-temporal/polyfill':
+        specifier: 'catalog:'
+        version: 0.4.4
       '@soonlist/cal':
         specifier: workspace:*
         version: link:../cal
@@ -14281,7 +14284,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -19006,19 +19009,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       https-proxy-agent: 7.0.6
       metro-core: 0.83.3
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-config@0.83.3:
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

The 2027-date bug has been patched with prompt hardening twice already (#951, #860, #840) and still recurs — there are two live migrations (`fix2027Dates.ts`, `fix2027FeedDates.ts`) cleaning up after it. The root cause is that **prompt-level date-arithmetic constraints are soft** — the model violates the window often enough to keep corrupting data, and interpolating `"2027-02-10"` into the prompt as `maxDate` was actively priming it to emit 2027.

This PR takes the model out of the year-selection loop entirely.

- The model now extracts `MM-DD` only (it still writes a YYYY-MM-DD string to satisfy the schema, but we throw the year away) and self-reports a new `hasExplicitYear: boolean` flag.
- New helper `normalizeEventYear` computes the year deterministically using `Temporal`: the soonest future instance of the given MM-DD relative to "today" in the user's timezone. Year-spanning events (NYE shows ending Jan 1) have `endDate` bumped forward one year if it would otherwise precede `startDate`.
- Only when `hasExplicitYear === true` — meaning the source literally contains a 4-digit year — is the model's year trusted. That is the narrow path for "March 15, 2028" style inputs.
- Prompt simplified: removed the `minDate`/`maxDate` computation, removed the Year Inference window block, kept the instruction for what counts as "explicit year".
- Wired into `aiHelpers.ts` so normalization happens on every parsed event before it flows downstream.

## Why this should stick

Every previous fix relied on the model to enforce the window. This one doesn't — the year is picked by `Temporal.PlainDate.compare`, which is infallible. The only model decision left is the boolean `hasExplicitYear`, which is a classification task, not arithmetic.

## Verification

Manually verified against the exact bug scenario and edge cases. Representative case from the report: on `2026-04-10`, a model output of `2027-04-20` with `hasExplicitYear=false` now produces `2026-04-20`. NYE `2025-12-31 → 2026-01-01` (no explicit year) correctly normalizes to `2026-12-31 → 2027-01-01`. All 12 scenarios in a local verification script passed; script was deleted before commit since there is no test runner in `@soonlist/cal`.

Adding vitest to `packages/cal` would be a bigger yak shave than this PR warrants — happy to do it in a follow-up.

## Follow-up

After merge, run `npx convex run migrations/fix2027Dates:dryRun` (and the feed variant) to see how many records are still corrupted from before this fix, then run the migrations if the count is non-zero.

## Test plan

- [ ] Capture an event with no explicit year (Instagram post, flyer image) and confirm the stored `startDate` is the current year
- [ ] Capture an event dated in the first ~2 months of the calendar year and confirm it rolls over to next year
- [ ] Capture an event that explicitly says "2028" and confirm the year is preserved
- [ ] Capture an NYE event ending after midnight and confirm `endDate` is the correct next-day date
- [ ] `pnpm -F @soonlist/cal typecheck && pnpm -F @soonlist/backend typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deterministically compute event years to eliminate the 2027-date bug, now hardened for leap days and timezone offsets. The model extracts month/day plus `hasExplicitYear`; we pick the year using `Temporal` in the user’s timezone.

- **Bug Fixes**
  - Added `normalizeEventYear` in `@soonlist/cal` to choose the soonest future year, scan for a valid year for Feb 29, reject invalid month/day, and bump `endDate` when `endDate < startDate` (applies even when the year is explicit).
  - Updated `@soonlist/cal` prompts: added `hasExplicitYear` to `EventSchema`, removed the min/max window, and use the current year as a placeholder when not explicit.
  - In `@soonlist/backend` `aiHelpers.ts`, normalize years for all parsed events using `formatOffsetAsIANASoft` to resolve timezones like "UTC+5"; trust the model’s year only when `hasExplicitYear` is true; added `@js-temporal/polyfill` as a direct dependency.

- **Migration**
  - After merge, run `npx convex run migrations/fix2027Dates:dryRun` and `npx convex run migrations/fix2027FeedDates:dryRun`, then run the migrations if any records are flagged.

<sup>Written for commit a461d9c4622ae1d63321799964fc6923b02dc573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events without explicit years now resolve to the soonest matching future date.
  * Improved handling of events that span year boundaries (end dates adjusted to follow starts).
  * Deterministic parsing to prevent malformed or ambiguous month/day inputs.

* **Refactor**
  * Prompt/date-generation logic simplified: removed prior date-window constraints and now honors an explicit-year flag to control year usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->