### PR TITLE
Clear My Scene badge on unsubscribe; refine empty state copy

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -14,7 +14,7 @@ import {
   View,
 } from "react-native";
 import { Image } from "expo-image";
-import { Redirect, useRouter } from "expo-router";
+import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
 import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
@@ -36,6 +36,7 @@ import LoadingSpinner from "~/components/LoadingSpinner";
 import ScenePreviewThreeUp from "~/components/ScenePreviewThreeUp";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
+import { useAddEventFlow } from "~/hooks/useAddEventFlow";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
@@ -275,6 +276,7 @@ function FollowingEmptyState({
   onExitToFeed: () => void;
 }) {
   const { user } = useUser();
+  const { triggerAddEventFlow } = useAddEventFlow();
 
   const userData = useQuery(
     api.users.getByUsername,
@@ -293,15 +295,6 @@ function FollowingEmptyState({
         paddingBottom: 80,
       }}
     >
-      <View className="px-3 pb-2" style={{ marginTop: -4 }}>
-        <Text
-          className="mb-1 text-base font-medium text-neutral-2"
-          style={{ paddingLeft: 6 }}
-        >
-          Events from lists I subscribe to
-        </Text>
-      </View>
-
       <View className="px-6 pt-6">
         <Text
           className="mb-3 text-2xl font-bold text-neutral-1"
@@ -313,9 +306,9 @@ function FollowingEmptyState({
           className="mb-6 text-base text-neutral-2"
           style={{ lineHeight: 22 }}
         >
-          My Scene shows upcoming events from people you subscribe to.
+          My Scene shows upcoming events from lists you subscribe to.
           {featuredLists.length > 0
-            ? " Start with one of these featured lists."
+            ? " These featured lists are based in Portland, OR."
             : ""}
         </Text>
 
@@ -354,7 +347,26 @@ function FollowingEmptyState({
               </Text>
             </TouchableOpacity>
           </View>
-        ) : null}
+        ) : (
+          <View className="mt-4 items-center">
+            <Text className="mb-1 text-sm text-neutral-2">
+              Not in Portland? Start your own Soonlist.
+            </Text>
+            <TouchableOpacity
+              onPress={() => {
+                void triggerAddEventFlow();
+              }}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel="Add an event"
+              className="px-2 py-2"
+            >
+              <Text className="text-base font-semibold text-interactive-1">
+                Add an event →
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
       </View>
     </ScrollView>
   );
@@ -390,6 +402,19 @@ function FollowingFeedContent() {
       setSelectedSegment("upcoming");
     }
   }, [followedLists, hasFollowings, emptyStateMode]);
+
+  // When the user returns to the tab with active subscriptions, dismiss the
+  // empty state so they land directly on their feed. The in-tab stickiness
+  // during a subscribe session is preserved because focus events don't fire
+  // while the user stays on this tab.
+  useFocusEffect(
+    useCallback(() => {
+      if (hasFollowings && emptyStateMode === "show") {
+        setEmptyStateMode("dismissed");
+      }
+    }, [hasFollowings, emptyStateMode]),
+  );
+
   const handleExitEmptyState = useCallback(() => {
     setEmptyStateMode("dismissed");
   }, []);
@@ -456,13 +481,25 @@ function FollowingFeedContent() {
       }));
   }, [events, stableTimestamp, selectedSegment]);
 
-  // Update tab badge count based on upcoming events
+  // Update tab badge count based on upcoming events. When the user
+  // unsubscribes from everything, the feed query is skipped and `events`
+  // retains its last value via useStablePaginatedQuery, so we must clear the
+  // badge explicitly based on `hasFollowings`.
   const setCommunityBadgeCount = useAppStore((s) => s.setCommunityBadgeCount);
   useEffect(() => {
+    if (!hasFollowings) {
+      setCommunityBadgeCount(0);
+      return;
+    }
     if (selectedSegment === "upcoming") {
       setCommunityBadgeCount(enrichedEvents.length);
     }
-  }, [enrichedEvents.length, selectedSegment, setCommunityBadgeCount]);
+  }, [
+    hasFollowings,
+    enrichedEvents.length,
+    selectedSegment,
+    setCommunityBadgeCount,
+  ]);
 
   const followedListCount = followedLists?.length ?? 0;
   const singleFollowedList =

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -404,15 +404,31 @@ function FollowingFeedContent() {
   }, [followedLists, hasFollowings, emptyStateMode]);
 
   // When the user returns to the tab with active subscriptions, dismiss the
-  // empty state so they land directly on their feed. The in-tab stickiness
-  // during a subscribe session is preserved because focus events don't fire
-  // while the user stays on this tab.
+  // empty state so they land directly on their feed. The focus callback is
+  // intentionally stable (empty deps) because useFocusEffect's internal
+  // useEffect re-runs whenever its callback reference changes — a naive deps
+  // array would dismiss mid-session as soon as hasFollowings flips to true,
+  // defeating the stickiness that lets users subscribe to multiple featured
+  // lists before the view swaps to the feed. A ref tracks whether the screen
+  // has actually blurred, so we only dismiss on a true return-to-tab.
+  const hasFollowingsRef = useRef(hasFollowings);
+  hasFollowingsRef.current = hasFollowings;
+  const emptyStateModeRef = useRef(emptyStateMode);
+  emptyStateModeRef.current = emptyStateMode;
+  const hasBlurredRef = useRef(false);
   useFocusEffect(
     useCallback(() => {
-      if (hasFollowings && emptyStateMode === "show") {
+      if (
+        hasBlurredRef.current &&
+        hasFollowingsRef.current &&
+        emptyStateModeRef.current === "show"
+      ) {
         setEmptyStateMode("dismissed");
       }
-    }, [hasFollowings, emptyStateMode]),
+      return () => {
+        hasBlurredRef.current = true;
+      };
+    }, []),
   );
 
   const handleExitEmptyState = useCallback(() => {


### PR DESCRIPTION
## Summary

Addresses feedback on the My Scene empty state and subscription flow.

- **Badge lingers after unsubscribing** — `communityBadgeCount` was only recomputed when the feed query returned results; once the user unfollowed every list the query was skipped and the stale count persisted. Now the badge resets to `0` whenever `hasFollowings` is false.
- **Empty state doesn't clear when returning to the tab** — `emptyStateMode` was sticky within a subscribe session, but also sticky across tab switches. Added `useFocusEffect` so re-focusing the My Scene tab with active subscriptions auto-dismisses the empty state. In-session stickiness is preserved because focus events don't fire while the user stays on the tab.
- **Empty state copy was duplicative and Portland-centric without context** — removed the duplicate "Events from lists I subscribe to" subtitle, reworded the description to "lists you subscribe to", noted that the featured lists are based in Portland, OR, and added a balanced "Add an event →" CTA (styled like the "View My Scene →" link) for viewers outside that scene.

### Not included

User also reported that "when you subscribe to a list, it doesn't show you all of their upcoming events." I traced the feed population paths (`followList` → `addListEventsToUserFeed`, `createEvent`/`updateEvent` → `updateEventInFeeds` → `addEventToListFollowersFeeds`, and the private→public fan-out already present in `updateEvent`) and the visibility+list bookkeeping all line up between `getPublicUserFeed` (the featured-row counter) and `getFollowedListsFeed` (the feed the user sees after subscribing). Couldn't reproduce a concrete discrepancy without runtime access — flagging in case someone with DB access wants to spot-check a specific featured user.

## Test plan

- [ ] Open My Scene with no subscriptions → empty state renders without the duplicate subtitle; description mentions Portland, OR; "Add an event →" CTA is visible and opens the photo picker.
- [ ] Subscribe to a featured list from the empty state → stays on the empty state mid-session (existing sticky behavior).
- [ ] Switch to My Soonlist tab and back → empty state is dismissed and the feed renders.
- [ ] Subscribe, confirm badge appears, then unsubscribe → badge clears immediately.
- [ ] Reopen app with no subscriptions → tab badge does not show a stale count.

https://claude.ai/code/session_01BdRRP2C2QmuCycWHq6JGsW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the lingering My Scene tab badge after unsubscribing and refines the empty state. The empty state now only dismisses on real tab re-focus; copy is clarified and a CTA is added for non‑Portland users.

- **Bug Fixes**
  - Reset `communityBadgeCount` to 0 when `hasFollowings` is false to clear the badge after unsubscribing.
  - Dismiss the empty state only when the My Scene tab actually regains focus and the user has subscriptions, avoiding mid-session dismissal when `hasFollowings` flips.

- **New Features**
  - Remove duplicate subtitle; update copy to “lists you subscribe to” and note featured lists are based in Portland, OR.
  - Add “Add an event →” CTA that triggers `useAddEventFlow` for users outside Portland.

<sup>Written for commit ca1c09d13bff6211bb4f1cf96b8d6e5932002423. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three issues with the My Scene (Following) tab: it resets `communityBadgeCount` to 0 via an explicit `!hasFollowings` guard so the badge clears immediately on unsubscribe (previously the skipped `useStablePaginatedQuery` retained its last value), adds `useFocusEffect` to auto-dismiss the empty state when the user returns to the tab with active subscriptions while preserving within-session stickiness, and updates the empty state copy to add Portland context and an "Add an event →" CTA for non-Portland users.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes are well-scoped, the state machine transitions are exhaustive, and no P1 issues were found.

The `emptyStateMode` state machine correctly handles all transitions (unset → show/dismissed, dismissed → show on unfollow-all, show → dismissed on focus). The badge fix is a simple guard that resolves a real user-visible bug. The `useFocusEffect` correctly uses expo-router's internal `lastEffect.current` ref pattern — deps in `useCallback` satisfy linting without affecting behavior. Copy changes are purely additive.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/following/index.tsx | Three targeted fixes: badge reset via `!hasFollowings` guard in the badge effect, `useFocusEffect` for auto-dismissing stale empty state on tab return, and empty-state copy improvements including Portland context and an Add-event CTA. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([emptyStateMode: unset]) --> |followedLists loads| B{hasFollowings?}
    B -- yes --> C([emptyStateMode: dismissed\nFeed visible])
    B -- no --> D([emptyStateMode: show\nEmpty state visible])

    D --> |User subscribes\nstays on tab| D
    D --> |User presses\nView My Scene| C
    D --> |Tab refocused\nhasFollowings=true\nuseFocusEffect| C

    C --> |User unsubscribes all| D
    C --> |Tab refocused\nhasFollowings=true| C

    subgraph Badge
        E{hasFollowings?} -- no --> F[setCommunityBadgeCount 0]
        E -- yes, segment=upcoming --> G[setCommunityBadgeCount enrichedEvents.length]
        E -- yes, segment=past --> H[badge unchanged]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Only dismiss empty state on real tab re-..."](https://github.com/jaronheard/soonlist-turbo/commit/ca1c09d13bff6211bb4f1cf96b8d6e5932002423) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28843020)</sub>

<!-- /greptile_comment -->