### PR TITLE
chore(claude): add pre-commit format hook for Claude Code

### DIFF
--- a/.claude/hooks/format-before-commit.sh
+++ b/.claude/hooks/format-before-commit.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# PreToolUse:Bash hook — runs `pnpm format:fix` at repo root before any
+# `git commit` and re-stages files that were already staged. Idempotent;
+# turbo + prettier caches make warm runs ~1s.
+#
+# Design goals: match CI exactly (same command CI runs in check mode),
+# never let an unformatted file reach a commit, never clobber unrelated work.
+
+set -u
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | /usr/bin/python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("tool_input",{}).get("command",""))
+except: pass' 2>/dev/null || true)
+
+# Only act on actual `git commit` invocations at a shell command position
+# (start of line or after a command separator like ; && || |).
+if ! [[ "$cmd" =~ (^|[;\&\|])[[:space:]]*git[[:space:]]+commit([[:space:]]|$) ]]; then
+  exit 0
+fi
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$root" || exit 0
+
+# Snapshot what's staged so we know what to re-add after formatting.
+mapfile -t staged < <(git diff --cached --name-only --diff-filter=ACMR)
+
+# Guard: if any staged file ALSO has unstaged changes (partial staging via
+# `git add -p`), abort. Re-staging with `git add <file>` would pull the
+# unstaged hunks into the commit — silently changing its contents.
+mapfile -t unstaged < <(git diff --name-only)
+partial=()
+for s in "${staged[@]}"; do
+  for u in "${unstaged[@]}"; do
+    [ "$s" = "$u" ] && partial+=("$s")
+  done
+done
+if [ ${#partial[@]} -gt 0 ]; then
+  echo "[format-hook] partial staging detected — aborting to avoid clobbering unstaged hunks:" >&2
+  printf '  - %s\n' "${partial[@]}" >&2
+  echo "[format-hook] run 'pnpm format:fix', stage the formatted files as you want them, then re-commit." >&2
+  exit 2
+fi
+
+# Run the canonical command. CI runs `pnpm format` (check); we run the
+# write version. Same turbo task, same prettier config, same cache file.
+if ! pnpm format:fix >&2 2>&1; then
+  echo "[format-hook] pnpm format:fix failed — aborting commit" >&2
+  exit 2
+fi
+
+# Re-stage files that were already in the index if prettier touched them.
+# Files prettier touched that weren't staged are left unstaged on purpose
+# (they weren't part of this commit).
+for f in "${staged[@]}"; do
+  [ -f "$f" ] && git add -- "$f"
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a PreToolUse:Bash hook for Claude Code that runs `pnpm format:fix` before any `git commit` and re-stages the previously-staged files. Stops the recurring CI format failures caused by Claude skipping the format step documented in `CLAUDE.md`.

## Why

CI runs `pnpm format` (check mode). Nothing locally enforces `pnpm format:fix` before commits — the instruction in `CLAUDE.md` is a suggestion Claude routinely skips, so PRs keep landing with unformatted files.

## How it works

- Triggers only on real `git commit` invocations (`^` or after `;` `&&` `||` `|`). Substrings like `echo "git commit"` no-op.
- Runs the repo's canonical `pnpm format:fix` at the repo root — same turbo task CI runs, just with `--write`. Hits every package, respects every `.prettierignore`.
- Re-stages only the files that were already staged. Files prettier touches outside the commit scope stay unstaged.
- **Aborts on partial staging** (`git add -p`): if a staged file also has unstaged changes, the hook exits 2 with a clear message rather than silently clobbering the unstaged hunks.
- Fast: ~1–2s warm (turbo + prettier cache), ~5s cold.

## Opt-in per developer

The hook script is committed, but wiring is per-developer in the gitignored `.claude/settings.local.json`:

```json
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash",
        "hooks": [
          {
            "type": "command",
            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/format-before-commit.sh"
          }
        ]
      }
    ]
  }
}
```

## Test plan

- [ ] Enable in local `.claude/settings.local.json`
- [ ] Modify a file in a way prettier would reformat (e.g. add stray whitespace)
- [ ] Run `git add` + `git commit` via Claude
- [ ] Verify the committed blob is formatted (not the pre-fix working-tree version)
- [ ] Verify CI `format` job passes
- [ ] Try `git add -p` partial staging and confirm the hook aborts cleanly
- [ ] Run a non-commit bash command and confirm no-op (no prettier run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Code PreToolUse Bash hook that runs `pnpm format:fix` before any `git commit` and re-stages the files that were already staged. This keeps unformatted code out of commits and stops CI `pnpm format` failures.

- **New Features**
  - Triggers only on real `git commit` invocations; no-ops for echoed strings.
  - Runs repo-root `pnpm format:fix` to match CI’s check command (write mode).
  - Re-stages only files that were staged; leaves other changes untouched.
  - Aborts on partial staging to avoid pulling unstaged hunks into the commit.

- **Migration**
  - Opt-in: add a PreToolUse Bash hook in `.claude/settings.local.json` pointing to `.claude/hooks/format-before-commit.sh`.

<sup>Written for commit df3844941b3abf765f7007098d4f908bce664a53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated pre-commit hook that formats code before commits and validates staging to prevent accidental inclusion of unformatted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->