### PR TITLE
feat(expo): delay paywall until after onboarding

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -1,324 +1,69 @@
-import React, { useCallback, useEffect, useState } from "react";
-import {
-  ActivityIndicator,
-  Pressable,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
-import RevenueCatUI, { PAYWALL_RESULT } from "react-native-purchases-ui";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { router } from "expo-router";
+import React from "react";
+import { Pressable, Text, View } from "react-native";
 
-import { ProgressBar } from "~/components/ProgressBar";
-import { useRevenueCat } from "~/providers/RevenueCatProvider";
-import {
-  useAppStore,
-  usePendingFollowUsername,
-  useSetHasSeenOnboarding,
-} from "~/store";
-import { AF_EVENTS, trackAFEvent } from "~/utils/appsflyerEvents";
-import { shouldMockPaywall } from "~/utils/deviceInfo";
+import { Check } from "~/components/icons";
+import { QuestionContainer } from "~/components/QuestionContainer";
+import { useOnboarding } from "~/hooks/useOnboarding";
+import { usePendingFollowUsername, useSetHasSeenOnboarding } from "~/store";
+import { hapticLight } from "~/utils/feedback";
 
-// Route path for the sign-in screen within the onboarding flow.
-// Expo Router's typed routes are generated from the file structure and may be stale.
-// Using a relative path avoids the strict typed-route check.
-const SIGN_IN_PATH = "./05-sign-in" as const;
+const BULLETS = [
+  "Free to save events & share lists",
+  "Built for real life, not algorithms",
+  "Community supported — optional supporter perks",
+];
 
-export default function PaywallScreen() {
-  const { isInitialized, customerInfo } = useRevenueCat();
-  const { setOnboardingData } = useAppStore();
+export default function CommunitySupportedScreen() {
   const pendingFollowUsername = usePendingFollowUsername();
-  const [showMockPaywall] = useState(() => shouldMockPaywall());
-  const [paywallPresented, setPaywallPresented] = useState(false);
-  const hasUnlimited =
-    customerInfo?.entitlements.active.unlimited?.isActive ?? false;
+  const setHasSeenOnboarding = useSetHasSeenOnboarding();
+  const { saveStep } = useOnboarding();
 
-  // Paywall is the step after notifications. Sign-in sits at totalSteps - 1
-  // and final "done" is totalSteps, so paywall lands at totalSteps - 2.
+  // Keep the existing step math: this screen sits at totalSteps - 2,
+  // with sign-in at totalSteps - 1 and the final tick reserved for the
+  // "account created" state.
   const totalSteps = pendingFollowUsername ? 7 : 6;
   const currentStep = totalSteps - 2;
 
-  const setHasSeenOnboarding = useSetHasSeenOnboarding();
-
-  const completeOnboarding = useCallback(() => {
+  const handleContinue = () => {
+    void hapticLight();
     setHasSeenOnboarding(true);
-  }, [setHasSeenOnboarding]);
-
-  const presentPaywall = useCallback(async () => {
-    try {
-      setPaywallPresented(true);
-      // Use presentPaywallIfNeeded to double-check entitlements
-      const paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
-        requiredEntitlementIdentifier: "unlimited",
-      });
-
-      switch (paywallResult) {
-        case PAYWALL_RESULT.PURCHASED:
-        case PAYWALL_RESULT.RESTORED:
-          // User subscribed successfully
-          setOnboardingData({
-            subscribed: true,
-            subscribedAt: new Date().toISOString(),
-          });
-          // Mark onboarding as seen
-          completeOnboarding();
-          // Navigate to sign-in screen with subscription status
-          router.navigate({
-            pathname: SIGN_IN_PATH,
-            params: { fromPaywall: "true", subscribed: "true" },
-          });
-          break;
-
-        case PAYWALL_RESULT.NOT_PRESENTED:
-          // User already has the required entitlement
-          setOnboardingData({
-            subscribed: true,
-            subscribedAt: new Date().toISOString(),
-          });
-          // Mark onboarding as seen
-          completeOnboarding();
-          // Navigate to sign-in screen with subscription status
-          router.navigate({
-            pathname: SIGN_IN_PATH,
-            params: {
-              fromPaywall: "true",
-              subscribed: "true",
-              skipped: "already_subscribed",
-            },
-          });
-          break;
-
-        case PAYWALL_RESULT.CANCELLED:
-        case PAYWALL_RESULT.ERROR:
-          // User cancelled or error occurred - enter trial mode
-          trackAFEvent(AF_EVENTS.START_TRIAL, {});
-          setOnboardingData({
-            subscribed: false,
-            trialMode: true,
-            trialStartedAt: new Date().toISOString(),
-          });
-          // Mark onboarding as seen
-          completeOnboarding();
-          // Navigate to sign-in screen in trial mode
-          router.navigate({
-            pathname: SIGN_IN_PATH,
-            params: { fromPaywall: "true", trial: "true" },
-          });
-          break;
-      }
-    } catch (error) {
-      console.error("Error presenting paywall:", error);
-      // On error, continue to sign-up in trial mode
-      setOnboardingData({
-        subscribed: false,
-        trialMode: true,
-        trialStartedAt: new Date().toISOString(),
-      });
-      // Mark onboarding as seen
-      completeOnboarding();
-      router.navigate({
-        pathname: SIGN_IN_PATH,
-        params: { fromPaywall: "true", trial: "true" },
-      });
-    }
-  }, [setOnboardingData, setPaywallPresented, completeOnboarding]);
-
-  useEffect(() => {
-    // Check if user is already subscribed
-    if (isInitialized && hasUnlimited) {
-      // User already has subscription, skip paywall
-      setOnboardingData({
-        subscribed: true,
-        subscribedAt: new Date().toISOString(),
-      });
-      // Mark onboarding as seen
-      completeOnboarding();
-      // Navigate to sign-in screen with subscription status
-      router.navigate({
-        pathname: SIGN_IN_PATH,
-        params: {
-          fromPaywall: "true",
-          subscribed: "true",
-          skipped: "already_subscribed",
-        },
-      });
-      return;
-    }
-
-    // Present paywall for non-subscribers on real devices
-    if (
-      !showMockPaywall &&
-      isInitialized &&
-      !hasUnlimited &&
-      !paywallPresented
-    ) {
-      void presentPaywall();
-    }
-  }, [
-    isInitialized,
-    showMockPaywall,
-    presentPaywall,
-    hasUnlimited,
-    setOnboardingData,
-    paywallPresented,
-  ]);
-
-  const handleSkip = () => {
-    // Dismiss the paywall and enter trial mode
-    if (!showMockPaywall) {
-      // Paywall will dismiss automatically
-    }
-
-    trackAFEvent(AF_EVENTS.START_TRIAL, {});
-
-    // Save that they're in trial mode
-    setOnboardingData({
-      subscribed: false,
-      trialMode: true,
-      trialStartedAt: new Date().toISOString(),
-    });
-
-    // Mark onboarding as seen
-    completeOnboarding();
-
-    // Navigate to sign-in screen
-    router.navigate({
-      pathname: SIGN_IN_PATH,
-      params: { fromPaywall: "true", trial: "true" },
-    });
+    saveStep("paywall", {}, "/(onboarding)/onboarding/05-sign-in");
   };
 
-  const handleMockSubscribe = (plan: string) => {
-    // Mock subscription for simulator
-    setOnboardingData({
-      subscribed: true,
-      subscribedAt: new Date().toISOString(),
-      subscriptionPlan: plan,
-    });
-    // Mark onboarding as seen
-    completeOnboarding();
-    // Navigate to sign-in screen
-    router.navigate({
-      pathname: SIGN_IN_PATH,
-      params: { fromPaywall: "true", subscribed: "true", plan },
-    });
-  };
-
-  // Show mock paywall UI in simulator/development
-  if (showMockPaywall) {
-    return (
-      <SafeAreaView className="flex-1 bg-interactive-1">
-        <View className="pt-2">
-          <ProgressBar
-            currentStep={currentStep}
-            totalSteps={totalSteps}
-            backgroundColor="bg-neutral-3"
-            foregroundColor="bg-neutral-1"
-          />
-        </View>
-        <ScrollView className="flex-1 px-6">
-          <View className="py-8">
-            <Text className="mb-2 text-center text-3xl font-bold text-white">
-              Unlock Soonlist
-            </Text>
-            <Text className="mb-2 text-center text-lg text-white/80">
-              Save unlimited events and never miss out
-            </Text>
-            <Text className="mb-8 text-center text-sm text-accent-yellow">
-              (Mock Paywall - Simulator Mode)
-            </Text>
-
-            {/* Mock Plans */}
-            <View className="mb-8 space-y-4">
-              <Pressable
-                onPress={() => handleMockSubscribe("monthly")}
-                className="rounded-2xl border-2 border-white/30 bg-white/5 p-4"
-              >
-                <View className="flex-row items-center justify-between">
-                  <View>
-                    <Text className="text-lg font-semibold text-white">
-                      Monthly
-                    </Text>
-                    <Text className="text-white/80">Cancel anytime</Text>
-                  </View>
-                  <View className="items-end">
-                    <Text className="text-2xl font-bold text-white">$9.99</Text>
-                    <Text className="text-sm text-white/60">/month</Text>
-                  </View>
-                </View>
-              </Pressable>
-
-              <Pressable
-                onPress={() => handleMockSubscribe("yearly")}
-                className="rounded-2xl border-2 border-white bg-white/10 p-4"
-              >
-                <View className="flex-row items-center justify-between">
-                  <View>
-                    <Text className="text-lg font-semibold text-white">
-                      Yearly
-                    </Text>
-                    <Text className="text-white/80">Save 50% - Best value</Text>
-                  </View>
-                  <View className="items-end">
-                    <Text className="text-2xl font-bold text-white">
-                      $59.99
-                    </Text>
-                    <Text className="text-sm text-white/60">/year</Text>
-                  </View>
-                </View>
-                <View className="mt-2 self-start rounded-full bg-accent-yellow px-3 py-1">
-                  <Text className="text-sm font-semibold text-black">
-                    BEST VALUE
-                  </Text>
-                </View>
-              </Pressable>
-            </View>
-
-            <Text className="mb-4 text-center text-white/60">
-              Tap a plan to simulate purchase
-            </Text>
-
-            {/* Try Free Button */}
-            <Pressable onPress={handleSkip} className="py-2">
-              <Text className="text-center text-white/80 underline">
-                Continue for free
-              </Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </SafeAreaView>
-    );
-  }
-
-  // Real device - show loading spinner
-  // The RevenueCat paywall will appear as a modal over this screen
   return (
-    <SafeAreaView className="flex-1 bg-interactive-1">
-      <View className="pt-2">
-        <ProgressBar
-          currentStep={currentStep}
-          totalSteps={totalSteps}
-          backgroundColor="bg-neutral-3"
-          foregroundColor="bg-neutral-1"
-        />
-      </View>
-      <View className="flex-1 items-center justify-center px-6">
-        <ActivityIndicator size="large" color="white" />
-        <Text className="mt-4 text-lg text-white">
-          {!isInitialized
-            ? "Initializing..."
-            : "Loading subscription options..."}
-        </Text>
-        {/* Show skip button only before paywall is presented */}
-        {isInitialized && !paywallPresented && (
-          <Pressable onPress={handleSkip} className="mt-8 py-2">
-            <Text className="text-center text-white/60 underline">
-              Skip for now
+    <QuestionContainer
+      question="Free to use. Community supported."
+      subtitle="Soonlist is an invitation to real life — not a feed."
+      currentStep={currentStep}
+      totalSteps={totalSteps}
+    >
+      <View className="flex-1 justify-between">
+        <View className="mt-4">
+          {BULLETS.map((text) => (
+            <View key={text} className="mb-5 flex-row items-start">
+              <View className="mr-3 mt-1 h-6 w-6 items-center justify-center rounded-full bg-white">
+                <Check size={16} color="#5A32FB" strokeWidth={3} />
+              </View>
+              <Text className="flex-1 text-lg text-white">{text}</Text>
+            </View>
+          ))}
+        </View>
+
+        <View>
+          <Text className="mb-4 text-center text-sm text-white/70">
+            No ads. No algorithms. All features are free — supporter perks come
+            later.
+          </Text>
+          <Pressable
+            onPress={handleContinue}
+            className="rounded-full bg-white py-4 active:scale-[0.98] active:bg-neutral-100"
+          >
+            <Text className="text-center text-lg font-semibold text-interactive-1">
+              Continue
             </Text>
           </Pressable>
-        )}
+        </View>
       </View>
-    </SafeAreaView>
+    </QuestionContainer>
   );
 }

--- a/apps/expo/src/app/(onboarding)/onboarding/05-sign-in.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/05-sign-in.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Text, View } from "react-native";
-import { useLocalSearchParams } from "expo-router";
+import { View } from "react-native";
 
 import { FollowContextBanner } from "~/components/FollowContextBanner";
 import OnboardingOrbit from "~/components/OnboardingOrbit";
@@ -8,50 +7,25 @@ import SignInWithOAuth from "~/components/SignInWithOAuth";
 import { useAppStore, usePendingFollowUsername } from "~/store";
 
 export default function OnboardingSignInScreen() {
-  const { fromPaywall, subscribed, plan } = useLocalSearchParams<{
-    fromPaywall?: string;
-    subscribed?: string;
-    trial?: string;
-    plan?: string;
-  }>();
   const pendingFollowUsername = usePendingFollowUsername();
   const setHasCompletedOnboarding = useAppStore(
     (state) => state.setHasCompletedOnboarding,
   );
 
   // Mark onboarding as completed on mount
-  // hasSeenOnboarding was already set to true by 04-paywall
+  // hasSeenOnboarding was already set to true by the prior step
   // The layout redirect will handle navigation once the user is authenticated
   useEffect(() => {
     setHasCompletedOnboarding(true);
   }, [setHasCompletedOnboarding]);
 
-  // Show contextual banners based on paywall result
-  const showBanner = fromPaywall === "true";
   const showFollowBanner = !!pendingFollowUsername;
 
-  const banner =
-    showBanner || showFollowBanner ? (
-      <View className="px-4 pb-4 pt-4">
-        {subscribed === "true" && (
-          <View className="rounded-2xl bg-interactive-2 px-6 py-4">
-            <Text className="text-center text-lg font-bold text-neutral-1">
-              Thanks for subscribing! 🎉
-            </Text>
-            <Text className="text-center text-base text-neutral-1">
-              Create your account to get started
-            </Text>
-            {plan && (
-              <Text className="mt-1 text-center text-sm text-neutral-1/80">
-                {plan === "monthly" ? "Monthly plan" : "Yearly plan"}
-              </Text>
-            )}
-          </View>
-        )}
-
-        {showFollowBanner && <FollowContextBanner />}
-      </View>
-    ) : null;
+  const banner = showFollowBanner ? (
+    <View className="px-4 pb-4 pt-4">
+      <FollowContextBanner />
+    </View>
+  ) : null;
 
   // Progress continues from the earlier onboarding screens. Sign-in sits at
   // totalSteps - 1 so the bar reads "almost done" — the final tick fills in


### PR DESCRIPTION
## Summary

Replaces the RevenueCat paywall step in Expo onboarding with a "community-supported" framing screen. The paywall is no longer shown during onboarding — it surfaces later via the existing event-view trigger instead.

- **`04-paywall.tsx`** — now a simple "Free to use. Community supported." screen using the existing `QuestionContainer` treatment, with three check-bulleted value props ("Free to save events & share lists", "Built for real life, not algorithms", "Community supported — optional supporter perks") and a single Continue button that marks onboarding seen and advances to sign-in. No RevenueCat presentation, no mock paywall, no trial-mode branching.
- **`05-sign-in.tsx`** — drops the `fromPaywall` / `subscribed` / `plan` query params and the "Thanks for subscribing! 🎉" banner, since nothing upstream sets them anymore. The follow-context banner (from referral links) is preserved.

Step math is unchanged: this screen sits at `totalSteps - 2`, sign-in at `totalSteps - 1`. The filename stays `04-paywall.tsx` to avoid churning the typed-route string that `03-notifications.tsx` navigates to; only the contents changed.

## Notes / assumptions

- Per the feedback, this is the "delay paywall entirely" alternative. The attached mock (Annual/Monthly/Lifetime tiers) is framing for the *real* paywall that Jaron will update in RevenueCat — not something this PR renders during onboarding.
- The existing post-onboarding paywall trigger in `event/[id]/index.tsx` (every 20 event views via `shouldShowViewPaywall`) is unchanged and will continue to be the organic path to the paywall. `SubscriptionGuard` exists but is still unmounted — I didn't wire it up to avoid a regression where every app open re-presents the paywall to non-subscribers.
- The `"paywall"` value in `OnboardingStep` is retained for analytics continuity — `saveStep("paywall", …)` still fires on Continue so PostHog funnels don't break.
- Pre-existing lint errors on `main` (10 errors in files I didn't touch: `utils/config.ts` et al.) are unchanged. `typecheck` and `format` pass.

## Test plan

- [ ] Onboarding: welcome → try-it → your-list → notifications → **community-supported screen** → sign-in, with progress bar reading 4/6 on the new screen and 5/6 on sign-in (6/7 / 7/7 with a pending referral follow).
- [ ] Tapping Continue sets `hasSeenOnboarding = true` and navigates to sign-in with no params.
- [ ] Existing subscriber path (user already has `unlimited` entitlement): no paywall appears during onboarding — they land on sign-in same as everyone else.
- [ ] Post-sign-in, event-view paywall still fires after ~20 event detail views for non-subscribers.
- [ ] Referral deep link: welcome shows referral card, totals shift to /7, community screen still renders, follow banner still appears on sign-in.

https://claude.ai/code/session_01G7L8rNVc3WLPgMALfMNBD3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delays the paywall until after onboarding so new users can sign in without interruptions. Adds a short “Community supported” screen in place of the old paywall.

- **Refactors**
  - Replaced the onboarding paywall step with a simple screen using `QuestionContainer` and a single Continue that marks onboarding seen and moves to sign-in.
  - Removed onboarding RevenueCat presentation logic (`react-native-purchases-ui`); the paywall now only appears via the existing event-view trigger.
  - Simplified sign-in by removing `fromPaywall`, `subscribed`, and `plan` params and the subscription banner; the follow-context banner remains.
  - Kept step math and analytics stable: the screen still occupies the “paywall” step (totalSteps - 2) and continues to call `saveStep("paywall", …)`.

<sup>Written for commit 2948cc1c2ecd01ca3667c1eef005d1ead2b6ecba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the RevenueCat paywall step in onboarding with a lightweight "Free to use. Community supported." screen (`CommunitySupportedScreen`), and cleans up the now-unused `fromPaywall`/`subscribed`/`plan` params from `05-sign-in.tsx`. The analytics step name `"paywall"` is preserved so PostHog funnels remain intact, and the post-onboarding event-view paywall trigger is untouched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are a clean, focused replacement of the paywall screen with no regressions to navigation, analytics, or state management.

The diff is small and well-scoped. Navigation order (setHasSeenOnboarding → saveStep → router.navigate inside saveStep) matches the existing pattern used by every other onboarding screen. saveStep is intentionally synchronous with internal fire-and-forget async, consistent with all other callers. The sign-in screen cleanup is purely subtractive. No P0/P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx | Replaces full RevenueCat paywall (324 lines) with a simple community-supported framing screen (69 lines); preserves analytics via saveStep("paywall", …) and step-progress math; no logical issues found. |
| apps/expo/src/app/(onboarding)/onboarding/05-sign-in.tsx | Removes fromPaywall/subscribed/plan params and the "Thanks for subscribing!" banner since nothing upstream sets them; follow-context banner is preserved; clean and correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant 03-notifications
    participant 04-paywall (new)
    participant 05-sign-in
    participant Store

    User->>03-notifications: completes notifications step
    03-notifications->>04-paywall (new): router.navigate
    User->>04-paywall (new): taps Continue
    04-paywall (new)->>Store: setHasSeenOnboarding(true)
    04-paywall (new)->>Store: saveStep("paywall", {}) → setOnboardingData + setCurrentStep
    04-paywall (new)->>05-sign-in: router.navigate (inside saveStep)
    Note over 04-paywall (new): Convex + PostHog run in background
    05-sign-in->>Store: setHasCompletedOnboarding(true) on mount
    User->>05-sign-in: signs in with OAuth
    Note over 05-sign-in: layout redirect handles post-auth navigation
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): delay paywall until after on..."](https://github.com/jaronheard/soonlist-turbo/commit/2948cc1c2ecd01ca3667c1eef005d1ead2b6ecba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28871558)</sub>

<!-- /greptile_comment -->