### PR TITLE
fix(cal): simpler deterministic event-year normalization (alt to #984)

### DIFF
--- a/packages/backend/convex/model/aiHelpers.ts
+++ b/packages/backend/convex/model/aiHelpers.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
+import { Temporal } from "@js-temporal/polyfill";
 import { waitUntil } from "@vercel/functions";
 import { generateObject, GenerateObjectResult } from "ai";
 import { ConvexError } from "convex/values";
@@ -10,9 +11,11 @@ import {
   addCommonAddToCalendarProps,
   EventMetadataSchema,
   EventSchema,
+  formatOffsetAsIANASoft,
   getPrompt,
   getSystemMessage,
   getSystemMessageMetadata,
+  normalizeEventYear,
 } from "@soonlist/cal";
 
 import type { ActionCtx } from "../_generated/server";
@@ -571,7 +574,28 @@ export async function fetchAndProcessEvent({
   const generatedEvent = event.object;
   const generatedMetadata = EventMetadataSchema.parse(metadata.object);
 
-  const eventObject = { ...generatedEvent, eventMetadata: generatedMetadata };
+  // Deterministically compute the year from the MM-DD the model extracted.
+  // The model is unreliable at enforcing a year window in the prompt (see
+  // migrations/fix2027Dates.ts and fix2027FeedDates.ts for the history);
+  // this replaces the year whenever the source did not explicitly state one.
+  const today = Temporal.Now.instant()
+    .toZonedDateTimeISO(formatOffsetAsIANASoft(input.timezone))
+    .toPlainDate();
+  const normalized = normalizeEventYear(
+    {
+      startDate: generatedEvent.startDate,
+      endDate: generatedEvent.endDate,
+      hasExplicitYear: generatedEvent.hasExplicitYear ?? false,
+    },
+    today,
+  );
+
+  const eventObject = {
+    ...generatedEvent,
+    startDate: normalized.startDate,
+    endDate: normalized.endDate,
+    eventMetadata: generatedMetadata,
+  };
 
   const events = addCommonAddToCalendarProps([eventObject]);
   const response = `${

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,6 +33,7 @@
     "@convex-dev/migrations": "catalog:",
     "@convex-dev/workflow": "catalog:",
     "@convex-dev/workpool": "catalog:",
+    "@js-temporal/polyfill": "catalog:",
     "@soonlist/cal": "workspace:*",
     "@vercel/functions": "catalog:",
     "ai": "catalog:",

--- a/packages/cal/src/index.ts
+++ b/packages/cal/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./normalizeEventYear";
 export * from "./prompts";
 export * from "./similarEvents";
 export * from "./utils";

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -66,7 +66,11 @@ function findDate(
       // Invalid for this year (e.g. Feb 29 in a non-leap year); try next.
     }
   }
-  throw new Error(`Invalid month/day combination: ${month}-${day}`);
+  throw new Error(
+    `Could not find a valid date for month ${month}, day ${day} ` +
+      `within ${MAX_YEAR_OFFSET} years of ${startYear}` +
+      (notBefore ? ` on or after ${notBefore.toString()}` : ""),
+  );
 }
 
 /**

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -71,7 +71,11 @@ export function normalizeEventYear(
       )
     : findDate(today.year, start.month, start.day, today);
 
-  const endStartYear = input.hasExplicitYear ? end.year : startDate.year;
+  // Floor the explicit end year at startDate.year so an inconsistent model
+  // output (e.g. start 2030, end 2020) can't push the scan past its window.
+  const endStartYear = input.hasExplicitYear
+    ? Math.max(end.year, startDate.year)
+    : startDate.year;
   const endDate = findDate(endStartYear, end.month, end.day, startDate);
 
   return {

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -1,20 +1,8 @@
 import { Temporal } from "@js-temporal/polyfill";
 
-/**
- * Deterministically pick the year for event dates that the model extracted
- * without an explicit year in the source.
- *
- * The model is unreliable at enforcing a date-window constraint in the prompt
- * (this caused the recurring "2027 date" bug — see migrations/fix2027Dates.ts
- * and migrations/fix2027FeedDates.ts). Instead of trusting the model, we have
- * it extract MM-DD and self-report whether the source explicitly stated a
- * year. If not, we compute the year ourselves: the soonest future instance
- * of that MM-DD relative to "today" in the user's timezone.
- *
- * Feb 29 inputs advance to the next leap year instead of silently clamping to
- * Feb 28. Events that span a year boundary (e.g. an NYE show that ends Jan 1)
- * are handled by advancing the end year until end >= start.
- */
+// Pick the year for an event's MM-DD deterministically rather than trusting
+// the model, which doesn't reliably enforce a date-window constraint in the
+// prompt. See migrations/fix2027Dates.ts for the bug this replaces.
 
 const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 const MAX_YEAR_OFFSET = 4;
@@ -40,13 +28,9 @@ function parseYMD(value: string): { year: number; month: number; day: number } {
   };
 }
 
-/**
- * Earliest valid PlainDate for `month`/`day` starting at `startYear`, scanning
- * forward up to MAX_YEAR_OFFSET years. When `notBefore` is provided, the
- * returned date is also >= it. Uses overflow:"reject" so Feb 29 finds the
- * next leap year instead of silently clamping. Throws on truly invalid
- * month/day combinations (e.g. 13-40, 02-30).
- */
+// Earliest valid PlainDate for month/day at or after startYear (and notBefore,
+// if given). Scans forward so Feb 29 advances to the next leap year instead of
+// clamping to Feb 28.
 function findDate(
   startYear: number,
   month: number,
@@ -73,18 +57,6 @@ function findDate(
   );
 }
 
-/**
- * Normalize event start/end dates.
- *
- * - Explicit year: trust the model's year on both `startDate` and `endDate`.
- *   `startDate` is taken exactly (throws on an invalid date like Feb 29 of a
- *   non-leap year). `endDate`'s year is preserved when the range is legit
- *   multi-year (e.g. 2026-01-01 → 2027-01-01) and advanced only when
- *   `end < start` (NYE-style spans).
- * - Inferred year: replace `startDate`'s year with the soonest future year
- *   for its MM-DD relative to `today`; then pick `endDate`'s year starting
- *   at `startDate.year` so it remains on/after `startDate`.
- */
 export function normalizeEventYear(
   input: NormalizeInput,
   today: Temporal.PlainDate,

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -72,13 +72,14 @@ function findDate(
 /**
  * Normalize event start/end dates.
  *
- * - Explicit year: trust the model's year on `startDate` (throws on an
- *   invalid date like Feb 29 of a non-leap year). The end year is always
- *   advanced if needed so NYE-style events with `end < start` stay
- *   consistent.
+ * - Explicit year: trust the model's year on both `startDate` and `endDate`.
+ *   `startDate` is taken exactly (throws on an invalid date like Feb 29 of a
+ *   non-leap year). `endDate`'s year is preserved when the range is legit
+ *   multi-year (e.g. 2026-01-01 → 2027-01-01) and advanced only when
+ *   `end < start` (NYE-style spans).
  * - Inferred year: replace `startDate`'s year with the soonest future year
- *   for its MM-DD relative to `today`; then pick `endDate`'s year so it
- *   remains on/after `startDate`.
+ *   for its MM-DD relative to `today`; then pick `endDate`'s year starting
+ *   at `startDate.year` so it remains on/after `startDate`.
  */
 export function normalizeEventYear(
   input: NormalizeInput,
@@ -94,7 +95,8 @@ export function normalizeEventYear(
       )
     : findDate(today.year, start.month, start.day, today);
 
-  const endDate = findDate(startDate.year, end.month, end.day, startDate);
+  const endStartYear = input.hasExplicitYear ? end.year : startDate.year;
+  const endDate = findDate(endStartYear, end.month, end.day, startDate);
 
   return {
     startDate: startDate.toString(),

--- a/packages/cal/src/normalizeEventYear.ts
+++ b/packages/cal/src/normalizeEventYear.ts
@@ -1,0 +1,103 @@
+import { Temporal } from "@js-temporal/polyfill";
+
+/**
+ * Deterministically pick the year for event dates that the model extracted
+ * without an explicit year in the source.
+ *
+ * The model is unreliable at enforcing a date-window constraint in the prompt
+ * (this caused the recurring "2027 date" bug — see migrations/fix2027Dates.ts
+ * and migrations/fix2027FeedDates.ts). Instead of trusting the model, we have
+ * it extract MM-DD and self-report whether the source explicitly stated a
+ * year. If not, we compute the year ourselves: the soonest future instance
+ * of that MM-DD relative to "today" in the user's timezone.
+ *
+ * Feb 29 inputs advance to the next leap year instead of silently clamping to
+ * Feb 28. Events that span a year boundary (e.g. an NYE show that ends Jan 1)
+ * are handled by advancing the end year until end >= start.
+ */
+
+const DATE_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MAX_YEAR_OFFSET = 4;
+
+interface NormalizeInput {
+  startDate: string;
+  endDate: string;
+  hasExplicitYear: boolean;
+}
+
+interface NormalizeOutput {
+  startDate: string;
+  endDate: string;
+}
+
+function parseYMD(value: string): { year: number; month: number; day: number } {
+  const match = DATE_REGEX.exec(value);
+  if (!match) throw new Error(`Expected YYYY-MM-DD, got: ${value}`);
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+/**
+ * Earliest valid PlainDate for `month`/`day` starting at `startYear`, scanning
+ * forward up to MAX_YEAR_OFFSET years. When `notBefore` is provided, the
+ * returned date is also >= it. Uses overflow:"reject" so Feb 29 finds the
+ * next leap year instead of silently clamping. Throws on truly invalid
+ * month/day combinations (e.g. 13-40, 02-30).
+ */
+function findDate(
+  startYear: number,
+  month: number,
+  day: number,
+  notBefore?: Temporal.PlainDate,
+): Temporal.PlainDate {
+  for (let offset = 0; offset <= MAX_YEAR_OFFSET; offset++) {
+    try {
+      const candidate = Temporal.PlainDate.from(
+        { year: startYear + offset, month, day },
+        { overflow: "reject" },
+      );
+      if (!notBefore || Temporal.PlainDate.compare(candidate, notBefore) >= 0) {
+        return candidate;
+      }
+    } catch {
+      // Invalid for this year (e.g. Feb 29 in a non-leap year); try next.
+    }
+  }
+  throw new Error(`Invalid month/day combination: ${month}-${day}`);
+}
+
+/**
+ * Normalize event start/end dates.
+ *
+ * - Explicit year: trust the model's year on `startDate` (throws on an
+ *   invalid date like Feb 29 of a non-leap year). The end year is always
+ *   advanced if needed so NYE-style events with `end < start` stay
+ *   consistent.
+ * - Inferred year: replace `startDate`'s year with the soonest future year
+ *   for its MM-DD relative to `today`; then pick `endDate`'s year so it
+ *   remains on/after `startDate`.
+ */
+export function normalizeEventYear(
+  input: NormalizeInput,
+  today: Temporal.PlainDate,
+): NormalizeOutput {
+  const start = parseYMD(input.startDate);
+  const end = parseYMD(input.endDate);
+
+  const startDate = input.hasExplicitYear
+    ? Temporal.PlainDate.from(
+        { year: start.year, month: start.month, day: start.day },
+        { overflow: "reject" },
+      )
+    : findDate(today.year, start.month, start.day, today);
+
+  const endDate = findDate(startDate.year, end.month, end.day, startDate);
+
+  return {
+    startDate: startDate.toString(),
+    endDate: endDate.toString(),
+  };
+}

--- a/packages/cal/src/prompts.ts
+++ b/packages/cal/src/prompts.ts
@@ -188,6 +188,12 @@ export const EventSchema = z.object({
     .describe(
       "End time in 24-hour format HH:MM:SS (e.g., 14:30:00 for 2:30 PM). Always include seconds, even if they're 00.",
     ),
+  hasExplicitYear: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true ONLY if the source text or image explicitly states a 4-digit year for the event (e.g., 'March 15, 2028' or 'Summer 2027'). Omit or set to false in every other case, including when the year is merely implied by recency, context, or your own guess. When false, any placeholder year you pick for startDate/endDate will be discarded and replaced downstream with the soonest future year that matches the month and day.",
+    ),
   timeZone: z.string().describe("Timezone in IANA format."),
   location: z.string().describe("Location of the event."),
   // eventMetadata: EventMetadataSchema,
@@ -294,15 +300,8 @@ export const systemMessage = (schema?: string) =>
  * Generates the main event extraction prompt text.
  * @param date - Current date in YYYY-MM-DD format (e.g., "2026-01-20")
  * @param timezone - IANA timezone identifier (e.g., "America/Los_Angeles")
- * @param minDate - Earliest valid date in YYYY-MM-DD format (e.g., "2025-11-20")
- * @param maxDate - Latest valid date in YYYY-MM-DD format (e.g., "2026-11-20")
  */
-export const getText = (
-  date: string,
-  timezone: string,
-  minDate: string,
-  maxDate: string,
-) => `# CONTEXT
+export const getText = (date: string, timezone: string) => `# CONTEXT
 The current date is ${date}, and the default timezone is ${timezone} unless specified otherwise.
 
 ## YOUR JOB
@@ -335,9 +334,10 @@ The system using the output requires specific date and time formatting.
 - Always include seconds in the time, even if they're 00.
 - Always provide both startTime and endTime.
 
-**Year Inference:**
-- If no year is explicitly stated: You MUST infer a year that places the date between ${minDate} and ${maxDate}.
-- If a year IS explicitly stated: Use that exact year. This is the ONLY time a date can fall outside the ${minDate} to ${maxDate} window.
+**Year Inference (read carefully):**
+- Set \`hasExplicitYear\` to true ONLY when the source text or image literally contains a 4-digit year tied to the event (e.g., "March 15, 2028", "Summer 2027", "NYE 2026/2027"). Recency, context, or your own best guess DO NOT count as explicit.
+- When \`hasExplicitYear\` is false, the year you write into \`startDate\`/\`endDate\` does not matter — pick the current year as a placeholder. The system will replace it downstream with the soonest future year that matches the month and day, so DO NOT try to reason about whether the event has "already passed this year".
+- When \`hasExplicitYear\` is true, use the exact year stated. Never invent a year just to satisfy recency.
 
 ** Time Inference (when a start or end time is not explicitly stated):**
 - If start time is not explicitly stated, infer a reasonable start time based on the event type and context (e.g., 19:00:00 for an evening concert, 10:00:00 for a morning workshop).
@@ -388,7 +388,7 @@ Common pitfalls (avoid):
 - Guessing platform; when unsure, use "unknown".
 `;
 
-const formatOffsetAsIANASoft = (offset: string) => {
+export const formatOffsetAsIANASoft = (offset: string) => {
   const timezone = soft(offset)[0];
   return timezone?.iana || Intl.DateTimeFormat().resolvedOptions().timeZone;
 };
@@ -398,28 +398,25 @@ export const getPrompt = (
 ) => {
   const timezoneIANA = formatOffsetAsIANASoft(timezone);
   const now = Temporal.Now.instant().toZonedDateTimeISO(timezoneIANA);
-  const currentDate = now.toPlainDate();
-  const date = currentDate.toString();
-  const minDate = currentDate.subtract({ months: 2 }).toString();
-  const maxDate = currentDate.add({ months: 10 }).toString();
+  const date = now.toPlainDate().toString();
 
   return {
-    text: getText(date, timezoneIANA, minDate, maxDate),
+    text: getText(date, timezoneIANA),
     textMetadata: getTextMetadata(),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };
 
 export const getSystemMessage = () => {
   return {
     text: systemMessage(),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };
 
 export const getSystemMessageMetadata = () => {
   return {
     text: systemMessage(eventMetadataSchemaAsText),
-    version: "v2026.03.30.2", // simplify year inference to strict date window with rare explicit-year override
+    version: "v2026.04.10.1", // delegate year inference to deterministic post-processing (normalizeEventYear)
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ catalogs:
     langfuse:
       specifier: ^3.11.0
       version: 3.38.6
+    lefthook:
+      specifier: ^2.1.5
+      version: 2.1.6
     lucide-react:
       specifier: ^0.373.0
       version: 0.373.0
@@ -549,6 +552,9 @@ importers:
       dotenv-cli:
         specifier: 'catalog:'
         version: 7.4.4
+      lefthook:
+        specifier: 'catalog:'
+        version: 2.1.6
       prettier:
         specifier: 'catalog:'
         version: 3.7.4
@@ -7872,6 +7878,60 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -18663,6 +18723,49 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   leven@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,9 +327,6 @@ catalogs:
     langfuse:
       specifier: ^3.11.0
       version: 3.38.6
-    lefthook:
-      specifier: ^2.1.5
-      version: 2.1.5
     lucide-react:
       specifier: ^0.373.0
       version: 0.373.0
@@ -552,9 +549,6 @@ importers:
       dotenv-cli:
         specifier: 'catalog:'
         version: 7.4.4
-      lefthook:
-        specifier: 'catalog:'
-        version: 2.1.5
       prettier:
         specifier: 'catalog:'
         version: 3.7.4
@@ -1082,6 +1076,9 @@ importers:
       '@convex-dev/workpool':
         specifier: 'catalog:'
         version: 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+      '@js-temporal/polyfill':
+        specifier: 'catalog:'
+        version: 0.4.4
       '@soonlist/cal':
         specifier: workspace:*
         version: link:../cal
@@ -5196,12 +5193,11 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5582,7 +5578,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -7876,60 +7872,6 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
-
-  lefthook-darwin-arm64@2.1.5:
-    resolution: {integrity: sha512-VITTaw8PxxyE26gkZ8UcwIa5ZrWnKNRGLeeSrqri40cQdXvLTEoMq2tjjw7eiL9UcB0waRReDdzydevy9GOPUQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@2.1.5:
-    resolution: {integrity: sha512-AvtjYiW0BSGHBGrdvL313seUymrW9FxI+6JJwJ+ZSaa2sH81etrTB0wAwlH1L9VfFwK9+gWvatZBvLfF3L4fPw==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@2.1.5:
-    resolution: {integrity: sha512-mXjJwe8jKGWGiBYUxfQY1ab3Nn5NhafqT9q3KJz8m5joGGQj4JD0cbWxF1nVBLBWsDGbWZRZunTCMGcIScT2bQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@2.1.5:
-    resolution: {integrity: sha512-exD69dCjc1K45BxatDPGoH4NmEvgLKPm4kJLOWn1fTeHRKZwWiFPwnjknEoG2OemlCDHmCU++5X40kMEG0WBlA==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@2.1.5:
-    resolution: {integrity: sha512-57TDKC5ewWpsCLZQKIJMHumFEObYKVundmPpiWhX491hINRZYYOL/26yrnVnNcidThRzTiTC+HLcuplLcaXtbA==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@2.1.5:
-    resolution: {integrity: sha512-bqK3LrAB5l5YaCaoHk6qRWlITrGWzP4FbwRxA31elbxjd0wgNWZ2Sn3zEfSEcxz442g7/PPkEwqqsTx0kSFzpg==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@2.1.5:
-    resolution: {integrity: sha512-5aSwK7vV3A6t0w9PnxCMiVjQlcvopBP50BtmnnLnNJyAYHnFbZ0Baq5M0WkE9IsUkWSux0fe6fd0jDkuG711MA==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@2.1.5:
-    resolution: {integrity: sha512-Y+pPdDuENJ8qWnUgL02xxhpjblc0WnwXvWGfqnl3WZrAgHzQpwx3G6469RID/wlNVdHYAlw3a8UkFSMYsTzXvA==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@2.1.5:
-    resolution: {integrity: sha512-2PlcFBjTzJaMufw0c28kfhB/0zmaRCU0TRPPsil/HU2YNOExod4upPGLk9qjgsOmb2YVWFz6zq6u7+D1yqmzTQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@2.1.5:
-    resolution: {integrity: sha512-yiAh8qxml6uqy10jDxOdN9fOQpyLxBFY1fgCEAhn7sVJYmJKRhjqSBwZX6LG5MQjzr29KStrIdw7TR3lf3rT7Q==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@2.1.5:
-    resolution: {integrity: sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A==}
-    hasBin: true
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -14342,7 +14284,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.3
+      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -18722,49 +18664,6 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
-  lefthook-darwin-arm64@2.1.5:
-    optional: true
-
-  lefthook-darwin-x64@2.1.5:
-    optional: true
-
-  lefthook-freebsd-arm64@2.1.5:
-    optional: true
-
-  lefthook-freebsd-x64@2.1.5:
-    optional: true
-
-  lefthook-linux-arm64@2.1.5:
-    optional: true
-
-  lefthook-linux-x64@2.1.5:
-    optional: true
-
-  lefthook-openbsd-arm64@2.1.5:
-    optional: true
-
-  lefthook-openbsd-x64@2.1.5:
-    optional: true
-
-  lefthook-windows-arm64@2.1.5:
-    optional: true
-
-  lefthook-windows-x64@2.1.5:
-    optional: true
-
-  lefthook@2.1.5:
-    optionalDependencies:
-      lefthook-darwin-arm64: 2.1.5
-      lefthook-darwin-x64: 2.1.5
-      lefthook-freebsd-arm64: 2.1.5
-      lefthook-freebsd-x64: 2.1.5
-      lefthook-linux-arm64: 2.1.5
-      lefthook-linux-x64: 2.1.5
-      lefthook-openbsd-arm64: 2.1.5
-      lefthook-openbsd-x64: 2.1.5
-      lefthook-windows-arm64: 2.1.5
-      lefthook-windows-x64: 2.1.5
-
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -19110,19 +19009,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       https-proxy-agent: 7.0.6
       metro-core: 0.83.3
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-config@0.83.3:
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Alternative to #984 — same behavior and hardening, ~40% smaller in the core file (`normalizeEventYear.ts`: 103 lines vs 163). Open for comparison; close/rebase whichever isn't preferred.

## What's different from #984

The core module had two near-identical forward-scan helpers (`pickYearForMonthDay` and `pickValidDate`) and two separate branches for the explicit-year vs inferred-year paths in `normalizeEventYear`. This PR collapses both into a single helper:

```ts
function findDate(
  startYear: number,
  month: number,
  day: number,
  notBefore?: Temporal.PlainDate,
): Temporal.PlainDate
```

`notBefore` is the only thing that actually differed between the two old helpers. With it optional, start-year selection (needs `today` as the floor) and end-year selection (needs `startDate` as the floor) become one call each.

The end-after-start adjustment also falls out naturally: `findDate(startDate.year, end.month, end.day, startDate)` already scans forward until end ≥ start, so the explicit-NYE advance and the inferred year-spanning advance share one path.

```ts
const startDate = input.hasExplicitYear
  ? Temporal.PlainDate.from(
      { year: start.year, month: start.month, day: start.day },
      { overflow: "reject" },
    )
  : findDate(today.year, start.month, start.day, today);

const endDate = findDate(startDate.year, end.month, end.day, startDate);
```

## Preserved from #984

- `overflow:"reject"` + forward scan so Feb 29 advances to the next leap year instead of silently clamping to Feb 28
- Explicit-year NYE events (`end < start`) still advance the end year
- Truly invalid MM-DD combinations (e.g. `02-30`, `13-40`) still throw with a clear message
- `formatOffsetAsIANASoft` exported and used in `aiHelpers.ts` to normalize offset-format timezones (`UTC+5`) before `Temporal.toZonedDateTimeISO`
- `@js-temporal/polyfill` as a direct dependency of `@soonlist/backend`
- Prompt changes: `hasExplicitYear` schema field, simplified `getText`, version bump to `v2026.04.10.1`

## Scenarios verified (mentally, by tracing)

| Input | Expected | Result |
|---|---|---|
| Feb 29 with placeholder year 2026, `hasExplicitYear=false`, today=2026-04-17 | 2028-02-29 | `findDate(2026, 2, 29, today)` rejects 2026/2027, returns 2028 ✓ |
| `2028-03-15`, `hasExplicitYear=true` | 2028-03-15 preserved | Trusted directly via `PlainDate.from(..., reject)` ✓ |
| NYE inferred: start=`2026-12-31`, end=`2026-01-01`, `hasExplicitYear=false`, today=2026-04-17 | start 2026-12-31, end 2027-01-01 | `findDate(2026, 12, 31, today)` returns 2026-12-31; `findDate(2026, 1, 1, 2026-12-31)` advances to 2027 ✓ |
| NYE explicit: start=`2026-12-31`, end=`2026-01-01`, `hasExplicitYear=true` | start 2026-12-31, end 2027-01-01 | Start trusted; end `findDate(2026, 1, 1, 2026-12-31)` → 2027-01-01 ✓ |
| `UTC+5` timezone | No `RangeError` | Normalized via `formatOffsetAsIANASoft` in aiHelpers ✓ |

## Files Changed

| File | Purpose |
|---|---|
| `packages/cal/src/normalizeEventYear.ts` | Simpler rewrite: one `findDate` helper, unified branches |
| `packages/cal/src/index.ts` | Re-export new module |
| `packages/cal/src/prompts.ts` | Add `hasExplicitYear`; simplify `getText`; export `formatOffsetAsIANASoft`; bump prompt version |
| `packages/backend/convex/model/aiHelpers.ts` | Post-process via `normalizeEventYear`; normalize TZ |
| `packages/backend/package.json` | Direct `@js-temporal/polyfill` dep |

## Context

Dry-run against prod today shows **12 events** (8 users) still incorrectly stamped 2027 under the current `v2026.03.30.2` prompt — this is the recurring pattern both #984 and this PR fix at the root. A follow-up run of the existing `fix2027Dates` + `fix2027FeedDates` migrations cleans up the already-corrupted data.

Closes #984 if this version is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies and hardens event‑year handling by computing the year from MM‑DD in the user’s timezone. Fixes recurring mis‑stamps, preserves explicit multi‑year spans, and prevents inconsistent end‑year outputs.

- **Bug Fixes**
  - Deterministically compute the year for MM‑DD without an explicit year using `Temporal` (soonest future in user TZ; Feb 29 → next leap year).
  - Preserve explicit multi‑year spans: trust `end.year` when `hasExplicitYear`, but floor it to `startDate.year` to avoid backward end dates; otherwise ensure end ≥ start across NYE via one forward scan.
  - Clearer errors distinguishing invalid MM‑DD vs scan‑window exhaustion; normalize `UTC+/-` offsets via `formatOffsetAsIANASoft`.

- **Refactors**
  - Added `normalizeEventYear` with a single `findDate` scan; removed duplicated logic.
  - Introduced `hasExplicitYear` in `EventSchema`; simplified prompt text; bumped version to `v2026.04.10.1`.
  - Backend now post‑processes with `normalizeEventYear`; exported helpers; added `@js-temporal/polyfill` to `@soonlist/backend`; re‑exported from `cal` index.

<sup>Written for commit 8815d94698639a629348aa1022142fc991ed0d9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the event-year normalization approach by replacing two near-identical forward-scan helpers with a single `findDate` utility and a unified branch structure in `normalizeEventYear.ts`. A new `hasExplicitYear` schema field lets the model self-report whether a year was literally stated in the source; when false, the year is deterministically replaced post-inference rather than relying on the model to honor a min/max date window in the prompt.

- **Lockfile inconsistency (P1):** `lefthook` is removed from `pnpm-lock.yaml` (catalog section, root-workspace importer, and all snapshots), but `pnpm-workspace.yaml` and the root `package.json` still declare `\"lefthook\": \"catalog:\"` with `\"prepare\": \"lefthook install\"`. Any CI step running `pnpm install --frozen-lockfile` will fail, and the pre-commit hook setup described in `CLAUDE.md` would break for new contributors.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the lockfile — core normalization logic is correct and well-reasoned.

The `normalizeEventYear` logic is clean and handles all traced edge cases (Feb 29, NYE wrap, explicit-year trust). The only blocking concern is the pnpm lockfile being out of sync with `package.json` and `pnpm-workspace.yaml`, which will break `pnpm install --frozen-lockfile` in CI. A simple `pnpm install` at the repo root would regenerate a consistent lockfile and unblock the merge.

`pnpm-lock.yaml` — lefthook entries were dropped but are still required by `package.json` and `pnpm-workspace.yaml`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cal/src/normalizeEventYear.ts | New module: clean single-helper design. `findDate` correctly handles leap years via `overflow:"reject"` + forward scan, NYE wrap-around via `notBefore=startDate`, and truly invalid combos via MAX_YEAR_OFFSET exhaustion. |
| packages/backend/convex/model/aiHelpers.ts | Calls `normalizeEventYear` post-inference with `today` derived from the user's timezone. Core logic is sound; no error boundary wraps the normalize call — a RangeError from an invalid explicit-year date would propagate as an unhandled rejection. |
| packages/cal/src/prompts.ts | Adds `hasExplicitYear` optional field to `EventSchema`, removes `minDate`/`maxDate` window from `getText`, exports `formatOffsetAsIANASoft`, and bumps prompt version to `v2026.04.10.1`. |
| pnpm-lock.yaml | Adds `@js-temporal/polyfill` to the backend importer. Also removes all `lefthook` entries while root `package.json` and `pnpm-workspace.yaml` still declare it — lockfile is out of sync. |
| packages/backend/package.json | Adds `@js-temporal/polyfill` from the workspace catalog as a direct dependency of `@soonlist/backend`. |
| packages/cal/src/index.ts | Adds `export * from "./normalizeEventYear"` to expose the new module; no conflicts with existing exports. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AI model returns\nstartDate, endDate,\nhasExplicitYear] --> B{hasExplicitYear?}
    B -- true --> C[PlainDate.from\nyear=start.year\noverflow:reject\nthrows on invalid date]
    B -- false --> D[findDate\nstartYear=today.year\nnotBefore=today\nadvances to next valid leap year etc.]
    C --> E[startDate fixed]
    D --> E
    E --> F[findDate\nstartYear=startDate.year\nnotBefore=startDate\nadvances end year if end < start]
    F --> G[endDate]
    E --> H[Return normalized\nstartDate + endDate]
    G --> H
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pnpm-lock.yaml`, line 327-329 ([link](https://github.com/jaronheard/soonlist-turbo/blob/b998960b7ffbed9254f2fec7044ef77eeded679f/pnpm-lock.yaml#L327-L329)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Lockfile out of sync — will break `--frozen-lockfile` CI**

   `lefthook` is removed from the `catalogs:` section, the root-workspace importer entry, and all package/snapshot entries in this diff. However, the root `package.json` still declares `"lefthook": "catalog:"` in `devDependencies` and `"prepare": "lefthook install"` in scripts, and `pnpm-workspace.yaml` still has `lefthook: ^2.1.5` in the catalog. Any CI job that runs `pnpm install --frozen-lockfile` (the pnpm default in CI) will fail because the lockfile no longer records a resolved version for a package that `package.json` requires. New contributors who clone and run `pnpm install` will also get no lefthook git-hook setup, silently bypassing the pre-commit Prettier check described in `CLAUDE.md`. Please re-run `pnpm install` from the repo root to regenerate a consistent lockfile before merging.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: pnpm-lock.yaml
   Line: 327-329

   Comment:
   **Lockfile out of sync — will break `--frozen-lockfile` CI**

   `lefthook` is removed from the `catalogs:` section, the root-workspace importer entry, and all package/snapshot entries in this diff. However, the root `package.json` still declares `"lefthook": "catalog:"` in `devDependencies` and `"prepare": "lefthook install"` in scripts, and `pnpm-workspace.yaml` still has `lefthook: ^2.1.5` in the catalog. Any CI job that runs `pnpm install --frozen-lockfile` (the pnpm default in CI) will fail because the lockfile no longer records a resolved version for a package that `package.json` requires. New contributors who clone and run `pnpm install` will also get no lefthook git-hook setup, silently bypassing the pre-commit Prettier check described in `CLAUDE.md`. Please re-run `pnpm install` from the repo root to regenerate a consistent lockfile before merging.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: pnpm-lock.yaml
Line: 327-329

Comment:
**Lockfile out of sync — will break `--frozen-lockfile` CI**

`lefthook` is removed from the `catalogs:` section, the root-workspace importer entry, and all package/snapshot entries in this diff. However, the root `package.json` still declares `"lefthook": "catalog:"` in `devDependencies` and `"prepare": "lefthook install"` in scripts, and `pnpm-workspace.yaml` still has `lefthook: ^2.1.5` in the catalog. Any CI job that runs `pnpm install --frozen-lockfile` (the pnpm default in CI) will fail because the lockfile no longer records a resolved version for a package that `package.json` requires. New contributors who clone and run `pnpm install` will also get no lefthook git-hook setup, silently bypassing the pre-commit Prettier check described in `CLAUDE.md`. Please re-run `pnpm install` from the repo root to regenerate a consistent lockfile before merging.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cal/src/normalizeEventYear.ts
Line: 66-69

Comment:
**Error message conflates two distinct failure modes**

`findDate` throws `"Invalid month/day combination: ${month}-${day}"` in two different situations: (a) the month/day pair is genuinely impossible (e.g. `02-30`), and (b) every candidate within the scan window was rejected by the `notBefore` constraint. In situation (b) the combination itself is valid — only the floor date pushes it out of reach. While situation (b) is practically unreachable for the window sizes in use, the message would mislead anyone trying to debug it. Consider distinguishing the two:

```suggestion
    } catch {
      // Invalid for this year (e.g. Feb 29 in a non-leap year); try next.
    }
  }
  throw new Error(
    `Could not find a valid date for month ${month}, day ${day} ` +
      `within ${MAX_YEAR_OFFSET} years of ${startYear}` +
      (notBefore ? ` on or after ${notBefore}` : ""),
  );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: regenerate lockfile after rebase ..."](https://github.com/jaronheard/soonlist-turbo/commit/b998960b7ffbed9254f2fec7044ef77eeded679f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28808585)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->