### PR TITLE
Profile redesign + subscribe vocabulary

### DIFF
--- a/apps/expo/src/app/(tabs)/following/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/following/_layout.tsx
@@ -1,26 +1,11 @@
-import React, { useCallback } from "react";
-import { Share, View } from "react-native";
+import React from "react";
+import { View } from "react-native";
 import { Stack } from "expo-router";
-import { useUser } from "@clerk/clerk-expo";
 
 import { CaptureOverlayButton } from "~/components/CaptureOverlayButton";
 import { ProfileMenu } from "~/components/ProfileMenu";
 
 export default function FollowingLayout() {
-  const { user } = useUser();
-  const username = user?.username;
-
-  const handleShare = useCallback(async () => {
-    if (!username) return;
-    try {
-      await Share.share({
-        url: `https://soonlist.com/${username}/my-scene`,
-      });
-    } catch {
-      // ignore
-    }
-  }, [username]);
-
   return (
     <View style={{ flex: 1 }}>
       <Stack
@@ -38,14 +23,6 @@ export default function FollowingLayout() {
           options={{
             title: "My Scene",
             unstable_headerRightItems: () => [
-              {
-                type: "button",
-                label: "",
-                icon: { type: "sfSymbol", name: "square.and.arrow.up" },
-                onPress: () => void handleShare(),
-                accessibilityLabel: "Share",
-                tintColor: "#5A32FB",
-              },
               {
                 type: "custom",
                 element: <ProfileMenu />,

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -124,7 +124,7 @@ function FollowingEmptyState() {
           className="mb-1 text-base font-medium text-neutral-2"
           style={{ paddingLeft: 6 }}
         >
-          Events from lists I follow
+          Events from lists I subscribe to
         </Text>
       </View>
       <View
@@ -157,7 +157,7 @@ function FollowingEmptyState() {
             lineHeight: 22,
           }}
         >
-          Follow other lists to see their events here
+          Subscribe to other lists to see their events here
         </Text>
         <TouchableOpacity
           onPress={() => void handleInvite()}
@@ -301,7 +301,7 @@ function FollowingFeedContent() {
           className="mb-1 text-base font-medium text-neutral-2"
           style={{ paddingLeft: 6 }}
         >
-          Events from lists I follow
+          Events from lists I subscribe to
         </Text>
         {followedListCount > 0 && (
           <TouchableOpacity

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,10 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   ActivityIndicator,
-  Modal,
-  Platform,
-  Pressable,
-  ScrollView,
   Text,
   TouchableOpacity,
   View,
@@ -16,18 +12,14 @@ import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { Check, User } from "~/components/icons";
+import { User } from "~/components/icons";
 import SaveShareButton from "~/components/SaveShareButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
-import { hapticSuccess, toast } from "~/utils/feedback";
-
-function isPersonalSystemList(list: Doc<"lists">): boolean {
-  return list.isSystemList === true && list.systemListType === "personal";
-}
+import { hapticLight, toast } from "~/utils/feedback";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -47,260 +39,11 @@ function profileLocationFromUser(user: {
   return null;
 }
 
-const sceneCardShadow =
-  Platform.OS === "ios"
-    ? {
-        shadowColor: "#5A32FB",
-        shadowOffset: { width: 0, height: 6 },
-        shadowOpacity: 0.07,
-        shadowRadius: 14,
-      }
-    : { elevation: 2 };
-
-/** Three tilted tiles; soft edges, no harsh strokes. */
-function ScenePreviewThreeUp({
-  imageUris,
-  align = "start",
-}: {
-  imageUris: (string | null)[];
-  align?: "start" | "center";
-}) {
-  const slots: (string | null)[] = [0, 1, 2].map((i) => imageUris[i] ?? null);
-  return (
-    <View
-      className={`flex-row items-center py-1 ${align === "center" ? "justify-center" : "justify-start"}`}
-    >
-      {slots.map((uri, i) => (
-        <View
-          key={i}
-          className="overflow-hidden rounded-lg bg-neutral-4"
-          style={{
-            width: 56,
-            height: 72,
-            marginLeft: i > 0 ? -14 : 0,
-            transform: [{ rotate: `${-8 + i * 8}deg` }],
-            zIndex: 3 - i,
-            ...sceneCardShadow,
-          }}
-        >
-          {uri ? (
-            <Image
-              source={{ uri }}
-              style={{ width: "100%", height: "100%" }}
-              contentFit="cover"
-              cachePolicy="disk"
-            />
-          ) : (
-            <View className="h-full w-full bg-neutral-4" />
-          )}
-        </View>
-      ))}
-    </View>
-  );
-}
-
-type ListWithCount = Doc<"lists"> & { followerCount: number };
-
-function OptOutCheckboxVisual({ checked }: { checked: boolean }) {
-  return (
-    <View
-      accessibilityElementsHidden
-      className={`h-6 w-6 items-center justify-center rounded-md ${
-        checked ? "bg-interactive-1" : "border-2 border-neutral-4 bg-white"
-      }`}
-    >
-      {checked ? <Check size={14} color="#FFFFFF" strokeWidth={3} /> : null}
-    </View>
-  );
-}
-
-/** Compact centered sheet: Follow all + checkboxes to opt out (X-style). */
-function FollowSceneModal({
-  visible,
-  onClose,
-  packLists,
-  followingIds,
-  followListMutation,
-}: {
-  visible: boolean;
-  onClose: () => void;
-  packLists: ListWithCount[];
-  followingIds: Set<string>;
-  followListMutation: (args: { listId: string }) => Promise<unknown>;
-}) {
-  const [includedIds, setIncludedIds] = useState<Set<string>>(new Set());
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    if (!visible) return;
-    setIncludedIds(new Set(packLists.map((l) => l.id)));
-  }, [visible, packLists]);
-
-  const toggleIncluded = useCallback((listId: string) => {
-    setIncludedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(listId)) next.delete(listId);
-      else next.add(listId);
-      return next;
-    });
-  }, []);
-
-  const handleFollowAll = useCallback(async () => {
-    const toFollow = packLists.filter(
-      (l) => includedIds.has(l.id) && !followingIds.has(l.id),
-    );
-    if (toFollow.length === 0) {
-      const anySelected = packLists.some((l) => includedIds.has(l.id));
-      if (!anySelected) {
-        toast.warning("Select at least one list");
-      } else {
-        void hapticSuccess();
-      }
-      onClose();
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      for (const l of toFollow) {
-        await followListMutation({ listId: l.id });
-      }
-      void hapticSuccess();
-      onClose();
-    } catch (error) {
-      logError("Follow scene batch", error);
-      toast.error("Couldn’t complete follows");
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [packLists, includedIds, followingIds, followListMutation, onClose]);
-
-  if (packLists.length === 0) {
-    return (
-      <Modal
-        visible={visible}
-        transparent
-        animationType="fade"
-        onRequestClose={onClose}
-      >
-        <Pressable
-          className="flex-1 items-center justify-center bg-black/35 px-6"
-          onPress={onClose}
-        >
-          <Pressable
-            className="w-full max-w-sm rounded-3xl bg-white px-5 py-5"
-            onPress={(e) => e.stopPropagation()}
-            style={sceneCardShadow}
-          >
-            <Text className="text-center text-base font-semibold text-neutral-1">
-              No lists in this scene yet
-            </Text>
-            <TouchableOpacity
-              onPress={onClose}
-              className="mt-4 items-center rounded-full bg-neutral-4 py-3"
-              activeOpacity={0.8}
-            >
-              <Text className="text-sm font-semibold text-neutral-2">
-                Close
-              </Text>
-            </TouchableOpacity>
-          </Pressable>
-        </Pressable>
-      </Modal>
-    );
-  }
-
-  return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={onClose}
-    >
-      <Pressable
-        className="flex-1 items-center justify-center bg-black/35 px-5"
-        onPress={onClose}
-      >
-        <Pressable
-          className="w-full max-w-sm rounded-3xl bg-white px-5 py-5"
-          onPress={(e) => e.stopPropagation()}
-          style={sceneCardShadow}
-        >
-          <Text className="text-lg font-bold text-neutral-1">Follow scene</Text>
-          <Text className="mt-1 text-sm leading-5 text-neutral-2">
-            You’ll follow every list below. Uncheck any you want to skip.
-          </Text>
-
-          <ScrollView
-            className="mt-4 max-h-64"
-            keyboardShouldPersistTaps="handled"
-            showsVerticalScrollIndicator={false}
-          >
-            {packLists.map((list) => {
-              const included = includedIds.has(list.id);
-              return (
-                <TouchableOpacity
-                  key={list.id}
-                  className="mb-3 flex-row items-center gap-3 py-1"
-                  onPress={() => toggleIncluded(list.id)}
-                  activeOpacity={0.7}
-                  accessibilityRole="checkbox"
-                  accessibilityState={{ checked: included }}
-                >
-                  <OptOutCheckboxVisual checked={included} />
-                  <View className="min-w-0 flex-1">
-                    <Text
-                      className="text-base font-semibold text-neutral-1"
-                      numberOfLines={2}
-                    >
-                      {list.name}
-                    </Text>
-                    {followingIds.has(list.id) ? (
-                      <Text className="text-xs text-neutral-2">
-                        Already following
-                      </Text>
-                    ) : null}
-                  </View>
-                </TouchableOpacity>
-              );
-            })}
-          </ScrollView>
-
-          <TouchableOpacity
-            onPress={() => void handleFollowAll()}
-            disabled={isSubmitting}
-            className="mt-2 items-center rounded-full bg-interactive-1 py-3.5"
-            activeOpacity={0.85}
-          >
-            {isSubmitting ? (
-              <ActivityIndicator color="#FFFFFF" />
-            ) : (
-              <Text className="text-base font-semibold text-white">
-                Follow all
-              </Text>
-            )}
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            onPress={onClose}
-            className="mt-2 items-center py-2"
-            activeOpacity={0.7}
-          >
-            <Text className="text-base font-semibold text-interactive-1">
-              Cancel
-            </Text>
-          </TouchableOpacity>
-        </Pressable>
-      </Pressable>
-    </Modal>
-  );
-}
-
 export default function UserProfilePage() {
   const { username } = useLocalSearchParams<{ username: string }>();
   const stableTimestamp = useStableTimestamp();
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
-  const [scenePackOpen, setScenePackOpen] = useState(false);
 
   const targetUser = useQuery(
     api.users.getByUsername,
@@ -309,17 +52,34 @@ export default function UserProfilePage() {
 
   const currentUser = useQuery(api.users.getCurrentUser);
 
-  const userLists = useQuery(
-    api.lists.getListsForUser,
-    targetUser?.id ? { userId: targetUser.id } : "skip",
-  );
-
   const personalList = useQuery(
     api.lists.getPersonalListForUser,
     targetUser?.id ? { userId: targetUser.id } : "skip",
   );
 
-  const followListMutation = useMutation(api.lists.followList);
+  const followListMutation = useMutation(
+    api.lists.followList,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.lists.getFollowedLists, {});
+    if (current === undefined || !personalList) return;
+    if (current.some((l) => l.id === args.listId)) return;
+    localStore.setQuery(api.lists.getFollowedLists, {}, [
+      ...current,
+      personalList,
+    ]);
+  });
+
+  const unfollowListMutation = useMutation(
+    api.lists.unfollowList,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.lists.getFollowedLists, {});
+    if (current === undefined) return;
+    localStore.setQuery(
+      api.lists.getFollowedLists,
+      {},
+      current.filter((l) => l.id !== args.listId),
+    );
+  });
 
   const savedEventIdsQuery = useQuery(
     api.events.getSavedIdsForUser,
@@ -355,41 +115,6 @@ export default function UserProfilePage() {
     });
   }, [events, stableTimestamp]);
 
-  const scenePreviewImageUris = useMemo((): (string | null)[] => {
-    const urls: string[] = [];
-    for (const e of filteredEvents) {
-      const url = e.image;
-      if (typeof url === "string" && url.length > 0) {
-        urls.push(url);
-        if (urls.length >= 3) break;
-      }
-    }
-    return [urls[0] ?? null, urls[1] ?? null, urls[2] ?? null];
-  }, [filteredEvents]);
-
-  const sceneLists = useMemo((): ListWithCount[] => {
-    if (!userLists) return [];
-    return userLists.filter((list) => !isPersonalSystemList(list));
-  }, [userLists]);
-
-  const personalListFollowerCount = useMemo(() => {
-    if (!personalList || !userLists) return 0;
-    const row = userLists.find((l) => l.id === personalList.id);
-    return row?.followerCount ?? 0;
-  }, [personalList, userLists]);
-
-  const packLists = useMemo((): ListWithCount[] => {
-    const out: ListWithCount[] = [];
-    if (personalList) {
-      out.push({
-        ...personalList,
-        followerCount: personalListFollowerCount,
-      });
-    }
-    out.push(...sceneLists);
-    return out;
-  }, [personalList, personalListFollowerCount, sceneLists]);
-
   const handleLoadMore = () => {
     if (status === "CanLoadMore") {
       loadMore(25);
@@ -405,14 +130,6 @@ export default function UserProfilePage() {
     [followedLists],
   );
 
-  const openScenePack = useCallback(() => {
-    if (!isAuthenticated) {
-      router.push("/(auth)/sign-in");
-      return;
-    }
-    setScenePackOpen(true);
-  }, [isAuthenticated, router]);
-
   const isUserLoading = targetUser === undefined;
   const userNotFound = targetUser === null;
   const isOwnProfile = currentUser?.id === targetUser?.id;
@@ -420,22 +137,32 @@ export default function UserProfilePage() {
   const screenTitle =
     targetUser?.displayName || targetUser?.username || "Profile";
 
-  const sceneSourceCount = sceneLists.length;
-  const moreEventsBeyondPreview = Math.max(0, filteredEvents.length - 3);
-  const sceneStatsLine = useMemo(() => {
-    const n = filteredEvents.length;
-    if (n === 0) {
-      return "No upcoming events in this feed yet.";
+  const isFollowingPersonalList = personalList
+    ? followingIds.has(personalList.id)
+    : false;
+
+  const handleFollowListPress = useCallback(() => {
+    if (!personalList) return;
+    if (!isAuthenticated) {
+      router.push("/(auth)/sign-in");
+      return;
     }
-    const sources =
-      sceneSourceCount > 0
-        ? `${sceneSourceCount} source${sceneSourceCount === 1 ? "" : "s"}`
-        : "their picks";
-    if (moreEventsBeyondPreview <= 0) {
-      return `${n} event${n === 1 ? "" : "s"} from ${sources}`;
-    }
-    return `${moreEventsBeyondPreview} more event${moreEventsBeyondPreview === 1 ? "" : "s"} from ${sources}`;
-  }, [filteredEvents.length, moreEventsBeyondPreview, sceneSourceCount]);
+    void hapticLight();
+    const run = isFollowingPersonalList
+      ? unfollowListMutation
+      : followListMutation;
+    run({ listId: personalList.id }).catch((error: unknown) => {
+      logError("Toggle follow personal list", error);
+      toast.error("Couldn't update follow");
+    });
+  }, [
+    personalList,
+    isAuthenticated,
+    isFollowingPersonalList,
+    followListMutation,
+    unfollowListMutation,
+    router,
+  ]);
 
   const listHeader = useMemo(() => {
     if (!targetUser) {
@@ -444,66 +171,14 @@ export default function UserProfilePage() {
     const upcomingCount = filteredEvents.length;
 
     return (
-      <>
-        <ProfileIdentityHeader
-          user={targetUser}
-          upcomingEventCount={upcomingCount}
-        />
-
-        <View className="px-4 pb-2">
-          <Text className="mb-1 text-base font-medium text-neutral-1">
-            {isOwnProfile ? "Your scene" : "Their scene"}
-          </Text>
-          <TouchableOpacity
-            onPress={
-              isOwnProfile
-                ? undefined
-                : packLists.length > 0
-                  ? openScenePack
-                  : undefined
-            }
-            disabled={isOwnProfile || packLists.length === 0}
-            activeOpacity={0.85}
-            accessibilityRole="button"
-            accessibilityLabel={`${isOwnProfile ? "Your" : "Their"} scene: follow lists`}
-          >
-            <View className="flex-row items-center gap-3">
-              <ScenePreviewThreeUp
-                imageUris={scenePreviewImageUris}
-                align="start"
-              />
-              <View className="min-w-0 flex-1">
-                <Text className="text-sm leading-5 text-neutral-2">
-                  {sceneStatsLine}
-                </Text>
-                {!isOwnProfile && packLists.length > 0 ? (
-                  <View className="mt-1.5 self-start rounded-full bg-interactive-1 px-4 py-1.5">
-                    <Text className="text-sm font-semibold text-white">
-                      Follow scene
-                    </Text>
-                  </View>
-                ) : null}
-              </View>
-            </View>
-          </TouchableOpacity>
-        </View>
-
-        <View className="px-4 pb-2">
-          <Text className="text-base font-medium text-neutral-1">
-            {isOwnProfile ? "From your Soonlist" : "From their Soonlist"}
-          </Text>
-        </View>
-      </>
+      <ProfileIdentityHeader
+        user={targetUser}
+        upcomingEventCount={upcomingCount}
+      />
     );
-  }, [
-    targetUser,
-    isOwnProfile,
-    scenePreviewImageUris,
-    sceneStatsLine,
-    openScenePack,
-    packLists.length,
-    filteredEvents.length,
-  ]);
+  }, [targetUser, filteredEvents.length]);
+
+  const renderListHeader = useCallback(() => listHeader, [listHeader]);
 
   if (isUserLoading) {
     return (
@@ -573,7 +248,21 @@ export default function UserProfilePage() {
           headerTitleStyle: {
             color: "#5A32FB",
           },
-          headerRight: () => null,
+          unstable_headerRightItems:
+            isOwnProfile || !personalList
+              ? undefined
+              : () => [
+                  {
+                    type: "custom",
+                    element: (
+                      <ProfileFollowHeaderButton
+                        isFollowing={isFollowingPersonalList}
+                        onPress={handleFollowListPress}
+                      />
+                    ),
+                    hidesSharedBackground: true,
+                  },
+                ],
         }}
       />
       <View className="flex-1 bg-interactive-3">
@@ -587,17 +276,8 @@ export default function UserProfilePage() {
           primaryAction={isOwnProfile ? "addToCalendar" : "save"}
           ActionButton={ProfileSaveShareButtonWrapper}
           savedEventIds={savedEventIds}
-          HeaderComponent={() => listHeader}
+          HeaderComponent={renderListHeader}
         />
-        {!isOwnProfile ? (
-          <FollowSceneModal
-            visible={scenePackOpen}
-            onClose={() => setScenePackOpen(false)}
-            packLists={packLists}
-            followingIds={followingIds}
-            followListMutation={followListMutation}
-          />
-        ) : null}
       </View>
     </>
   );
@@ -614,54 +294,72 @@ interface ProfileIdentityHeaderProps {
   upcomingEventCount: number;
 }
 
-/** Left-aligned identity row: avatar + metadata (matches My Soonlist list header rhythm). */
+function ProfileFollowHeaderButton({
+  isFollowing,
+  onPress,
+}: {
+  isFollowing: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityLabel={isFollowing ? "Following list" : "Follow list"}
+      className={`rounded-full px-4 py-1.5 ${
+        isFollowing
+          ? "border border-interactive-1 bg-white"
+          : "bg-interactive-1"
+      }`}
+    >
+      <Text
+        className={`text-sm font-semibold ${
+          isFollowing ? "text-interactive-1" : "text-white"
+        }`}
+      >
+        {isFollowing ? "Following" : "Follow"}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+/** Profile header: avatar stacked above identity text block. */
 function ProfileIdentityHeader({
   user,
   upcomingEventCount,
 }: ProfileIdentityHeaderProps) {
   const locationLine = profileLocationFromUser(user);
-  const displayName = user.displayName || user.username;
-  const showAndroidTitle = Platform.OS === "android";
 
   return (
-    <View className="px-4 pb-2">
-      <View className="flex-row items-center gap-3">
-        <UserProfileFlair username={user.username} size="lg">
-          {user.userImage ? (
-            <Image
-              source={{ uri: user.userImage }}
-              style={{ width: 56, height: 56, borderRadius: 28 }}
-              contentFit="cover"
-              cachePolicy="disk"
-            />
-          ) : (
-            <View className="h-14 w-14 items-center justify-center rounded-full bg-neutral-4">
-              <User size={28} color="#627496" />
-            </View>
-          )}
-        </UserProfileFlair>
-        <View className="min-w-0 flex-1">
-          {showAndroidTitle ? (
-            <Text
-              className="text-xl font-bold text-neutral-1"
-              numberOfLines={2}
-            >
-              {displayName}
-            </Text>
-          ) : null}
-          <Text
-            className={`text-sm text-neutral-2 ${showAndroidTitle ? "mt-0.5" : ""}`}
-          >
-            {upcomingEventCount}{" "}
-            {upcomingEventCount === 1 ? "upcoming event" : "upcoming events"}
+    <View className="items-start gap-3 px-4 pb-4 pt-2">
+      <UserProfileFlair username={user.username} size="lg">
+        {user.userImage ? (
+          <Image
+            source={{ uri: user.userImage }}
+            style={{ width: 80, height: 80, borderRadius: 40 }}
+            contentFit="cover"
+            cachePolicy="disk"
+          />
+        ) : (
+          <View className="h-20 w-20 items-center justify-center rounded-full bg-neutral-4">
+            <User size={40} color="#627496" />
+          </View>
+        )}
+      </UserProfileFlair>
+      <View className="w-full">
+        <Text className="text-xl font-bold text-neutral-1">
+          @{user.username}
+        </Text>
+        <Text className="text-sm text-neutral-2">
+          {upcomingEventCount}{" "}
+          {upcomingEventCount === 1 ? "upcoming event" : "upcoming events"}
+        </Text>
+        {locationLine ? (
+          <Text className="text-sm text-neutral-2" numberOfLines={1}>
+            {locationLine}
           </Text>
-          {locationLine ? (
-            <Text className="text-sm text-neutral-2" numberOfLines={1}>
-              {locationLine}
-            </Text>
-          ) : null}
-          <Text className="text-sm text-neutral-2">@{user.username}</Text>
-        </View>
+        ) : null}
       </View>
     </View>
   );

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,10 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import {
-  ActivityIndicator,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { ActivityIndicator, Text, View } from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
@@ -14,12 +9,13 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { User } from "~/components/icons";
 import SaveShareButton from "~/components/SaveShareButton";
+import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
-import { hapticLight, toast } from "~/utils/feedback";
+import { toast } from "~/utils/feedback";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -147,13 +143,12 @@ export default function UserProfilePage() {
       router.push("/(auth)/sign-in");
       return;
     }
-    void hapticLight();
     const run = isFollowingPersonalList
       ? unfollowListMutation
       : followListMutation;
     run({ listId: personalList.id }).catch((error: unknown) => {
       logError("Toggle follow personal list", error);
-      toast.error("Couldn't update follow");
+      toast.error("Couldn't update subscription");
     });
   }, [
     personalList,
@@ -255,8 +250,8 @@ export default function UserProfilePage() {
                   {
                     type: "custom",
                     element: (
-                      <ProfileFollowHeaderButton
-                        isFollowing={isFollowingPersonalList}
+                      <SubscribeButton
+                        isSubscribed={isFollowingPersonalList}
                         onPress={handleFollowListPress}
                       />
                     ),
@@ -292,36 +287,6 @@ interface ProfileIdentityHeaderProps {
     publicMetadata?: unknown;
   };
   upcomingEventCount: number;
-}
-
-function ProfileFollowHeaderButton({
-  isFollowing,
-  onPress,
-}: {
-  isFollowing: boolean;
-  onPress: () => void;
-}) {
-  return (
-    <TouchableOpacity
-      onPress={onPress}
-      activeOpacity={0.85}
-      accessibilityRole="button"
-      accessibilityLabel={isFollowing ? "Following list" : "Follow list"}
-      className={`rounded-full px-4 py-1.5 ${
-        isFollowing
-          ? "border border-interactive-1 bg-white"
-          : "bg-interactive-1"
-      }`}
-    >
-      <Text
-        className={`text-sm font-semibold ${
-          isFollowing ? "text-interactive-1" : "text-white"
-        }`}
-      >
-        {isFollowing ? "Following" : "Follow"}
-      </Text>
-    </TouchableOpacity>
-  );
 }
 
 /** Profile header: avatar stacked above identity text block. */

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -46,7 +46,15 @@ export default function ListDetailScreen() {
     const current = localStore.getQuery(api.lists.getFollowedLists, {});
     if (current === undefined || !listData) return;
     if (current.some((l) => l.id === args.listId)) return;
-    localStore.setQuery(api.lists.getFollowedLists, {}, [...current, listData]);
+    // getBySlug returns an enriched shape; strip fields not on Doc<"lists">
+    // before writing to the getFollowedLists cache.
+    const {
+      owner: _owner,
+      contributorCount: _contributorCount,
+      followerCount: _followerCount,
+      ...rawList
+    } = listData;
+    localStore.setQuery(api.lists.getFollowedLists, {}, [...current, rawList]);
   });
 
   const unfollowListMutation = useMutation(

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -6,20 +6,22 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { List as ListIcon, ShareIcon } from "~/components/icons";
+import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { logError } from "~/utils/errorLogging";
-import { hapticSuccess, toast } from "~/utils/feedback";
+import { toast } from "~/utils/feedback";
 
 export default function ListDetailScreen() {
   const { slug } = useLocalSearchParams<{ slug: string }>();
   const normalizedSlug = typeof slug === "string" ? slug : "";
+  const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const currentUser = useQuery(api.users.getCurrentUser);
 
@@ -38,8 +40,26 @@ export default function ListDetailScreen() {
     { initialNumItems: 50 },
   );
 
-  const followListMutation = useMutation(api.lists.followList);
-  const unfollowListMutation = useMutation(api.lists.unfollowList);
+  const followListMutation = useMutation(
+    api.lists.followList,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.lists.getFollowedLists, {});
+    if (current === undefined || !listData) return;
+    if (current.some((l) => l.id === args.listId)) return;
+    localStore.setQuery(api.lists.getFollowedLists, {}, [...current, listData]);
+  });
+
+  const unfollowListMutation = useMutation(
+    api.lists.unfollowList,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.lists.getFollowedLists, {});
+    if (current === undefined) return;
+    localStore.setQuery(
+      api.lists.getFollowedLists,
+      {},
+      current.filter((l) => l.id !== args.listId),
+    );
+  });
 
   const followedLists = useQuery(
     api.lists.getFollowedLists,
@@ -53,22 +73,27 @@ export default function ListDetailScreen() {
 
   const isOwnList = listData?.userId === currentUser?.id;
 
-  const handleToggleFollow = useCallback(async () => {
+  const handleToggleFollow = useCallback(() => {
     if (!listData) return;
-    try {
-      if (isFollowing) {
-        await unfollowListMutation({ listId: listData.id });
-      } else {
-        await followListMutation({ listId: listData.id });
-      }
-      void hapticSuccess();
-    } catch (error) {
+    if (!isAuthenticated) {
+      router.push("/(auth)/sign-in");
+      return;
+    }
+    const run = isFollowing ? unfollowListMutation : followListMutation;
+    run({ listId: listData.id }).catch((error: unknown) => {
       logError("Error toggling list follow", error);
       toast.error(
-        isFollowing ? "Failed to unfollow list" : "Failed to follow list",
+        isFollowing ? "Failed to unsubscribe" : "Failed to subscribe",
       );
-    }
-  }, [listData, isFollowing, followListMutation, unfollowListMutation]);
+    });
+  }, [
+    listData,
+    isAuthenticated,
+    isFollowing,
+    followListMutation,
+    unfollowListMutation,
+    router,
+  ]);
 
   const handleShare = useCallback(async () => {
     if (!listData || !normalizedSlug) return;
@@ -172,17 +197,21 @@ export default function ListDetailScreen() {
       <Stack.Screen
         options={{
           title: "List Details",
-          headerRight: () =>
-            isAuthenticated && !isOwnList ? (
-              <TouchableOpacity
-                onPress={() => void handleToggleFollow()}
-                activeOpacity={0.7}
-              >
-                <Text className="text-base font-semibold text-interactive-1">
-                  {isFollowing ? "Unfollow" : "Follow"}
-                </Text>
-              </TouchableOpacity>
-            ) : null,
+          unstable_headerRightItems:
+            isOwnList || !listData
+              ? undefined
+              : () => [
+                  {
+                    type: "custom",
+                    element: (
+                      <SubscribeButton
+                        isSubscribed={isFollowing}
+                        onPress={handleToggleFollow}
+                      />
+                    ),
+                    hidesSharedBackground: true,
+                  },
+                ],
         }}
       />
       <UserEventsList

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -16,8 +16,9 @@ import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { ChevronRight, List, ShareIcon } from "~/components/icons";
+import { SubscribeButton } from "~/components/SubscribeButton";
 import { logError } from "~/utils/errorLogging";
-import { hapticSuccess, toast } from "~/utils/feedback";
+import { toast } from "~/utils/feedback";
 
 interface FollowedListsModalProps {
   visible: boolean;
@@ -30,25 +31,24 @@ export function FollowedListsModal({
 }: FollowedListsModalProps) {
   const insets = useSafeAreaInsets();
   const followedLists = useQuery(api.lists.getFollowedLists);
-  const unfollowListMutation = useMutation(api.lists.unfollowList);
-  const [unfollowingIds, setUnfollowingIds] = useState<Set<string>>(new Set());
+  const unfollowListMutation = useMutation(
+    api.lists.unfollowList,
+  ).withOptimisticUpdate((localStore, args) => {
+    const current = localStore.getQuery(api.lists.getFollowedLists, {});
+    if (current === undefined) return;
+    localStore.setQuery(
+      api.lists.getFollowedLists,
+      {},
+      current.filter((l) => l.id !== args.listId),
+    );
+  });
 
   const handleUnfollow = useCallback(
-    async (listId: string) => {
-      setUnfollowingIds((prev) => new Set(prev).add(listId));
-      try {
-        await unfollowListMutation({ listId });
-        void hapticSuccess();
-      } catch (error) {
+    (listId: string) => {
+      unfollowListMutation({ listId }).catch((error: unknown) => {
         logError("Error unfollowing list", error);
-        toast.error("Failed to unfollow list");
-      } finally {
-        setUnfollowingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(listId);
-          return next;
-        });
-      }
+        toast.error("Failed to unsubscribe");
+      });
     },
     [unfollowListMutation],
   );
@@ -90,7 +90,9 @@ export function FollowedListsModal({
       <View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
         {/* Header */}
         <View className="flex-row items-center justify-between border-b border-neutral-3 px-4 py-3">
-          <Text className="text-lg font-bold text-neutral-1">Following</Text>
+          <Text className="text-lg font-bold text-neutral-1">
+            Subscribed lists
+          </Text>
           <TouchableOpacity onPress={onClose} activeOpacity={0.7}>
             <Text className="text-base font-semibold text-interactive-1">
               Done
@@ -105,7 +107,7 @@ export function FollowedListsModal({
         ) : followedLists.length === 0 ? (
           <View className="flex-1 items-center justify-center px-4">
             <Text className="text-base text-neutral-2">
-              Not following any lists yet
+              Not subscribed to any lists yet
             </Text>
           </View>
         ) : (
@@ -123,7 +125,6 @@ export function FollowedListsModal({
               </Text>
             }
             renderItem={({ item: list }) => {
-              const isUnfollowing = unfollowingIds.has(list.id);
               return (
                 <View className="flex-row items-center py-3">
                   <TouchableOpacity
@@ -157,21 +158,14 @@ export function FollowedListsModal({
                     <ShareIcon size={18} color="#5A32FB" />
                   </TouchableOpacity>
 
-                  <TouchableOpacity
-                    onPress={() => void handleUnfollow(list.id)}
-                    disabled={isUnfollowing}
-                    className="ml-1 rounded-full bg-neutral-4 px-3 py-1.5"
-                    activeOpacity={0.7}
-                    accessibilityLabel={`Unfollow ${list.name}`}
-                  >
-                    {isUnfollowing ? (
-                      <ActivityIndicator size="small" color="#627496" />
-                    ) : (
-                      <Text className="text-xs font-semibold text-neutral-2">
-                        Unfollow
-                      </Text>
-                    )}
-                  </TouchableOpacity>
+                  <View className="ml-1">
+                    <SubscribeButton
+                      isSubscribed={true}
+                      onPress={() => handleUnfollow(list.id)}
+                      size="sm"
+                      accessibilityLabel={`Unsubscribe from ${list.name}`}
+                    />
+                  </View>
                 </View>
               );
             }}

--- a/apps/expo/src/components/FollowingFeedbackBanner.tsx
+++ b/apps/expo/src/components/FollowingFeedbackBanner.tsx
@@ -51,7 +51,7 @@ const FollowingFeedbackBanner: React.FC = () => {
             <View className="flex-1 flex-row items-center">
               <Text className="mr-1 text-lg">✨</Text>
               <Text className="flex-1 text-lg font-semibold text-neutral-1">
-                New! Follow lists
+                New! Subscribe to lists
               </Text>
             </View>
             <View className="flex-row items-center gap-2 rounded-full bg-interactive-1 px-4 py-2">

--- a/apps/expo/src/components/NavigationMenu.tsx
+++ b/apps/expo/src/components/NavigationMenu.tsx
@@ -45,7 +45,7 @@ const routeIcons = {
 
 const baseRoutes = [
   { label: "Upcoming", path: "/feed" },
-  { label: "Following", path: "/following" },
+  { label: "My Scene", path: "/following" },
   { label: "Past", path: "/past" },
   { label: "Discover", path: "/discover" },
 ] as const;

--- a/apps/expo/src/components/SubscribeButton.tsx
+++ b/apps/expo/src/components/SubscribeButton.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Text, TouchableOpacity } from "react-native";
+
+import { hapticLight } from "~/utils/feedback";
+
+interface SubscribeButtonProps {
+  isSubscribed: boolean;
+  onPress: () => void;
+  /** "md" = header pill; "sm" = row pill (tighter, smaller text). Defaults to "md". */
+  size?: "sm" | "md";
+  /** Override the default a11y label. */
+  accessibilityLabel?: string;
+}
+
+export function SubscribeButton({
+  isSubscribed,
+  onPress,
+  size = "md",
+  accessibilityLabel,
+}: SubscribeButtonProps) {
+  const containerSize =
+    size === "sm" ? "px-3 py-1" : "px-4 py-1.5";
+  const textSize = size === "sm" ? "text-xs" : "text-sm";
+
+  return (
+    <TouchableOpacity
+      onPress={() => {
+        void hapticLight();
+        onPress();
+      }}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityLabel={
+        accessibilityLabel ??
+        (isSubscribed ? "Subscribed to list" : "Subscribe to list")
+      }
+      className={`rounded-full ${containerSize} ${
+        isSubscribed
+          ? "border border-interactive-1 bg-white"
+          : "bg-interactive-1"
+      }`}
+    >
+      <Text
+        className={`${textSize} font-semibold ${
+          isSubscribed ? "text-interactive-1" : "text-white"
+        }`}
+      >
+        {isSubscribed ? "Subscribed" : "Subscribe"}
+      </Text>
+    </TouchableOpacity>
+  );
+}

--- a/apps/expo/src/components/SubscribeButton.tsx
+++ b/apps/expo/src/components/SubscribeButton.tsx
@@ -18,8 +18,7 @@ export function SubscribeButton({
   size = "md",
   accessibilityLabel,
 }: SubscribeButtonProps) {
-  const containerSize =
-    size === "sm" ? "px-3 py-1" : "px-4 py-1.5";
+  const containerSize = size === "sm" ? "px-3 py-1" : "px-4 py-1.5";
   const textSize = size === "sm" ? "text-xs" : "text-sm";
 
   return (


### PR DESCRIPTION
## Summary

Simplifies the profile experience and rebrands list-following as "subscribing" across the Expo app.

Two commits:

1. **`refactor(expo): simplify profile + remove scene sharing`** — scenes are no longer a shareable social object. Removed the "My Scene" tab share button and the "Your/Their scene" preview block on user profiles. Profile is now a single idea: a user's Soonlist, with a one-tap subscribe pill in the native header right. Rebuilt the profile identity block (80×80 avatar stacked above `@handle` + event count + optional location). Added `.withOptimisticUpdate` to `followList` / `unfollowList` so the pill flips instantly. Fixed an avatar-flash bug caused by `HeaderComponent={() => listHeader}` remounting the `FlatList` header on every re-render (stabilized with `useCallback`).

2. **`refactor(expo): extract SubscribeButton + rename follow → subscribe`** — extracted a shared `<SubscribeButton>` used by the profile header, list detail header, and `FollowedListsModal`. Optimistic updates and fire-and-forget haptics now work identically across all three. Migrated user-facing copy from "follow" to "subscribe" (pill labels, empty states, headers, error toasts, nav dropdown). Data layer (`api.lists.followList`, `getFollowedLists`, etc.) intentionally unchanged — UI surface only.

## What reviewers should know

- **Backend untouched.** Every `followList` / `unfollowList` / `getFollowedLists` name is still in the Convex schema and mutations. Only user-visible strings and frontend code say "subscribe".
- **Behavior change on list detail:** the follow pill previously hid from unauthenticated users; it now shows and routes to sign-in on tap. Matches the profile page pattern and is a better growth affordance.
- **Modal UX change:** `FollowedListsModal` used to track in-flight `unfollowingIds` and show a spinner; now it relies on `.withOptimisticUpdate` for instant row removal. Rollback on mutation error is automatic.
- **Copy changes to double-check:** modal header "Following" → "Subscribed lists"; bottom-tab dropdown label "Following" → "My Scene" (native tab was already "My Scene"); two instances of "Events from lists I follow" → "Events from lists I subscribe to".
- **Optimistic pattern vetted** against the canonical `useEventActions.ts` save/unsave pattern. Undefined guards, non-paginated `getQuery`/`setQuery`, error rollback, shape fidelity — all match.

## Test plan

- [ ] Visit another user's profile → Subscribe pill appears in top-right; tap flips to "Subscribed" instantly with light haptic; no avatar flash.
- [ ] Visit your own profile → no pill; no scene preview block.
- [ ] List detail page → pill in header right, optimistic toggle, toast on network error.
- [ ] My Scene tab → header has no share icon; empty state reads "Subscribe to other lists..."; header reads "Events from lists I subscribe to".
- [ ] Followed-lists modal → titled "Subscribed lists"; tapping a row's "Subscribed" pill removes it instantly; empty state reads "Not subscribed to any lists yet".
- [ ] Unauthenticated → tap Subscribe on list detail → routes to sign-in.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the profile to center on a user’s Soonlist and switches UI language from “follow” to “subscribe.” Adds a shared subscribe pill with optimistic updates across profile, list detail, and modal, and removes scene sharing.

- New Features
  - Profile: 80×80 avatar + handle + event count; subscribe pill in header for other users. Removed scene preview and share; “My Scene” tab no longer shows a share button.
  - Shared `SubscribeButton` used in profile header, list detail header, and followed-lists modal; sm/md sizes with light haptic.
  - Optimistic subscribe/unsubscribe across profile, list detail, and modal; unauthenticated taps route to sign-in.
  - UI copy: “follow” → “subscribe” (modal “Subscribed lists,” nav “My Scene”). Backend APIs (`followList`, `unfollowList`, `getFollowedLists`) unchanged.

- Bug Fixes
  - Fixed avatar flash on profile by stabilizing the list header with `useCallback`.
  - List detail optimistic cache now writes a plain `Doc<"lists">` to `getFollowedLists` (strips enriched fields from `getBySlug`).

<sup>Written for commit 21f2c55f4f098592e34341dba55d3022e4635dad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the Expo profile screen (removes the \"scene\" social layer and share button, rebuilds the identity block with a stacked 80×80 avatar), extracts a shared `SubscribeButton` component, and migrates all user-facing copy from \"follow\" to \"subscribe\". The backend data layer is intentionally unchanged.

The optimistic-update pattern is correctly applied across all three call sites (profile, list detail, followed-lists modal), with consistent duplicate-check guards, `args.listId` filtering, and `.catch()` error rollback. The `renderListHeader = useCallback(() => listHeader, [listHeader])` fix correctly prevents the avatar flash caused by passing an inline arrow function as `HeaderComponent`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no runtime impact.

The optimistic update pattern is correctly implemented at all three call sites with proper guards, rollback on error, and shape fidelity for the profile page. The one shape inconsistency (enriched listData in list/[slug].tsx) does not affect rendering or correctness today. No P0 or P1 issues found.

apps/expo/src/app/list/[slug].tsx — minor shape inconsistency in the optimistic follow update worth cleaning up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/SubscribeButton.tsx | New shared component — clean, two-size pill with haptic-on-press and correct accessibility roles. |
| apps/expo/src/app/[username]/index.tsx | Large simplification — removes FollowSceneModal/ScenePreview, adds optimistic follow/unfollow with correct guards, fixes HeaderComponent flash via useCallback. |
| apps/expo/src/app/list/[slug].tsx | Adds optimistic updates and unauthenticated subscribe redirect; listData from getBySlug (enriched with owner/followerCount) is used directly as the optimistic cache value for getFollowedLists. |
| apps/expo/src/components/FollowedListsModal.tsx | Replaces manual unfollowingIds spinner state with optimistic update pattern; ActivityIndicator is still used for the initial load state. |
| apps/expo/src/app/(tabs)/following/_layout.tsx | Removes share button and associated Share/useUser/useCallback; clean simplification. |
| apps/expo/src/app/(tabs)/following/index.tsx | Copy-only changes: "follow" → "subscribe" in two empty-state strings. |
| apps/expo/src/components/NavigationMenu.tsx | Renames the dropdown label from "Following" to "My Scene" to match the native tab. |
| apps/expo/src/components/FollowingFeedbackBanner.tsx | Single copy change: "Follow lists" → "Subscribe to lists". |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant SB as SubscribeButton
    participant H as Handler (profile / list / modal)
    participant OS as Convex localStore (optimistic)
    participant CV as Convex server

    U->>SB: tap
    SB->>SB: hapticLight()
    SB->>H: onPress()
    H->>OS: setQuery(getFollowedLists, filtered/appended)
    Note over OS: UI flips instantly (pill + isFollowing)
    H->>CV: followList / unfollowList { listId }
    alt success
        CV-->>OS: server confirms → cache synced
    else error
        CV-->>OS: rollback optimistic value
        OS-->>U: toast.error(...)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/list/[slug].tsx
Line: 49

Comment:
**Enriched type pushed into plain-Doc cache**

`listData` comes from `getBySlug` and carries extra computed fields (`owner`, `contributorCount`, `followerCount`) that are not part of `Doc<"lists">`, which is the element type of `getFollowedLists`. TypeScript's structural typing lets the assignment through, and nothing currently reads those extra fields from the `getFollowedLists` cache — so there is no runtime bug today. However, if future code accesses `followerCount` or `owner` on items returned by `getFollowedLists`, the value will be stale/present only for this one optimistically-inserted entry.

The profile-page equivalent (`[username]/index.tsx`) avoids this by using `personalList` from `getPersonalListForUser`, which returns a plain `Doc<"lists">` and is the correct shape to store here. You could apply the same idea — extract just the raw list fields before pushing into the cache:

```ts
// strip enriched fields before writing to the getFollowedLists cache
const { owner: _owner, contributorCount: _cc, followerCount: _fc, ...rawList } = listData;
localStore.setQuery(api.lists.getFollowedLists, {}, [...current, rawList]);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(expo): extract SubscribeButton ..."](https://github.com/jaronheard/soonlist-turbo/commit/a3b87ba7970a3ec7ec77b2274cd157e5603942af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28712322)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->