### PR TITLE
chore: enable turbo tui for interactive dev logs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,7 @@
     "STRIPE_WEBHOOK_SECRET"
   ],
   "globalPassThroughEnv": ["COREPACK_HOME"],
-  "ui": "stream",
+  "ui": "tui",
   "tasks": {
     "topo": {
       "dependsOn": ["^topo"]


### PR DESCRIPTION
## Summary
- Switch turbo's `ui` from `stream` to `tui` so `pnpm dev` renders an interactive terminal UI where you can tab between tasks instead of getting a single interleaved log stream.

## Test plan
- [ ] Run `pnpm dev` locally and confirm the TUI opens (arrow keys to switch tasks, `?` for shortcuts).
- [ ] Confirm CI still renders logs (TUI falls back to stream in non-interactive terminals).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `turbo.json` `ui` from `stream` to `tui` so `pnpm dev` shows an interactive task UI instead of interleaved logs. CI remains unchanged; non-interactive terminals automatically fall back to stream logs.

<sup>Written for commit 443109fc8454a86a1546d18b000f9c39c8347606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches Turborepo's `ui` config in `turbo.json` from `"stream"` to `"tui"`, enabling the interactive Terminal UI for local development. Per Turborepo's documented behavior, the TUI automatically falls back to `stream` mode in non-interactive terminals (CI/CD), so this change is safe for both local and automated workflows.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config change with well-documented CI fallback behavior.

The only change is switching Turborepo's `ui` setting from `stream` to `tui`. The TUI automatically degrades to stream in non-interactive terminals, so CI is unaffected. No logic, security, or correctness concerns exist.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| turbo.json | Single-line change switching `ui` from `"stream"` to `"tui"`; no other tasks or configuration affected. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm dev / turbo run] --> B{Interactive terminal?}
    B -- Yes --> C[TUI mode\nTab between tasks\nArrow-key navigation]
    B -- No\nCI / pipe / non-TTY --> D[Stream mode\nInterleaved log output]
    C --> E[Developer experience ✓]
    D --> F[CI logs intact ✓]
```

<sub>Reviews (1): Last reviewed commit: ["chore: enable turbo tui for interactive ..."](https://github.com/jaronheard/soonlist-turbo/commit/443109fc8454a86a1546d18b000f9c39c8347606) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28597700)</sub>

<!-- /greptile_comment -->