### PR TITLE
Refine event detail spacing and date line (Expo)

### DIFF
--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -351,11 +351,12 @@ function EventDetail({ id }: { id: string }) {
         maximumZoomScale={5}
       >
         <View className="p-4">
-          <View className="flex flex-col gap-5">
+          {/* Date + title */}
+          <View className="flex flex-col gap-2">
             <View>
-              <Text className="text-lg text-neutral-2">{date}</Text>
-              <Text className="text-lg text-neutral-2">
-                {time}
+              <Text className="text-lg font-medium text-neutral-2">
+                {date}
+                {time ? ` • ${time}` : ""}
                 {eventTime && (
                   <>
                     {" "}
@@ -364,81 +365,86 @@ function EventDetail({ id }: { id: string }) {
                 )}
               </Text>
             </View>
-            <Text className="font-heading text-4xl font-bold text-neutral-1">
+            <Text className="font-heading text-3xl font-bold text-neutral-1">
               {eventData.name}
             </Text>
-
-            {/* Location link */}
-            {eventData.location && (
-              <Link
-                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                  eventData.location,
-                )}`}
-                asChild
-              >
-                <Pressable>
-                  <View className="flex-row items-center">
-                    <MapPinned size={16} color="#5A32FB" />
-                    <Text className="ml-1 text-interactive-1">
-                      {eventData.location}
-                    </Text>
-                  </View>
-                </Pressable>
-              </Link>
-            )}
-
-            {/* Visibility or user info */}
-            {showDiscover && (
-              <>
-                {isCurrentUserEvent ? (
-                  <View className="flex-row items-center gap-2">
-                    {event.visibility === "public" ? (
-                      <Globe2 size={16} color="#627496" />
-                    ) : (
-                      <EyeOff size={16} color="#627496" />
-                    )}
-                    <Text className="text-sm text-neutral-2">
-                      {event.visibility === "public"
-                        ? "Discoverable"
-                        : "Not discoverable"}
-                    </Text>
-                  </View>
-                ) : (
-                  <Pressable
-                    onPress={() => router.push(`/${event.user?.username}`)}
-                    className="-my-2 flex-row items-center gap-2 py-2"
-                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  >
-                    <UserProfileFlair
-                      username={event.user?.username || ""}
-                      size="xs"
-                    >
-                      {event.user?.userImage ? (
-                        <ExpoImage
-                          source={{ uri: event.user.userImage }}
-                          style={{ width: 20, height: 20, borderRadius: 10 }}
-                          contentFit="cover"
-                          contentPosition="center"
-                          cachePolicy="disk"
-                          transition={100}
-                        />
-                      ) : (
-                        <User size={20} color="#627496" />
-                      )}
-                    </UserProfileFlair>
-                    <Text className="text-sm text-neutral-2">
-                      {event.user?.displayName ||
-                        event.user?.username ||
-                        "unknown"}
-                    </Text>
-                  </Pressable>
-                )}
-              </>
-            )}
           </View>
 
+          {/* Meta rows (venue + visibility/author) */}
+          {(eventData.location || showDiscover) && (
+            <View className="mt-4 flex flex-col gap-2">
+              {/* Location link */}
+              {eventData.location && (
+                <Link
+                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                    eventData.location,
+                  )}`}
+                  asChild
+                >
+                  <Pressable>
+                    <View className="flex-row items-center">
+                      <MapPinned size={16} color="#5A32FB" />
+                      <Text className="ml-1 text-interactive-1">
+                        {eventData.location}
+                      </Text>
+                    </View>
+                  </Pressable>
+                </Link>
+              )}
+
+              {/* Visibility or user info */}
+              {showDiscover && (
+                <>
+                  {isCurrentUserEvent ? (
+                    <View className="flex-row items-center gap-2">
+                      {event.visibility === "public" ? (
+                        <Globe2 size={16} color="#627496" />
+                      ) : (
+                        <EyeOff size={16} color="#627496" />
+                      )}
+                      <Text className="text-sm text-neutral-2">
+                        {event.visibility === "public"
+                          ? "Discoverable"
+                          : "Not discoverable"}
+                      </Text>
+                    </View>
+                  ) : (
+                    <Pressable
+                      onPress={() => router.push(`/${event.user?.username}`)}
+                      className="-my-2 flex-row items-center gap-2 py-2"
+                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    >
+                      <UserProfileFlair
+                        username={event.user?.username || ""}
+                        size="xs"
+                      >
+                        {event.user?.userImage ? (
+                          <ExpoImage
+                            source={{ uri: event.user.userImage }}
+                            style={{ width: 20, height: 20, borderRadius: 10 }}
+                            contentFit="cover"
+                            contentPosition="center"
+                            cachePolicy="disk"
+                            transition={100}
+                          />
+                        ) : (
+                          <User size={20} color="#627496" />
+                        )}
+                      </UserProfileFlair>
+                      <Text className="text-sm text-neutral-2">
+                        {event.user?.displayName ||
+                          event.user?.username ||
+                          "unknown"}
+                      </Text>
+                    </Pressable>
+                  )}
+                </>
+              )}
+            </View>
+          )}
+
           {/* Description */}
-          <View className="my-8">
+          <View className="mb-3 mt-6">
             <Text className="text-neutral-1">{eventData.description}</Text>
           </View>
 


### PR DESCRIPTION
## Summary

Polish pass on the Expo event detail screen ([apps/expo/src/app/event/[id]/index.tsx](apps/expo/src/app/event/[id]/index.tsx)):

- **Date line** now matches the list view's pattern — one line, bullet separator (`date • time`), `text-lg font-medium text-neutral-2` — instead of two stacked `Text` lines at normal weight. The bullet is suppressed when there's no time (all-day events).
- **Title** dropped from `text-4xl` to `text-3xl` for better balance on mobile.
- **Spacing scale** applied across the screen for a more consistent rhythm:

  | Transition | Spacing |
  | --- | --- |
  | Date → Title | 8px |
  | Title → Meta rows | 16px |
  | Between meta rows | 8px |
  | Meta → Description | 24px |
  | Description → Attribution | 12px |
  | Attribution → Image | 24px |

  Structurally, the previous single `gap-4` header wrapper is split into a date+title group and a meta group (venue + visibility/author). The meta group is only rendered when there's at least one row to show.

## Why

The original screen used a uniform `gap-5` across date, title, venue, and discoverability, plus `my-8` around description — which made the header feel airy and inconsistent with the tightly-grouped list view. The new scale preserves hierarchy (title still breathes) while making related rows (date+title; venue+visibility) read as groups.

## Test plan

- [ ] Open an event with start + end time → date/time reads as one bold-ish line with bullet
- [ ] Open an all-day event (no time) → no trailing bullet
- [ ] Open an event with a non-local timezone → italic `(HH:MMPM TZ)` still renders after the local time
- [ ] Event without a location → header spacing still correct (meta group hidden or showing only visibility row)
- [ ] Event without attribution → description sits reasonably close to the image
- [ ] Visual: compare against list view to confirm typographic alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Expo event detail screen to match the list view: date and time are now a single `text-lg font-medium` line with a bullet (suppressed for all‑day), the title drops to `text-3xl`, and spacing is standardized for clearer grouping. The header is split into a date+title block and an optional meta block (location and discoverability/author), with adjusted description spacing for a tighter rhythm.

<sup>Written for commit ddcce5f18aff5f20bc3e0dccf3a53e2a50052193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines the Expo event detail screen with a focused spacing polish: the two-line date+time display is consolidated into a single `date • time` line (bullet suppressed for all-day events), the title drops from `text-4xl` to `text-3xl`, and the header is restructured into a date+title group and a conditionally-rendered meta group (venue + visibility/author). No logic changes were made — all touched behaviour is purely presentational.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely presentational changes with no logic or data flow modifications.

All changes are layout/typographic adjustments. The date-line consolidation correctly guards the bullet with `time ? ` • ${time}` : ""`, and `eventTime` can only be truthy when `startTime` is present (enforced upstream by `shouldShowTimezone`), so the italic timezone suffix never appears orphaned. The conditional meta-group wrapper `(eventData.location || showDiscover)` is correct and mirrors the inner guards. No P0 or P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/event/[id]/index.tsx | Spacing and typographic polish: date+time merged to one line with bullet separator, title downscaled, header split into two conditional groups, description margins tightened. No functional changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventDetail render] --> B[Date + Title group\ngap-2]
    B --> C{time truthy?}
    C -- yes --> D["date • time"]
    C -- no --> E["date only\n(all-day)"]
    D --> F{eventTime?}
    E --> F
    F -- yes --> G["italic (TZ abbrev)"]
    F -- no --> H[End date line]
    G --> H
    H --> I{location OR showDiscover?}
    I -- yes --> J[Meta group\nmt-4 gap-2]
    J --> K{location?}
    K -- yes --> L[MapPinned + location link]
    K -- no --> M{showDiscover?}
    L --> M
    M -- yes --> N{isCurrentUserEvent?}
    N -- yes --> O[Visibility badge]
    N -- no --> P[Author pressable]
    O --> Q[Description\nmb-3 mt-6]
    P --> Q
    M -- no --> Q
    I -- no --> Q
    Q --> R[Metadata / Attribution / Image]
```

<sub>Reviews (1): Last reviewed commit: ["style(expo): refine event detail spacing..."](https://github.com/jaronheard/soonlist-turbo/commit/ddcce5f18aff5f20bc3e0dccf3a53e2a50052193) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28599837)</sub>

<!-- /greptile_comment -->