### PR TITLE
Redesign Following tab empty state with featured lists

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -46,12 +46,7 @@ interface FeaturedList {
   displayName: string;
 }
 
-// Hardcoded fallback used while the appConfig query loads, and when no
-// featuredLists row is present on the deployment. Remote config
-// (api.appConfig.getFeaturedLists) is authoritative when set, so the featured
-// list can be curated without shipping a client release. Env-keyed here only
-// so the fallback matches the deployment — each Convex deployment is itself
-// environment-specific, so a non-null remote response needs no env split.
+// Fallback for when api.appConfig.getFeaturedLists is loading or unset.
 const DEFAULT_FEATURED_LISTS_BY_ENV: Record<
   "production" | "development",
   FeaturedList[]
@@ -201,8 +196,6 @@ function FeaturedListRow({
     return followedLists.some((l) => l.id === personalList.id);
   }, [personalList, followedLists]);
 
-  // Ref (not state) — this is purely a re-entry lock; nothing visible depends
-  // on it, so using state would just trigger two extra re-renders per tap.
   const isMutatingRef = useRef(false);
 
   const handleToggleSubscribe = useCallback(() => {
@@ -314,11 +307,7 @@ function FollowingEmptyState({
   );
   const currentUserId = userData?.id;
 
-  // Remote-configurable featured lists (api.appConfig.getFeaturedLists).
-  // null = no appConfig row set (fall back to defaults for the env)
-  // []   = admin has intentionally cleared the featured lists
-  // T[]  = curated list from the deployment
-  // undefined = query loading — use defaults so the empty state isn't blank
+  // null = row not set (fall back); [] = admin intentionally cleared.
   const remoteFeaturedLists = useQuery(api.appConfig.getFeaturedLists, {});
   const featuredLists =
     remoteFeaturedLists !== undefined && remoteFeaturedLists !== null
@@ -407,12 +396,9 @@ function FollowingFeedContent() {
   const followedLists = useQuery(api.lists.getFollowedLists);
   const hasFollowings = (followedLists?.length ?? 0) > 0;
 
-  // Session-sticky empty state: once the user lands with no followings, keep the empty
-  // state visible so they can follow multiple featured lists without it disappearing
-  // after the first follow. Re-latch to "show" if the user empties their lists mid-
-  // session (e.g., unfollows everything from the feed view) — otherwise the feed view
-  // would be stuck rendering stale results from the skipped getFollowedListsFeed query,
-  // and the next subscribe tap would snap them right back out of onboarding.
+  // Sticky so users can subscribe to multiple featured lists without the
+  // screen flipping to the feed mid-flow. Re-latches to "show" after an
+  // unfollow-all so the feed isn't stuck on stale paginated results.
   const [emptyStateMode, setEmptyStateMode] = useState<
     "unset" | "show" | "dismissed"
   >("unset");
@@ -591,11 +577,7 @@ function FollowingFeedContent() {
     handleShareList,
   ]);
 
-  // Show the empty state when:
-  // 1) the latch is "show" (initial onboarding, or re-latched after unfollow-all), or
-  // 2) data is loaded and the user has no followings — covers the first render before
-  //    the latch effect commits, and guards the feed view from rendering stale results
-  //    from the skipped getFollowedListsFeed query after an unfollow-all.
+  // Second branch avoids a one-frame flash before the latch effect commits.
   const showEmptyState =
     emptyStateMode === "show" ||
     (followedLists !== undefined && !hasFollowings);

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -21,6 +21,7 @@ import {
   useQuery,
 } from "convex/react";
 
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { FollowedListsModal } from "~/components/FollowedListsModal";
@@ -39,7 +40,10 @@ interface FeaturedList {
   displayName: string;
 }
 
-const FEATURED_LISTS_BY_ENV: Record<"production" | "development", FeaturedList[]> = {
+const FEATURED_LISTS_BY_ENV: Record<
+  "production" | "development",
+  FeaturedList[]
+> = {
   production: [
     { username: "thepianofarm", displayName: "Anis Mojgani" },
     { username: "kaylakennett", displayName: "Kayla Kennett" },
@@ -105,20 +109,22 @@ function FeaturedListRow({
   username,
   displayName,
   currentUserId,
+  followedLists,
 }: {
   username: string;
   displayName: string;
   currentUserId: string | undefined;
+  followedLists: Doc<"lists">[] | undefined;
 }) {
   const router = useRouter();
   const stableTimestamp = useStableTimestamp();
 
   const targetUser = useQuery(api.users.getByUsername, { userName: username });
+  const targetUserFound = targetUser !== null && targetUser !== undefined;
   const personalList = useQuery(
     api.lists.getPersonalListForUser,
-    targetUser?.id ? { userId: targetUser.id } : "skip",
+    targetUserFound ? { userId: targetUser.id } : "skip",
   );
-  const followedLists = useQuery(api.lists.getFollowedLists, {});
 
   const followListMutation = useMutation(
     api.lists.followList,
@@ -146,8 +152,8 @@ function FeaturedListRow({
 
   const { results: events } = useStablePaginatedQuery(
     api.feeds.getPublicUserFeed,
-    { username, filter: "upcoming" as const },
-    { initialNumItems: 10 },
+    targetUserFound ? { username, filter: "upcoming" as const } : "skip",
+    { initialNumItems: 50 },
   );
 
   const { imageUris, upcomingCount } = useMemo((): {
@@ -265,10 +271,12 @@ function FeaturedListRow({
 function FollowingEmptyState({
   hasFollowings,
   followedEventCount,
+  followedLists,
   onExitToFeed,
 }: {
   hasFollowings: boolean;
   followedEventCount: number;
+  followedLists: Doc<"lists">[] | undefined;
   onExitToFeed: () => void;
 }) {
   const { user } = useUser();
@@ -319,6 +327,7 @@ function FollowingEmptyState({
               username={list.username}
               displayName={list.displayName}
               currentUserId={currentUserId}
+              followedLists={followedLists}
             />
           ))}
         </View>
@@ -360,16 +369,16 @@ function FollowingFeedContent() {
 
   // Session-sticky empty state: once the user lands with no followings, keep the empty
   // state visible so they can follow multiple featured lists without it disappearing
-  // after the first follow. They exit explicitly via "See your scene" or on next tab
-  // remount (when hasFollowings is already true on load).
+  // after the first follow. Decision is made once (on initial query resolution); after
+  // that the latch is terminal for the session — unfollowing every list in-session
+  // won't drag the user back into onboarding after they've tapped "View My Scene".
   const [emptyStateMode, setEmptyStateMode] = useState<
     "unset" | "show" | "dismissed"
   >("unset");
   useEffect(() => {
     if (followedLists === undefined) return;
-    if (!hasFollowings && emptyStateMode !== "show") {
-      setEmptyStateMode("show");
-    }
+    if (emptyStateMode !== "unset") return;
+    setEmptyStateMode(hasFollowings ? "dismissed" : "show");
   }, [followedLists, hasFollowings, emptyStateMode]);
   const handleExitEmptyState = useCallback(() => {
     setEmptyStateMode("dismissed");
@@ -542,6 +551,7 @@ function FollowingFeedContent() {
       <FollowingEmptyState
         hasFollowings={hasFollowings}
         followedEventCount={enrichedEvents.length}
+        followedLists={followedLists}
         onExitToFeed={handleExitEmptyState}
       />
     );

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -283,11 +283,13 @@ function FeaturedListRow({
 function FollowingEmptyState({
   hasFollowings,
   followedEventCount,
+  hasMoreFollowedEvents,
   followedLists,
   onExitToFeed,
 }: {
   hasFollowings: boolean;
   followedEventCount: number;
+  hasMoreFollowedEvents: boolean;
   followedLists: Doc<"lists">[] | undefined;
   onExitToFeed: () => void;
 }) {
@@ -349,7 +351,9 @@ function FollowingEmptyState({
             <Text className="mb-1 text-sm text-neutral-2">
               {followedEventCount === 1
                 ? "1 event added to My Scene"
-                : `${followedEventCount} events added to My Scene`}
+                : `${followedEventCount}${
+                    hasMoreFollowedEvents ? "+" : ""
+                  } events added to My Scene`}
             </Text>
             <TouchableOpacity
               onPress={onExitToFeed}
@@ -576,6 +580,7 @@ function FollowingFeedContent() {
       <FollowingEmptyState
         hasFollowings={hasFollowings}
         followedEventCount={enrichedEvents.length}
+        hasMoreFollowedEvents={status === "CanLoadMore"}
         followedLists={followedLists}
         onExitToFeed={handleExitEmptyState}
       />

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Platform,
   ScrollView,
@@ -40,7 +46,13 @@ interface FeaturedList {
   displayName: string;
 }
 
-const FEATURED_LISTS_BY_ENV: Record<
+// Hardcoded fallback used while the appConfig query loads, and when no
+// featuredLists row is present on the deployment. Remote config
+// (api.appConfig.getFeaturedLists) is authoritative when set, so the featured
+// list can be curated without shipping a client release. Env-keyed here only
+// so the fallback matches the deployment — each Convex deployment is itself
+// environment-specific, so a non-null remote response needs no env split.
+const DEFAULT_FEATURED_LISTS_BY_ENV: Record<
   "production" | "development",
   FeaturedList[]
 > = {
@@ -56,7 +68,7 @@ const FEATURED_LISTS_BY_ENV: Record<
   ],
 };
 
-const FEATURED_LISTS = FEATURED_LISTS_BY_ENV[Config.env];
+const DEFAULT_FEATURED_LISTS = DEFAULT_FEATURED_LISTS_BY_ENV[Config.env];
 
 type Segment = "upcoming" | "past";
 
@@ -189,11 +201,13 @@ function FeaturedListRow({
     return followedLists.some((l) => l.id === personalList.id);
   }, [personalList, followedLists]);
 
-  const [isMutating, setIsMutating] = useState(false);
+  // Ref (not state) — this is purely a re-entry lock; nothing visible depends
+  // on it, so using state would just trigger two extra re-renders per tap.
+  const isMutatingRef = useRef(false);
 
   const handleToggleSubscribe = useCallback(() => {
-    if (!personalList || isSelf || isMutating) return;
-    setIsMutating(true);
+    if (!personalList || isSelf || isMutatingRef.current) return;
+    isMutatingRef.current = true;
     const promise = isSubscribed
       ? unfollowListMutation({ listId: personalList.id })
       : followListMutation({ listId: personalList.id });
@@ -207,12 +221,11 @@ function FeaturedListRow({
         );
       })
       .finally(() => {
-        setIsMutating(false);
+        isMutatingRef.current = false;
       });
   }, [
     personalList,
     isSelf,
-    isMutating,
     isSubscribed,
     unfollowListMutation,
     followListMutation,
@@ -301,6 +314,17 @@ function FollowingEmptyState({
   );
   const currentUserId = userData?.id;
 
+  // Remote-configurable featured lists (api.appConfig.getFeaturedLists).
+  // null = no appConfig row set (fall back to defaults for the env)
+  // []   = admin has intentionally cleared the featured lists
+  // T[]  = curated list from the deployment
+  // undefined = query loading — use defaults so the empty state isn't blank
+  const remoteFeaturedLists = useQuery(api.appConfig.getFeaturedLists, {});
+  const featuredLists =
+    remoteFeaturedLists !== undefined && remoteFeaturedLists !== null
+      ? remoteFeaturedLists
+      : DEFAULT_FEATURED_LISTS;
+
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
@@ -335,7 +359,7 @@ function FollowingEmptyState({
         </Text>
 
         <View className="mb-2">
-          {FEATURED_LISTS.map((list) => (
+          {featuredLists.map((list) => (
             <FeaturedListRow
               key={list.username}
               username={list.username}

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -547,8 +547,17 @@ function FollowingFeedContent() {
     handleShareList,
   ]);
 
-  // Show empty state if this session started empty and the user hasn't exited yet.
-  if (emptyStateMode === "show") {
+  // Show the empty state if this session started empty and the user hasn't
+  // exited yet. The "unset && loaded && no followings" branch makes the very
+  // first render correct so we don't flash UserEventsList's generic empty
+  // component for one frame before the useEffect above transitions the latch
+  // to "show".
+  const showEmptyState =
+    emptyStateMode === "show" ||
+    (emptyStateMode === "unset" &&
+      followedLists !== undefined &&
+      !hasFollowings);
+  if (showEmptyState) {
     return (
       <FollowingEmptyState
         hasFollowings={hasFollowings}

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -150,15 +150,16 @@ function FeaturedListRow({
     );
   });
 
-  const { results: events } = useStablePaginatedQuery(
+  const { results: events, status: feedStatus } = useStablePaginatedQuery(
     api.feeds.getPublicUserFeed,
     targetUserFound ? { username, filter: "upcoming" as const } : "skip",
     { initialNumItems: 50 },
   );
 
-  const { imageUris, upcomingCount } = useMemo((): {
+  const { imageUris, upcomingCount, hasMoreUpcoming } = useMemo((): {
     imageUris: (string | null)[];
     upcomingCount: number;
+    hasMoreUpcoming: boolean;
   } => {
     const currentTime = new Date(stableTimestamp).getTime();
     const upcoming = events.filter(
@@ -174,8 +175,9 @@ function FeaturedListRow({
     return {
       imageUris: [urls[0] ?? null, urls[1] ?? null, urls[2] ?? null],
       upcomingCount: upcoming.length,
+      hasMoreUpcoming: feedStatus === "CanLoadMore",
     };
-  }, [events, stableTimestamp]);
+  }, [events, stableTimestamp, feedStatus]);
 
   const isSelf =
     currentUserId !== undefined &&
@@ -209,7 +211,7 @@ function FeaturedListRow({
   const upcomingLabel =
     upcomingCount === 1
       ? "1 upcoming event"
-      : `${upcomingCount} upcoming events`;
+      : `${upcomingCount}${hasMoreUpcoming ? "+" : ""} upcoming events`;
 
   return (
     <View className="mb-4 flex-row items-center gap-3">

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -8,7 +8,8 @@ import {
   View,
 } from "react-native";
 import * as Haptics from "expo-haptics";
-import { Redirect } from "expo-router";
+import { Image } from "expo-image";
+import { Redirect, useRouter } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
 import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
@@ -17,19 +18,41 @@ import {
   Authenticated,
   AuthLoading,
   Unauthenticated,
+  useMutation,
   useQuery,
 } from "convex/react";
-import { usePostHog } from "posthog-react-native";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { FollowedListsModal } from "~/components/FollowedListsModal";
-import { ShareIcon } from "~/components/icons";
+import { User } from "~/components/icons";
 import LoadingSpinner from "~/components/LoadingSpinner";
+import ScenePreviewThreeUp from "~/components/ScenePreviewThreeUp";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
+import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
+
+interface FeaturedList {
+  username: string;
+  displayName: string;
+}
+
+const FEATURED_LISTS_BY_ENV: Record<"production" | "development", FeaturedList[]> = {
+  production: [
+    { username: "thepianofarm", displayName: "Anis Mojgani" },
+    { username: "kaylakennett", displayName: "Kayla Kennett" },
+    { username: "joshcarr", displayName: "Josh Carr" },
+  ],
+  development: [
+    { username: "jaron", displayName: "Jaron Heard" },
+    { username: "jaron-heard", displayName: "Jaron (Dev)" },
+    { username: "soonlist", displayName: "Soonlist" },
+  ],
+};
+
+const FEATURED_LISTS = FEATURED_LISTS_BY_ENV[Config.env];
 
 type Segment = "upcoming" | "past";
 
@@ -78,38 +101,178 @@ function SegmentedControlFallback({
   );
 }
 
-function FollowingEmptyState() {
-  const { user } = useUser();
-  const posthog = usePostHog();
-  const username = user?.username ?? "";
-  const handleInvite = async () => {
-    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+function FeaturedListRow({
+  username,
+  displayName,
+  currentUserId,
+}: {
+  username: string;
+  displayName: string;
+  currentUserId: string | undefined;
+}) {
+  const router = useRouter();
+  const stableTimestamp = useStableTimestamp();
 
-    // AppsFlyer OneLink with follow intent — recipient will be prompted to follow this user
-    const followUrl = `https://soonlist.onelink.me/QM97?pid=soonlist_app&c=following_empty_state&deep_link_value=follow&deep_link_sub1=${encodeURIComponent(username)}`;
-    const shareMessage =
-      "Hey, check out Soonlist! It turns your screenshots into saved plans and makes finding and sharing events way easier.";
+  const targetUser = useQuery(api.users.getByUsername, { userName: username });
+  const personalList = useQuery(
+    api.lists.getPersonalListForUser,
+    targetUser?.id ? { userId: targetUser.id } : "skip",
+  );
+  const followedLists = useQuery(api.lists.getFollowedLists, {});
+  const followListMutation = useMutation(api.lists.followList);
+  const unfollowListMutation = useMutation(api.lists.unfollowList);
 
+  const { results: events } = useStablePaginatedQuery(
+    api.feeds.getPublicUserFeed,
+    { username, filter: "upcoming" as const },
+    { initialNumItems: 10 },
+  );
+
+  const { imageUris, upcomingCount } = useMemo((): {
+    imageUris: (string | null)[];
+    upcomingCount: number;
+  } => {
+    const currentTime = new Date(stableTimestamp).getTime();
+    const upcoming = events.filter(
+      (e) => new Date(e.endDateTime).getTime() >= currentTime,
+    );
+    const urls: string[] = [];
+    for (const e of upcoming) {
+      if (typeof e.image === "string" && e.image.length > 0) {
+        urls.push(e.image);
+        if (urls.length >= 3) break;
+      }
+    }
+    return {
+      imageUris: [urls[0] ?? null, urls[1] ?? null, urls[2] ?? null],
+      upcomingCount: upcoming.length,
+    };
+  }, [events, stableTimestamp]);
+
+  const isSelf =
+    currentUserId !== undefined &&
+    targetUser?.id !== undefined &&
+    targetUser.id === currentUserId;
+
+  const isFollowing = useMemo(() => {
+    if (!personalList || !followedLists) return false;
+    return followedLists.some((l) => l.id === personalList.id);
+  }, [personalList, followedLists]);
+
+  const [isUpdatingFollow, setIsUpdatingFollow] = useState(false);
+
+  const handleToggleFollow = useCallback(async () => {
+    if (!personalList || isSelf || isUpdatingFollow) return;
+    setIsUpdatingFollow(true);
+    void Haptics.selectionAsync();
     try {
-      posthog.capture("invite_friend_initiated", {
-        source: "following_empty_state",
-      });
-
-      const result = await Share.share({
-        message: shareMessage,
-        url: followUrl,
-        title: "Soonlist — Save events instantly",
-      });
-
-      if (result.action === Share.sharedAction) {
-        posthog.capture("invite_friend_completed", {
-          source: "following_empty_state",
-        });
+      if (isFollowing) {
+        await unfollowListMutation({ listId: personalList.id });
+      } else {
+        await followListMutation({ listId: personalList.id });
       }
     } catch (error) {
-      logError("Error sharing from following empty state", error);
+      logError("Error toggling list follow from empty state", error);
+    } finally {
+      setIsUpdatingFollow(false);
     }
-  };
+  }, [
+    personalList,
+    isSelf,
+    isUpdatingFollow,
+    isFollowing,
+    unfollowListMutation,
+    followListMutation,
+  ]);
+
+  const upcomingLabel =
+    upcomingCount === 1
+      ? "1 upcoming event"
+      : `${upcomingCount} upcoming events`;
+
+  return (
+    <View className="mb-4 flex-row items-center gap-3">
+      <TouchableOpacity
+        onPress={() => router.push(`/${username}`)}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${displayName}'s profile`}
+        className="min-w-0 flex-1 flex-row items-center gap-3"
+      >
+        <ScenePreviewThreeUp imageUris={imageUris} align="start" />
+        <View className="min-w-0 flex-1">
+          <View className="flex-row items-center gap-1.5">
+            {targetUser?.userImage ? (
+              <Image
+                source={{ uri: targetUser.userImage }}
+                style={{ width: 20, height: 20, borderRadius: 10 }}
+                contentFit="cover"
+                cachePolicy="disk"
+              />
+            ) : (
+              <View className="h-5 w-5 items-center justify-center rounded-full bg-neutral-4">
+                <User size={12} color="#627496" />
+              </View>
+            )}
+            <Text
+              className="flex-1 text-base font-semibold text-neutral-1"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {displayName}
+            </Text>
+          </View>
+          <Text
+            className="text-sm text-neutral-2"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {upcomingLabel}
+          </Text>
+        </View>
+      </TouchableOpacity>
+      {!isSelf ? (
+        <TouchableOpacity
+          onPress={() => void handleToggleFollow()}
+          disabled={!personalList || isUpdatingFollow}
+          activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isFollowing ? `Unfollow ${displayName}` : `Follow ${displayName}`
+          }
+          className={`rounded-full px-4 py-2 ${
+            isFollowing ? "bg-neutral-4" : "bg-interactive-1"
+          } ${!personalList || isUpdatingFollow ? "opacity-60" : ""}`}
+        >
+          <Text
+            className={`text-sm font-semibold ${
+              isFollowing ? "text-neutral-1" : "text-white"
+            }`}
+          >
+            {isFollowing ? "Following" : "Follow"}
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+}
+
+function FollowingEmptyState({
+  hasFollowings,
+  followedEventCount,
+  onExitToFeed,
+}: {
+  hasFollowings: boolean;
+  followedEventCount: number;
+  onExitToFeed: () => void;
+}) {
+  const { user } = useUser();
+
+  const userData = useQuery(
+    api.users.getByUsername,
+    user?.username ? { userName: user.username } : "skip",
+  );
+  const currentUserId = userData?.id;
 
   return (
     <ScrollView
@@ -117,6 +280,7 @@ function FollowingEmptyState() {
       style={{ flex: 1, backgroundColor: "#F4F1FF" }}
       contentContainerStyle={{
         flexGrow: 1,
+        paddingBottom: 80,
       }}
     >
       <View className="px-3 pb-2" style={{ marginTop: -4 }}>
@@ -127,67 +291,53 @@ function FollowingEmptyState() {
           Events from lists I follow
         </Text>
       </View>
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "center",
-          alignItems: "center",
-          paddingHorizontal: 32,
-          paddingBottom: 200,
-        }}
-      >
+
+      <View className="px-6 pt-6">
         <Text
-          style={{
-            fontSize: 18,
-            fontWeight: "600",
-            color: "#627496",
-            textAlign: "center",
-            marginBottom: 8,
-            lineHeight: 26,
-          }}
+          className="mb-3 text-2xl font-bold text-neutral-1"
+          style={{ lineHeight: 30 }}
         >
-          Your scene starts with a list
+          Follow a list to get started
         </Text>
         <Text
-          style={{
-            fontSize: 15,
-            color: "#8E99A4",
-            textAlign: "center",
-            marginBottom: 24,
-            lineHeight: 22,
-          }}
+          className="mb-6 text-base text-neutral-2"
+          style={{ lineHeight: 22 }}
         >
-          Follow other lists to see their events here
+          My Scene shows upcoming events from people you follow. Start with
+          one of these featured lists.
         </Text>
-        <TouchableOpacity
-          onPress={() => void handleInvite()}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel="Invite friends to Soonlist"
-        >
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 8,
-              backgroundColor: "#5A32FB",
-              paddingHorizontal: 24,
-              paddingVertical: 14,
-              borderRadius: 999,
-            }}
-          >
-            <ShareIcon size={18} color="#FFFFFF" />
-            <Text
-              style={{
-                fontSize: 17,
-                fontWeight: "700",
-                color: "#FFFFFF",
-              }}
-            >
-              Invite friends
+
+        <View className="mb-2">
+          {FEATURED_LISTS.map((list) => (
+            <FeaturedListRow
+              key={list.username}
+              username={list.username}
+              displayName={list.displayName}
+              currentUserId={currentUserId}
+            />
+          ))}
+        </View>
+
+        {hasFollowings ? (
+          <View className="mt-4 items-center">
+            <Text className="mb-1 text-sm text-neutral-2">
+              {followedEventCount === 1
+                ? "1 event added to My Scene"
+                : `${followedEventCount} events added to My Scene`}
             </Text>
+            <TouchableOpacity
+              onPress={onExitToFeed}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="View My Scene"
+              className="px-2 py-2"
+            >
+              <Text className="text-base font-semibold text-interactive-1">
+                View My Scene →
+              </Text>
+            </TouchableOpacity>
           </View>
-        </TouchableOpacity>
+        ) : null}
       </View>
     </ScrollView>
   );
@@ -202,6 +352,23 @@ function FollowingFeedContent() {
   // Check if user is following any lists
   const followedLists = useQuery(api.lists.getFollowedLists);
   const hasFollowings = (followedLists?.length ?? 0) > 0;
+
+  // Session-sticky empty state: once the user lands with no followings, keep the empty
+  // state visible so they can follow multiple featured lists without it disappearing
+  // after the first follow. They exit explicitly via "See your scene" or on next tab
+  // remount (when hasFollowings is already true on load).
+  const [emptyStateMode, setEmptyStateMode] = useState<
+    "unset" | "show" | "dismissed"
+  >("unset");
+  useEffect(() => {
+    if (followedLists === undefined) return;
+    if (!hasFollowings && emptyStateMode !== "show") {
+      setEmptyStateMode("show");
+    }
+  }, [followedLists, hasFollowings, emptyStateMode]);
+  const handleExitEmptyState = useCallback(() => {
+    setEmptyStateMode("dismissed");
+  }, []);
 
   const handleSegmentChange = useCallback((segment: Segment) => {
     setSelectedSegment(segment);
@@ -364,9 +531,15 @@ function FollowingFeedContent() {
     handleShareList,
   ]);
 
-  // Show empty state if not following any lists
-  if (followedLists !== undefined && !hasFollowings) {
-    return <FollowingEmptyState />;
+  // Show empty state if this session started empty and the user hasn't exited yet.
+  if (emptyStateMode === "show") {
+    return (
+      <FollowingEmptyState
+        hasFollowings={hasFollowings}
+        followedEventCount={enrichedEvents.length}
+        onExitToFeed={handleExitEmptyState}
+      />
+    );
   }
 
   return (

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -38,32 +38,7 @@ import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
-import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
-
-interface FeaturedList {
-  username: string;
-  displayName: string;
-}
-
-// Fallback for when api.appConfig.getFeaturedLists is loading or unset.
-const DEFAULT_FEATURED_LISTS_BY_ENV: Record<
-  "production" | "development",
-  FeaturedList[]
-> = {
-  production: [
-    { username: "thepianofarm", displayName: "Anis Mojgani" },
-    { username: "kaylakennett", displayName: "Kayla Kennett" },
-    { username: "joshcarr", displayName: "Josh Carr" },
-  ],
-  development: [
-    { username: "jaron", displayName: "Jaron Heard" },
-    { username: "jaron-heard", displayName: "Jaron (Dev)" },
-    { username: "soonlist", displayName: "Soonlist" },
-  ],
-};
-
-const DEFAULT_FEATURED_LISTS = DEFAULT_FEATURED_LISTS_BY_ENV[Config.env];
 
 type Segment = "upcoming" | "past";
 
@@ -307,12 +282,7 @@ function FollowingEmptyState({
   );
   const currentUserId = userData?.id;
 
-  // null = row not set (fall back); [] = admin intentionally cleared.
-  const remoteFeaturedLists = useQuery(api.appConfig.getFeaturedLists, {});
-  const featuredLists =
-    remoteFeaturedLists !== undefined && remoteFeaturedLists !== null
-      ? remoteFeaturedLists
-      : DEFAULT_FEATURED_LISTS;
+  const featuredLists = useQuery(api.appConfig.getFeaturedLists, {}) ?? [];
 
   return (
     <ScrollView
@@ -343,21 +313,25 @@ function FollowingEmptyState({
           className="mb-6 text-base text-neutral-2"
           style={{ lineHeight: 22 }}
         >
-          My Scene shows upcoming events from people you subscribe to. Start
-          with one of these featured lists.
+          My Scene shows upcoming events from people you subscribe to.
+          {featuredLists.length > 0
+            ? " Start with one of these featured lists."
+            : ""}
         </Text>
 
-        <View className="mb-2">
-          {featuredLists.map((list) => (
-            <FeaturedListRow
-              key={list.username}
-              username={list.username}
-              displayName={list.displayName}
-              currentUserId={currentUserId}
-              followedLists={followedLists}
-            />
-          ))}
-        </View>
+        {featuredLists.length > 0 ? (
+          <View className="mb-2">
+            {featuredLists.map((list) => (
+              <FeaturedListRow
+                key={list.username}
+                username={list.username}
+                displayName={list.displayName}
+                currentUserId={currentUserId}
+                followedLists={followedLists}
+              />
+            ))}
+          </View>
+        ) : null}
 
         {hasFollowings ? (
           <View className="mt-4 items-center">

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -384,6 +384,10 @@ function FollowingFeedContent() {
     }
     if (emptyStateMode === "dismissed" && !hasFollowings) {
       setEmptyStateMode("show");
+      // Reset to the default segment so the onboarding confirmation count and
+      // the subsequent feed view both reflect upcoming events, not whatever
+      // segment the user had picked under their prior subscriptions.
+      setSelectedSegment("upcoming");
     }
   }, [followedLists, hasFollowings, emptyStateMode]);
   const handleExitEmptyState = useCallback(() => {

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -189,20 +189,30 @@ function FeaturedListRow({
     return followedLists.some((l) => l.id === personalList.id);
   }, [personalList, followedLists]);
 
+  const [isMutating, setIsMutating] = useState(false);
+
   const handleToggleSubscribe = useCallback(() => {
-    if (!personalList || isSelf) return;
-    if (isSubscribed) {
-      unfollowListMutation({ listId: personalList.id }).catch((error) => {
-        logError("Error unsubscribing from featured list", error);
+    if (!personalList || isSelf || isMutating) return;
+    setIsMutating(true);
+    const promise = isSubscribed
+      ? unfollowListMutation({ listId: personalList.id })
+      : followListMutation({ listId: personalList.id });
+    promise
+      .catch((error) => {
+        logError(
+          isSubscribed
+            ? "Error unsubscribing from featured list"
+            : "Error subscribing to featured list",
+          error,
+        );
+      })
+      .finally(() => {
+        setIsMutating(false);
       });
-    } else {
-      followListMutation({ listId: personalList.id }).catch((error) => {
-        logError("Error subscribing to featured list", error);
-      });
-    }
   }, [
     personalList,
     isSelf,
+    isMutating,
     isSubscribed,
     unfollowListMutation,
     followListMutation,
@@ -371,16 +381,22 @@ function FollowingFeedContent() {
 
   // Session-sticky empty state: once the user lands with no followings, keep the empty
   // state visible so they can follow multiple featured lists without it disappearing
-  // after the first follow. Decision is made once (on initial query resolution); after
-  // that the latch is terminal for the session — unfollowing every list in-session
-  // won't drag the user back into onboarding after they've tapped "View My Scene".
+  // after the first follow. Re-latch to "show" if the user empties their lists mid-
+  // session (e.g., unfollows everything from the feed view) — otherwise the feed view
+  // would be stuck rendering stale results from the skipped getFollowedListsFeed query,
+  // and the next subscribe tap would snap them right back out of onboarding.
   const [emptyStateMode, setEmptyStateMode] = useState<
     "unset" | "show" | "dismissed"
   >("unset");
   useEffect(() => {
     if (followedLists === undefined) return;
-    if (emptyStateMode !== "unset") return;
-    setEmptyStateMode(hasFollowings ? "dismissed" : "show");
+    if (emptyStateMode === "unset") {
+      setEmptyStateMode(hasFollowings ? "dismissed" : "show");
+      return;
+    }
+    if (emptyStateMode === "dismissed" && !hasFollowings) {
+      setEmptyStateMode("show");
+    }
   }, [followedLists, hasFollowings, emptyStateMode]);
   const handleExitEmptyState = useCallback(() => {
     setEmptyStateMode("dismissed");
@@ -547,16 +563,14 @@ function FollowingFeedContent() {
     handleShareList,
   ]);
 
-  // Show the empty state if this session started empty and the user hasn't
-  // exited yet. The "unset && loaded && no followings" branch makes the very
-  // first render correct so we don't flash UserEventsList's generic empty
-  // component for one frame before the useEffect above transitions the latch
-  // to "show".
+  // Show the empty state when:
+  // 1) the latch is "show" (initial onboarding, or re-latched after unfollow-all), or
+  // 2) data is loaded and the user has no followings — covers the first render before
+  //    the latch effect commits, and guards the feed view from rendering stale results
+  //    from the skipped getFollowedListsFeed query after an unfollow-all.
   const showEmptyState =
     emptyStateMode === "show" ||
-    (emptyStateMode === "unset" &&
-      followedLists !== undefined &&
-      !hasFollowings);
+    (followedLists !== undefined && !hasFollowings);
   if (showEmptyState) {
     return (
       <FollowingEmptyState

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -18,6 +18,10 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { Check, User } from "~/components/icons";
 import SaveShareButton from "~/components/SaveShareButton";
+import {
+  sceneCardShadow,
+  ScenePreviewThreeUp,
+} from "~/components/ScenePreviewThreeUp";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
@@ -45,58 +49,6 @@ function profileLocationFromUser(user: {
     }
   }
   return null;
-}
-
-const sceneCardShadow =
-  Platform.OS === "ios"
-    ? {
-        shadowColor: "#5A32FB",
-        shadowOffset: { width: 0, height: 6 },
-        shadowOpacity: 0.07,
-        shadowRadius: 14,
-      }
-    : { elevation: 2 };
-
-/** Three tilted tiles; soft edges, no harsh strokes. */
-function ScenePreviewThreeUp({
-  imageUris,
-  align = "start",
-}: {
-  imageUris: (string | null)[];
-  align?: "start" | "center";
-}) {
-  const slots: (string | null)[] = [0, 1, 2].map((i) => imageUris[i] ?? null);
-  return (
-    <View
-      className={`flex-row items-center py-1 ${align === "center" ? "justify-center" : "justify-start"}`}
-    >
-      {slots.map((uri, i) => (
-        <View
-          key={i}
-          className="overflow-hidden rounded-lg bg-neutral-4"
-          style={{
-            width: 56,
-            height: 72,
-            marginLeft: i > 0 ? -14 : 0,
-            transform: [{ rotate: `${-8 + i * 8}deg` }],
-            zIndex: 3 - i,
-            ...sceneCardShadow,
-          }}
-        >
-          {uri ? (
-            <Image
-              source={{ uri }}
-              style={{ width: "100%", height: "100%" }}
-              contentFit="cover"
-              cachePolicy="disk"
-            />
-          ) : (
-            <View className="h-full w-full bg-neutral-4" />
-          )}
-        </View>
-      ))}
-    </View>
-  );
 }
 
 type ListWithCount = Doc<"lists"> & { followerCount: number };

--- a/apps/expo/src/components/ScenePreviewThreeUp.tsx
+++ b/apps/expo/src/components/ScenePreviewThreeUp.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Platform, View } from "react-native";
+import { Image } from "expo-image";
+
+export const sceneCardShadow =
+  Platform.OS === "ios"
+    ? {
+        shadowColor: "#5A32FB",
+        shadowOffset: { width: 0, height: 6 },
+        shadowOpacity: 0.07,
+        shadowRadius: 14,
+      }
+    : { elevation: 2 };
+
+/** Three tilted tiles; soft edges, no harsh strokes. */
+export function ScenePreviewThreeUp({
+  imageUris,
+  align = "start",
+}: {
+  imageUris: (string | null)[];
+  align?: "start" | "center";
+}) {
+  const slots: (string | null)[] = [0, 1, 2].map((i) => imageUris[i] ?? null);
+  return (
+    <View
+      className={`flex-row items-center py-1 ${align === "center" ? "justify-center" : "justify-start"}`}
+    >
+      {slots.map((uri, i) => (
+        <View
+          key={i}
+          className="overflow-hidden rounded-lg bg-neutral-4"
+          style={{
+            width: 56,
+            height: 72,
+            marginLeft: i > 0 ? -14 : 0,
+            transform: [{ rotate: `${-8 + i * 8}deg` }],
+            zIndex: 3 - i,
+            ...sceneCardShadow,
+          }}
+        >
+          {uri ? (
+            <Image
+              source={{ uri }}
+              style={{ width: "100%", height: "100%" }}
+              contentFit="cover"
+              cachePolicy="disk"
+            />
+          ) : (
+            <View className="h-full w-full bg-neutral-4" />
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export default ScenePreviewThreeUp;

--- a/packages/backend/convex/appConfig.ts
+++ b/packages/backend/convex/appConfig.ts
@@ -33,15 +33,7 @@ const featuredListValidator = v.object({
   displayName: v.string(),
 });
 
-/**
- * Featured lists rendered in the Following tab onboarding empty state.
- *
- * Returns `null` when no config row exists (client falls back to hardcoded
- * defaults). Returns `[]` as an intentional "hide all featured lists" signal
- * an admin can set without a client release. Returns an array of entries
- * otherwise. Each Convex deployment is environment-specific, so no env key
- * is needed — prod and dev deployments hold their own featured list rows.
- */
+/** Returns `null` when the row is unset so clients can fall back to defaults. */
 export const getFeaturedLists = query({
   args: {},
   returns: v.union(v.null(), v.array(featuredListValidator)),

--- a/packages/backend/convex/appConfig.ts
+++ b/packages/backend/convex/appConfig.ts
@@ -27,3 +27,53 @@ export const getMinimumIOSVersion = query({
     return config?.value || null;
   },
 });
+
+const featuredListValidator = v.object({
+  username: v.string(),
+  displayName: v.string(),
+});
+
+/**
+ * Featured lists rendered in the Following tab onboarding empty state.
+ *
+ * Returns `null` when no config row exists (client falls back to hardcoded
+ * defaults). Returns `[]` as an intentional "hide all featured lists" signal
+ * an admin can set without a client release. Returns an array of entries
+ * otherwise. Each Convex deployment is environment-specific, so no env key
+ * is needed — prod and dev deployments hold their own featured list rows.
+ */
+export const getFeaturedLists = query({
+  args: {},
+  returns: v.union(v.null(), v.array(featuredListValidator)),
+  handler: async (ctx) => {
+    const config = await ctx.db
+      .query("appConfig")
+      .withIndex("by_key", (q) => q.eq("key", "featuredLists"))
+      .first();
+
+    if (!config?.value) return null;
+
+    try {
+      const parsed: unknown = JSON.parse(config.value);
+      if (!Array.isArray(parsed)) return null;
+      const validated: { username: string; displayName: string }[] = [];
+      for (const item of parsed) {
+        if (
+          item !== null &&
+          typeof item === "object" &&
+          typeof (item as { username?: unknown }).username === "string" &&
+          typeof (item as { displayName?: unknown }).displayName === "string"
+        ) {
+          const row = item as { username: string; displayName: string };
+          validated.push({
+            username: row.username,
+            displayName: row.displayName,
+          });
+        }
+      }
+      return validated;
+    } catch {
+      return null;
+    }
+  },
+});

--- a/packages/backend/convex/appConfig.ts
+++ b/packages/backend/convex/appConfig.ts
@@ -63,6 +63,9 @@ export const getFeaturedLists = query({
           });
         }
       }
+      // Any malformed row treats the whole config as unset so the client
+      // falls back to defaults instead of silently rendering a truncated list.
+      if (validated.length !== parsed.length) return null;
       return validated;
     } catch {
       return null;

--- a/packages/backend/convex/appConfig.ts
+++ b/packages/backend/convex/appConfig.ts
@@ -1,4 +1,5 @@
 import { v } from "convex/values";
+import { z } from "zod";
 
 import { query } from "./_generated/server";
 
@@ -28,14 +29,16 @@ export const getMinimumIOSVersion = query({
   },
 });
 
-const featuredListValidator = v.object({
-  username: v.string(),
-  displayName: v.string(),
-});
+const featuredListSchema = z.array(
+  z.object({
+    username: z.string(),
+    displayName: z.string(),
+  }),
+);
 
 export const getFeaturedLists = query({
   args: {},
-  returns: v.array(featuredListValidator),
+  returns: v.array(v.object({ username: v.string(), displayName: v.string() })),
   handler: async (ctx) => {
     const config = await ctx.db
       .query("appConfig")
@@ -44,36 +47,22 @@ export const getFeaturedLists = query({
 
     if (!config?.value) return [];
 
+    let raw: unknown;
     try {
-      const parsed: unknown = JSON.parse(config.value);
-      if (!Array.isArray(parsed)) {
-        console.warn("featuredLists appConfig is not an array");
-        return [];
-      }
-      const validated: { username: string; displayName: string }[] = [];
-      for (const item of parsed) {
-        if (
-          item !== null &&
-          typeof item === "object" &&
-          typeof (item as { username?: unknown }).username === "string" &&
-          typeof (item as { displayName?: unknown }).displayName === "string"
-        ) {
-          const row = item as { username: string; displayName: string };
-          validated.push({
-            username: row.username,
-            displayName: row.displayName,
-          });
-        }
-      }
-      if (validated.length !== parsed.length) {
-        console.warn(
-          `featuredLists appConfig dropped ${parsed.length - validated.length} malformed row(s)`,
-        );
-      }
-      return validated;
+      raw = JSON.parse(config.value);
     } catch (error) {
       console.warn("featuredLists appConfig JSON parse failed", error);
       return [];
     }
+
+    const result = featuredListSchema.safeParse(raw);
+    if (!result.success) {
+      console.warn(
+        "featuredLists appConfig failed validation",
+        result.error.flatten(),
+      );
+      return [];
+    }
+    return result.data;
   },
 });

--- a/packages/backend/convex/appConfig.ts
+++ b/packages/backend/convex/appConfig.ts
@@ -33,21 +33,23 @@ const featuredListValidator = v.object({
   displayName: v.string(),
 });
 
-/** Returns `null` when the row is unset so clients can fall back to defaults. */
 export const getFeaturedLists = query({
   args: {},
-  returns: v.union(v.null(), v.array(featuredListValidator)),
+  returns: v.array(featuredListValidator),
   handler: async (ctx) => {
     const config = await ctx.db
       .query("appConfig")
       .withIndex("by_key", (q) => q.eq("key", "featuredLists"))
       .first();
 
-    if (!config?.value) return null;
+    if (!config?.value) return [];
 
     try {
       const parsed: unknown = JSON.parse(config.value);
-      if (!Array.isArray(parsed)) return null;
+      if (!Array.isArray(parsed)) {
+        console.warn("featuredLists appConfig is not an array");
+        return [];
+      }
       const validated: { username: string; displayName: string }[] = [];
       for (const item of parsed) {
         if (
@@ -63,12 +65,15 @@ export const getFeaturedLists = query({
           });
         }
       }
-      // Any malformed row treats the whole config as unset so the client
-      // falls back to defaults instead of silently rendering a truncated list.
-      if (validated.length !== parsed.length) return null;
+      if (validated.length !== parsed.length) {
+        console.warn(
+          `featuredLists appConfig dropped ${parsed.length - validated.length} malformed row(s)`,
+        );
+      }
       return validated;
-    } catch {
-      return null;
+    } catch (error) {
+      console.warn("featuredLists appConfig JSON parse failed", error);
+      return [];
     }
   },
 });

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,7 +38,8 @@
     "ai": "catalog:",
     "convex": "catalog:",
     "langfuse": "catalog:",
-    "nanoid": "catalog:"
+    "nanoid": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@soonlist/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,9 @@ importers:
       nanoid:
         specifier: 'catalog:'
         version: 5.1.6
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       '@soonlist/eslint-config':
         specifier: workspace:*
@@ -5196,7 +5199,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}


### PR DESCRIPTION
## Summary

Turn the **Following** tab empty state into a guided onboarding surface built around three featured lists, with **Follow** as the unambiguous primary action.

- **New copy** oriented around the primary job:
  - Headline: *Follow a list to get started*
  - Body: *My Scene shows upcoming events from people you follow. Start with one of these featured lists.*
- **Featured rows** — three per session, each with:
  - Tilted 3-tile preview of the user's upcoming events (extracted into a shared `ScenePreviewThreeUp` component so the profile page and the empty state use the same visual).
  - Small avatar + display name (truncates on narrow widths).
  - Live *N upcoming events* count pulled from the same query that feeds the preview.
  - Per-row **Follow / Following** toggle wired to `api.lists.followList` against the user's personal list.
  - Tapping the left region navigates to the profile (existing Follow-scene flow still available there).
- **Session-sticky behavior.** A three-state latch (`unset` / `show` / `dismissed`) keeps the empty state visible after the first follow so the user can follow multiple lists without the screen disappearing. Once they've followed anything, an inline confirmation appears:
  > *N events added to My Scene*
  > **View My Scene →**
  Tapping the link sets the latch to `dismissed` and reveals the feed. Returning users with existing follows skip the empty state entirely (normal feed render).
- **Dev vs production featured lists.** Env-keyed map selects:
  - Prod: Anis Mojgani (`thepianofarm`), Kayla Kennett (`kaylakennett`), Josh Carr (`joshcarr`)
  - Dev: `jaron`, `jaron-heard`, `soonlist`
- **Removed** the previous *Share your Soonlist* / *Invite friends* CTA and its OneLink handler per external review — the primary action on this screen is now follow, not share.

## Why

Previously the empty state showed a generic *Your scene starts with a list* message and an *Invite friends* button. It didn't give new users anywhere to start, and sharing the app is the wrong first action when your scene is empty. The redesign gives new users three concrete starting points, lets them follow any combination, and moves the share/invite surface to a more appropriate location (out of scope for this PR).

## Edge cases handled

- **Self-row in dev** (e.g. logged in as `jaron` looking at the `jaron` row): Follow pill is hidden; row remains tappable to view the profile.
- **Already-following on mount**: row renders pre-filled as *Following*; toggle still works.
- **Follow mutation in flight**: pill is disabled and dimmed to prevent double-taps.
- **Zero upcoming events after following**: inline confirmation reads *0 events added to My Scene*; *View My Scene →* still works.
- **User returns to tab after follows**: component remounts with `hasFollowings === true`, latch stays `unset`, feed renders immediately.

## Test plan

- [ ] Fresh dev install, no followings → empty state shows three dev rows (`jaron`, `jaron-heard`, `soonlist`) with live event counts and 3-tile previews.
- [ ] Tap **Follow** on one row → pill flips to *Following*, empty state stays visible, inline confirmation appears with correct event count.
- [ ] Tap **Follow** on a second row → confirmation count updates to reflect both followed lists.
- [ ] Tap **Following** to unfollow → pill reverts; if zero lists remain, confirmation + *View My Scene* link disappear.
- [ ] Tap *View My Scene →* → feed renders with events from followed lists.
- [ ] Navigate away to another tab and back → feed renders directly (no empty-state re-show).
- [ ] Tap a row's left region → navigates to that user's profile.
- [ ] In prod build: featured rows are Anis, Kayla, Josh.
- [ ] Long display name (or narrow screen) truncates with ellipsis.
- [ ] `[username]/index.tsx` profile page still renders the scene preview identically (visual regression check on the shared component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Following tab empty state into guided onboarding with server‑curated featured lists, making Subscribe the primary action. New users can quickly add events to My Scene and only see the feed after tapping “View My Scene”.

- New Features
  - Featured rows with a tilted 3‑tile preview, avatar/name, and live upcoming count (“N/N+”); tapping a row opens the profile.
  - Session‑sticky empty state with inline “N/N+ events added” and a “View My Scene →” exit.
  - Featured lists loaded from `api.appConfig.getFeaturedLists` only; empty/invalid config returns `[]` and hides the section (no client defaults, no flash).
  - Shared `ScenePreviewThreeUp` component used in both the empty state and profile.
  - Removed the old “Invite friends” OneLink CTA.

- Bug Fixes
  - Show the empty state again when followings drop to 0; re‑latch “dismissed” → “show” after unfollow‑all to avoid a stale feed.
  - Reset the selected segment to “upcoming” when the empty state re‑latches so counts and the post‑exit feed match upcoming events.
  - Lock out concurrent Subscribe toggles with an in‑flight guard; keep optimistic updates.
  - Guard queries when a featured username is missing/renamed to avoid crashing (`api.feeds.getPublicUserFeed`/`api.lists.getPersonalListForUser` skip if `api.users.getByUsername` is null).
  - Pass `followedLists` from the parent to remove redundant `api.lists.getFollowedLists` subscriptions; improve upcoming counts by fetching 50 items and show “N+” when counts are capped (including the “events added” confirmation).
  - Prevent a one‑frame flash before the empty state renders by synchronizing the initial gate.
  - `api.appConfig.getFeaturedLists`: parse and validate JSON with `zod`, collapse bad/missing values to `[]`, and log console warnings instead of returning partial data.

<sup>Written for commit 28654c7f7af3ff9d76ba8b493aeb29610dd2f673. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR redesigns the **Following** tab's empty state into a guided onboarding surface: three env-keyed featured-list rows (each with a 3-tile preview, avatar, live event count, and a Follow/Following toggle) replace the old \"invite friends\" CTA. A session-sticky latch (`unset` → `show` → `dismissed`) keeps the surface visible while the user follows multiple lists, then exits on an explicit \"View My Scene\" tap. The shared `ScenePreviewThreeUp` component is cleanly extracted so both the profile page and the empty state use the same visual.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both findings are P2 style/edge-case suggestions that don't block the primary path.

All remaining findings are P2: one is a design edge case (dismissed latch reset on unfollow-all) that doesn't affect the primary onboarding flow, and the other is a redundant query-hook pattern that Convex deduplicates at the websocket level. Core logic, mutation safety (disabled button during in-flight, try/finally reset), self-row exclusion, and component extraction are all correct.

apps/expo/src/app/(tabs)/following/index.tsx — session-latch effect and per-row query subscriptions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/following/index.tsx | Main change: replaces the generic "invite friends" empty state with a featured-list onboarding surface backed by a three-state session latch; two P2 issues found — the dismissed latch can be re-triggered on unfollow-all, and each FeaturedListRow redundantly subscribes to getFollowedLists. |
| apps/expo/src/components/ScenePreviewThreeUp.tsx | New shared component extracted verbatim from [username]/index.tsx; both default and named exports provided, no issues found. |
| apps/expo/src/app/[username]/index.tsx | Removes the inline ScenePreviewThreeUp component and sceneCardShadow constant and replaces them with named imports from the new shared component file; no functional changes, clean extraction. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tab mounts] --> B{followedLists loaded?}
    B -- No --> C[emptyStateMode = unset\nshow loading spinner]
    B -- Yes, hasFollowings=true --> D[emptyStateMode stays unset\nRender full feed]
    B -- Yes, hasFollowings=false --> E[emptyStateMode = show\nRender FollowingEmptyState]

    E --> F{User taps Follow on a row}
    F --> G[followListMutation fires\nhasFollowings becomes true]
    G --> H[Confirmation: N events added\nView My Scene appears]
    H --> I{User taps View My Scene}
    I --> J[emptyStateMode = dismissed\nRender full feed]

    G --> K{User taps another Follow}
    K --> G

    J --> L{User unfollows ALL lists\nmid-session}
    L -- emptyStateMode=dismissed\nbut !hasFollowings --> M[⚠️ Effect re-sets to show\nEmpty state reappears]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/(tabs)/following/index.tsx
Line: 363-368

Comment:
**`"dismissed"` state overridden by unfollow-all**

The effect fires whenever `!hasFollowings && emptyStateMode !== "show"`, which includes `emptyStateMode === "dismissed"`. If a user taps **View My Scene** (setting the latch to `"dismissed"`) and then unfollows all their lists within the same session, the effect transitions the latch back to `"show"` and re-displays the onboarding surface — overriding their explicit dismissal. Consider anchoring the transition on the initial `"unset"` state only:

```
useEffect(() => {
  if (followedLists === undefined) return;
  if (emptyStateMode === "unset") {
    setEmptyStateMode(!hasFollowings ? "show" : "dismissed");
  }
}, [followedLists, hasFollowings, emptyStateMode]);
```

This makes `"dismissed"` a true terminal state for the session regardless of subsequent unfollow actions.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/app/(tabs)/following/index.tsx
Line: 121

Comment:
**Redundant `getFollowedLists` subscriptions per row**

Each of the three `FeaturedListRow` instances independently subscribes to `api.lists.getFollowedLists`. The parent `FollowingFeedContent` already subscribes to the same query (line 353) and the result is available as the `hasFollowings` gate. Passing `followedLists` down as a prop to `FollowingEmptyState` → `FeaturedListRow` would eliminate the three redundant hook calls and make the data flow explicit.

(Remove this line entirely and accept `followedLists` as a prop.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): redesign Following tab empty..."](https://github.com/jaronheard/soonlist-turbo/commit/85b146cd1099d27c8d2476ab87c3e2ddec778f1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28801749)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->