### PR TITLE
refactor(expo): reorder event menu items for logical grouping

### DIFF
--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -106,11 +106,26 @@ export function EventMenu({
   };
 
   const getMenuItems = (): MenuItem[] => {
-    const baseItems: MenuItem[] = [
+    const items: MenuItem[] = [];
+
+    if (!isOwner && !isSaved) {
+      items.push({
+        title: "Save",
+        lucideIcon: Heart,
+        systemIcon: "heart",
+      });
+    }
+
+    items.push(
       {
         title: "Share",
         lucideIcon: ShareIcon,
         systemIcon: "square.and.arrow.up",
+      },
+      {
+        title: "Add to calendar",
+        lucideIcon: CalendarPlus,
+        systemIcon: "calendar.badge.plus",
       },
       {
         title: "Show QR",
@@ -122,64 +137,50 @@ export function EventMenu({
         lucideIcon: Map,
         systemIcon: "map",
       },
-      {
-        title: "Add to calendar",
-        lucideIcon: CalendarPlus,
-        systemIcon: "calendar.badge.plus",
-      },
-      {
-        title: "Feedback",
-        lucideIcon: MessageSquare,
-        systemIcon: "message",
-      },
-    ];
+    );
 
-    if (showDiscover && isOwner) {
-      baseItems.push({
-        title:
-          event.visibility === "public"
-            ? "Make not discoverable"
-            : "Make discoverable",
-        lucideIcon: event.visibility === "public" ? EyeOff : Globe2,
-        systemIcon: event.visibility === "public" ? "eye.slash" : "globe",
+    if (isOwner) {
+      items.push({
+        title: "Edit",
+        lucideIcon: PenSquare,
+        systemIcon: "square.and.pencil",
+      });
+
+      if (showDiscover) {
+        items.push({
+          title:
+            event.visibility === "public"
+              ? "Make not discoverable"
+              : "Make discoverable",
+          lucideIcon: event.visibility === "public" ? EyeOff : Globe2,
+          systemIcon: event.visibility === "public" ? "eye.slash" : "globe",
+        });
+      }
+    }
+
+    items.push({
+      title: "Feedback",
+      lucideIcon: MessageSquare,
+      systemIcon: "message",
+    });
+
+    if (isOwner) {
+      items.push({
+        title: "Delete",
+        lucideIcon: Trash2,
+        systemIcon: "trash",
+        destructive: true,
+      });
+    } else if (isSaved) {
+      items.push({
+        title: "Unsave",
+        lucideIcon: MinusCircle,
+        systemIcon: "minus.circle",
+        destructive: true,
       });
     }
 
-    if (isOwner) {
-      return [
-        ...baseItems,
-        {
-          title: "Edit",
-          lucideIcon: PenSquare,
-          systemIcon: "square.and.pencil",
-        },
-        {
-          title: "Delete",
-          lucideIcon: Trash2,
-          systemIcon: "trash",
-          destructive: true,
-        },
-      ];
-    } else if (!isSaved) {
-      return [
-        {
-          title: "Save",
-          lucideIcon: Heart,
-          systemIcon: "heart",
-        },
-        ...baseItems,
-      ];
-    } else {
-      return [
-        ...baseItems,
-        {
-          title: "Unsave",
-          lucideIcon: MinusCircle,
-          systemIcon: "minus.circle",
-          destructive: true,
-        },
-      ];
-    }
+    return items;
   };
 
   const handleMenuSelect = (title: string) => {


### PR DESCRIPTION
## Summary

Reorders the items in the long-press context menu and three-dot popup menu on event list items (`EventMenu.tsx`) so they feel logical rather than arbitrary. The visible inline buttons on list items were already in a sensible order (save, share, add to calendar), so those are left alone — only the menu contents change.

### New menu order

Items are grouped by purpose and progress from most-used to destructive:

1. **Primary actions** — Save (non-owners who haven't saved yet), Share, Add to calendar
2. **Sharing / navigation utilities** — Show QR, Get directions
3. **Owner management** (owner only) — Edit, Make discoverable / Make not discoverable
4. **App meta** — Feedback
5. **Destructive** (end) — Delete (owner) or Unsave (saved non-owner)

### Concrete results per context

- **Non-owner, not saved:** Save → Share → Add to calendar → Show QR → Get directions → Feedback
- **Non-owner, saved:** Share → Add to calendar → Show QR → Get directions → Feedback → Unsave
- **Owner:** Share → Add to calendar → Show QR → Get directions → Edit → (Make discoverable/not) → Feedback → Delete

Both menu surfaces (long-press context menu and three-dot dropdown) share the same item generator, so the new order applies to both.

### Key behavior changes

- `Unsave` now sits at the very end when an event is saved (previously last, but after items in a less intentional order).
- `Add to calendar` moves up next to `Share`, mirroring the inline button priority.
- `Edit` and visibility toggle are grouped together for owners, rather than visibility being appended before Edit/Delete.
- `Feedback` is placed just before the destructive action as a clear separator.

## Test plan

- [ ] Open an event you don't own and haven't saved → long-press / three-dot menu shows Save first, Unsave absent, no Edit/Delete
- [ ] Save the event → long-press / three-dot menu now shows Unsave at the very end; Save is gone
- [ ] Open an event you own → menu shows Edit, visibility toggle (if enabled), Feedback, Delete at end
- [ ] Each menu item still triggers the correct action (`handleShare`, `handleAddToCal`, `handleShowQR`, `handleDirections`, `handleEdit`, `handleToggleVisibility`, `handleFollow`/`handleUnfollow`, `handleDelete`, Intercom)
- [ ] Inline list-item buttons (save/calendar + share + more) are visually unchanged

https://claude.ai/code/session_015yPHo8QPEEL8Ffvso5ZLba
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered event item menus in `EventMenu.tsx` into clear groups, prioritizing primary actions and placing destructive actions last. Applies to both long-press and three-dot menus for a consistent, faster UX.

- **Refactors**
  - Order: Primary (Save if available, Share, Add to calendar) → Utilities (Show QR, Get directions) → Owner (Edit, Discoverability) → Feedback → Destructive (Unsave/Delete).
  - Moved “Add to calendar” next to “Share”; “Unsave”/“Delete” always last.
  - Owners see Edit and discoverability grouped; Feedback sits before destructive.
  - One generator now builds the ordered list based on `isOwner`, `isSaved`, and `showDiscover`.

<sup>Written for commit 76d4f70b1e264553f652841fad7bddfa7cb00ea2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reorders context menu and three-dot popup items in `EventMenu.tsx` for a more intentional grouping: primary actions first, utilities next, owner management together, feedback as separator, destructive actions last. The refactor also simplifies `getMenuItems()` from three divergent return paths with array spreads into a single push-based builder, which is easier to maintain. No behavioral regressions — all three user contexts (non-owner unsaved, non-owner saved, owner) produce the correct item lists per the PR description.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure reorder/refactor with no logic regressions.

Single-file UI refactor with no new logic paths, no data mutations, and correct item ordering verified against all three user contexts. No P0/P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/EventMenu.tsx | Refactors getMenuItems() from three separate return statements with array spreads into a single imperative push-based builder; reorders items per the described grouping (primary → utilities → owner management → feedback → destructive). Logic is correct across all three user contexts (non-owner unsaved, non-owner saved, owner). |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(expo): reorder event menu items..."](https://github.com/jaronheard/soonlist-turbo/commit/76d4f70b1e264553f652841fad7bddfa7cb00ea2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28871940)</sub>

<!-- /greptile_comment -->