### PR TITLE
feat(expo): first-run sticker tutorial on onboarding screens (#1010)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ docs/superpowers/
 .claude/launch.json
 .claude/.worktree-ports
 .claude/.worktree-ports.lock
+
+.superpowers/

--- a/apps/expo/src/app/(onboarding)/onboarding/01-try-it.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/01-try-it.tsx
@@ -13,6 +13,7 @@ import { Image as ExpoImage } from "expo-image";
 
 import type { Event } from "~/components/UserEventsList";
 import { PlusIcon } from "~/components/icons";
+import { SaveSticker } from "~/components/onboarding-stickers";
 import { QuestionContainer } from "~/components/QuestionContainer";
 import { UserEventListItem } from "~/components/UserEventsList";
 import { useOnboarding } from "~/hooks/useOnboarding";
@@ -205,13 +206,16 @@ export default function TryItScreen() {
             entering={FadeIn.duration(500)}
             className="-mx-2 flex-1 justify-center"
           >
-            <UserEventListItem
-              event={demoEvent}
-              showCreator="never"
-              isSaved={false}
-              demoMode={true}
-              index={0}
-            />
+            <View>
+              <UserEventListItem
+                event={demoEvent}
+                showCreator="never"
+                isSaved={false}
+                demoMode={true}
+                index={0}
+              />
+              <SaveSticker style={{ top: -80, right: -4 }} />
+            </View>
           </Animated.View>
         ) : (
           <View className="flex-1 justify-center">

--- a/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
@@ -1,14 +1,18 @@
 import type { ImageSource } from "expo-image";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { SymbolView } from "expo-symbols";
 
 import type { EventWithSimilarity } from "~/utils/similarEvents";
+import {
+  EventDetailSticker,
+  SubscribeSticker,
+} from "~/components/onboarding-stickers";
 import { QuestionContainer } from "~/components/QuestionContainer";
 import UserEventsList from "~/components/UserEventsList";
 import { useOnboarding } from "~/hooks/useOnboarding";
 import { usePendingFollowUsername } from "~/store";
-import { hapticLight } from "~/utils/feedback";
+import { hapticLight, hapticMedium } from "~/utils/feedback";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
 const lloydMallCrawlImage: ImageSource = require("../../../assets/demo-lloyd-mall-crawl.webp");
@@ -16,6 +20,10 @@ const lloydMallCrawlImage: ImageSource = require("../../../assets/demo-lloyd-mal
 const jamieXxImage: ImageSource = require("../../../assets/demo-jamie-xx.webp");
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
 const sharpieSmileImage: ImageSource = require("../../../assets/demo-sharpie-smile.webp");
+
+// Demo curator handle used on screen 02's fake URL bar. Chosen to match
+// the Portland-area demo events (Lloyd Center, Pioneer Courthouse Square).
+const DEMO_CURATOR_HANDLE = "soonlist.com/portland";
 
 function makeDemoEvent(
   id: string,
@@ -123,21 +131,35 @@ function getDemoEvents(): EventWithSimilarity[] {
   ];
 }
 
+type Phase = "meet" | "subscribed";
+
 export default function YourListScreen() {
   const pendingFollowUsername = usePendingFollowUsername();
   const { saveStep } = useOnboarding();
   const totalSteps = pendingFollowUsername ? 7 : 6;
   const groupedEvents = useMemo(() => getDemoEvents(), []);
+  const [phase, setPhase] = useState<Phase>("meet");
 
   const handleContinue = () => {
     void hapticLight();
     saveStep("yourList", {}, "/(onboarding)/onboarding/03-notifications");
   };
 
+  const handleSubscribe = () => {
+    void hapticMedium();
+    setPhase("subscribed");
+  };
+
+  const isSubscribed = phase === "subscribed";
+
   return (
     <QuestionContainer
-      question="Meet your Soonlist"
-      subtitle="All in one place. Share with just a link."
+      question={isSubscribed ? "Subscribed ✓" : "Meet a Soonlist"}
+      subtitle={
+        isSubscribed
+          ? "Tap any event to see details."
+          : "Subscribe to follow a curator's events."
+      }
       currentStep={2}
       totalSteps={totalSteps}
     >
@@ -149,18 +171,55 @@ export default function YourListScreen() {
             borderColor: "#FFFFFF",
           }}
         >
-          {/* Share hint */}
+          {/* URL bar */}
           <View className="flex-row items-center justify-between bg-interactive-2 px-4 py-2">
             <Text className="text-sm font-semibold text-interactive-1">
-              soonlist.com/you
+              {DEMO_CURATOR_HANDLE}
             </Text>
-            <SymbolView
-              name="square.and.arrow.up"
-              size={16}
-              tintColor="#5A32FB"
-            />
+            {isSubscribed ? (
+              <View className="rounded-full bg-interactive-1 px-2 py-0.5">
+                <Text className="text-[10px] font-semibold text-white">
+                  ✓ subscribed
+                </Text>
+              </View>
+            ) : (
+              <SymbolView
+                name="square.and.arrow.up"
+                size={16}
+                tintColor="#5A32FB"
+              />
+            )}
           </View>
-          <View style={{ marginLeft: -6, marginRight: 6 }} className="flex-1">
+
+          {/* Demo Subscribe button / confirmation */}
+          <View className="px-4 py-3">
+            {isSubscribed ? (
+              <View className="rounded-full border border-interactive-1/30 bg-white/70 py-2.5">
+                <Text className="text-center text-base font-semibold text-interactive-1">
+                  Subscribed ✓
+                </Text>
+              </View>
+            ) : (
+              <View style={{ position: "relative" }}>
+                <Pressable
+                  onPress={handleSubscribe}
+                  className="rounded-full bg-interactive-1 py-2.5 active:scale-[0.98]"
+                  accessibilityRole="button"
+                  accessibilityLabel="Subscribe"
+                >
+                  <Text className="text-center text-base font-semibold text-white">
+                    + Subscribe
+                  </Text>
+                </Pressable>
+                <SubscribeSticker style={{ top: -54, right: 0 }} />
+              </View>
+            )}
+          </View>
+
+          <View
+            style={{ marginLeft: -6, marginRight: 6, position: "relative" }}
+            className="flex-1"
+          >
             <UserEventsList
               groupedEvents={groupedEvents}
               demoMode={true}
@@ -169,6 +228,9 @@ export default function YourListScreen() {
               onEndReached={() => {}}
               isFetchingNextPage={false}
             />
+            {isSubscribed && (
+              <EventDetailSticker style={{ top: -24, left: 16 }} />
+            )}
           </View>
         </View>
 

--- a/apps/expo/src/components/onboarding-stickers/EventDetailSticker.tsx
+++ b/apps/expo/src/components/onboarding-stickers/EventDetailSticker.tsx
@@ -1,0 +1,24 @@
+import type { StyleProp, ViewStyle } from "react-native";
+import React from "react";
+
+import { Sticker } from "./Sticker";
+
+interface EventDetailStickerProps {
+  style?: StyleProp<ViewStyle>;
+  onDismiss?: () => void;
+}
+
+export function EventDetailSticker({
+  style,
+  onDismiss,
+}: EventDetailStickerProps) {
+  return (
+    <Sticker
+      caption="open it up!"
+      orientation="down-right"
+      style={style}
+      onDismiss={onDismiss}
+      testID="onboarding-sticker-event-detail"
+    />
+  );
+}

--- a/apps/expo/src/components/onboarding-stickers/SaveSticker.tsx
+++ b/apps/expo/src/components/onboarding-stickers/SaveSticker.tsx
@@ -1,0 +1,21 @@
+import type { StyleProp, ViewStyle } from "react-native";
+import React from "react";
+
+import { Sticker } from "./Sticker";
+
+interface SaveStickerProps {
+  style?: StyleProp<ViewStyle>;
+  onDismiss?: () => void;
+}
+
+export function SaveSticker({ style, onDismiss }: SaveStickerProps) {
+  return (
+    <Sticker
+      caption="save it!"
+      orientation="down-right"
+      style={style}
+      onDismiss={onDismiss}
+      testID="onboarding-sticker-save"
+    />
+  );
+}

--- a/apps/expo/src/components/onboarding-stickers/Sticker.tsx
+++ b/apps/expo/src/components/onboarding-stickers/Sticker.tsx
@@ -1,0 +1,167 @@
+import type { StyleProp, ViewStyle } from "react-native";
+import React, { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
+import Svg, { Path } from "react-native-svg";
+
+export type StickerOrientation =
+  | "down-left"
+  | "down-right"
+  | "up-left"
+  | "up-right";
+
+interface StickerProps {
+  caption: string;
+  orientation?: StickerOrientation;
+  style?: StyleProp<ViewStyle>;
+  onDismiss?: () => void;
+  testID?: string;
+}
+
+// Marker-stroke arrow paths for a 60x60 viewBox. Each orientation has
+// a curved body and a matching chevron arrowhead at its terminus.
+const ARROW_PATHS: Record<StickerOrientation, { body: string; head: string }> =
+  {
+    "down-right": {
+      body: "M6,8 Q26,14 36,30 T52,50",
+      head: "M46,44 L54,54 L42,52",
+    },
+    "down-left": {
+      body: "M54,8 Q34,14 24,30 T8,50",
+      head: "M14,44 L6,54 L18,52",
+    },
+    "up-right": {
+      body: "M6,52 Q26,46 36,30 T52,10",
+      head: "M46,16 L54,6 L42,8",
+    },
+    "up-left": {
+      body: "M54,52 Q34,46 24,30 T8,10",
+      head: "M14,16 L6,6 L18,8",
+    },
+  };
+
+const STICKER_COLOR = "#FF4D4D";
+const STICKER_STROKE_WIDTH = 3.5;
+
+export function Sticker({
+  caption,
+  orientation = "down-right",
+  style,
+  onDismiss,
+  testID,
+}: StickerProps) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    onDismiss?.();
+  };
+
+  const { body, head } = ARROW_PATHS[orientation];
+  const isDown = orientation.startsWith("down");
+  const isRight = orientation.endsWith("right");
+  const captionRotation = isRight ? -6 : 6;
+
+  // Caption sits at the arrow's tail (opposite the arrowhead).
+  const captionPos: ViewStyle = {
+    position: "absolute",
+    ...(isDown ? { top: -6 } : { bottom: -6 }),
+    ...(isRight ? { left: 0 } : { right: 0 }),
+  };
+  const arrowPos: ViewStyle = {
+    position: "absolute",
+    ...(isDown ? { bottom: 0 } : { top: 0 }),
+    ...(isRight ? { right: 0 } : { left: 0 }),
+  };
+
+  return (
+    <Animated.View
+      entering={FadeIn.duration(400).delay(250)}
+      exiting={FadeOut.duration(180)}
+      style={[{ position: "absolute" }, style]}
+      pointerEvents="box-none"
+    >
+      <Pressable
+        onPress={handleDismiss}
+        accessibilityRole="button"
+        accessibilityLabel={`${caption}. Onboarding hint. Tap to dismiss.`}
+        accessibilityHint="Dismisses the onboarding hint"
+        hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+        testID={testID}
+      >
+        <View style={{ width: 120, height: 92 }}>
+          <Svg
+            width={60}
+            height={60}
+            viewBox="0 0 60 60"
+            style={arrowPos}
+            pointerEvents="none"
+          >
+            <Path
+              d={body}
+              stroke={STICKER_COLOR}
+              strokeWidth={STICKER_STROKE_WIDTH}
+              strokeLinecap="round"
+              fill="none"
+            />
+            <Path
+              d={head}
+              stroke={STICKER_COLOR}
+              strokeWidth={STICKER_STROKE_WIDTH}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          </Svg>
+          <View
+            style={[
+              captionPos,
+              {
+                flexDirection: "row",
+                alignItems: "center",
+                transform: [{ rotate: `${captionRotation}deg` }],
+              },
+            ]}
+          >
+            <Text
+              style={{
+                fontFamily: "Kalam_700Bold",
+                fontSize: 18,
+                color: STICKER_COLOR,
+                textShadowColor: "rgba(255,255,255,0.6)",
+                textShadowOffset: { width: 0, height: 1 },
+                textShadowRadius: 2,
+              }}
+            >
+              {caption}
+            </Text>
+            <View
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: 8,
+                backgroundColor: STICKER_COLOR,
+                marginLeft: 5,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Text
+                style={{
+                  color: "white",
+                  fontSize: 11,
+                  lineHeight: 13,
+                  fontWeight: "700",
+                }}
+              >
+                ×
+              </Text>
+            </View>
+          </View>
+        </View>
+      </Pressable>
+    </Animated.View>
+  );
+}

--- a/apps/expo/src/components/onboarding-stickers/SubscribeSticker.tsx
+++ b/apps/expo/src/components/onboarding-stickers/SubscribeSticker.tsx
@@ -1,0 +1,21 @@
+import type { StyleProp, ViewStyle } from "react-native";
+import React from "react";
+
+import { Sticker } from "./Sticker";
+
+interface SubscribeStickerProps {
+  style?: StyleProp<ViewStyle>;
+  onDismiss?: () => void;
+}
+
+export function SubscribeSticker({ style, onDismiss }: SubscribeStickerProps) {
+  return (
+    <Sticker
+      caption="start here!"
+      orientation="down-right"
+      style={style}
+      onDismiss={onDismiss}
+      testID="onboarding-sticker-subscribe"
+    />
+  );
+}

--- a/apps/expo/src/components/onboarding-stickers/index.ts
+++ b/apps/expo/src/components/onboarding-stickers/index.ts
@@ -1,0 +1,5 @@
+export { Sticker } from "./Sticker";
+export type { StickerOrientation } from "./Sticker";
+export { SaveSticker } from "./SaveSticker";
+export { SubscribeSticker } from "./SubscribeSticker";
+export { EventDetailSticker } from "./EventDetailSticker";

--- a/docs/brainstorms/2026-04-18-first-run-sticker-tutorial.md
+++ b/docs/brainstorms/2026-04-18-first-run-sticker-tutorial.md
@@ -1,0 +1,150 @@
+# First-run tutorial: hand-drawn sticker arrows
+
+**Date:** 2026-04-18
+**Issue:** [#1010](https://github.com/jaronheard/soonlist-turbo/issues/1010)
+**Parent context:** [#1005](https://github.com/jaronheard/soonlist-turbo/issues/1005) onboarding polish; Granola meeting *Soonlist onboarding flow user experience review* (2026-04-18).
+
+## Intent
+
+Teach first-run users the core loop — **subscribe → save → open** — with three hand-drawn marker-style sticker arrows placed inside the onboarding modal flow (not the real app screens).
+
+Narrow-scoped: three stickers, two onboarding screens, no reusable tooltip framework, no post-onboarding behavior, no journey restructure beyond light edits to the two screens that host the stickers.
+
+## Scope summary
+
+Changes to the existing onboarding flow:
+
+1. `01-try-it.tsx` (the "result" phase) — add a **Save sticker** pointing at the Save heart on the captured demo event.
+2. `02-your-list.tsx` — rename to a "Meet a Soonlist" framing, add a demo **Subscribe** button, add a **phase transition** from *pre-subscribe* → *post-subscribe*, add a **Subscribe sticker** (phase A) and an **Open-it-up sticker** (phase B).
+
+No changes to real app screens (feed, list detail, event detail).
+
+## Visual style
+
+- **Stroke:** bold solid marker, ~3.5pt weight, single clean line (no double-stroke/crayon texture).
+- **Color:** warm accent — red-ish (`#FF4D4D` starting point, to be refined against the `interactive-1` purple background for contrast).
+- **Caption font:** Kalam (or similar hand-drawn sans), weight 700, slight rotation (~−6°), hand-rendered not OS-system.
+- **Arrow + caption layout:** arrow is an inline SVG path with a chunky arrowhead; caption sits alongside at a complementary angle; small × glyph at caption's end signals dismissibility.
+- **Shadow / legibility:** subtle white text-shadow under the caption to keep it legible against the purple onboarding background.
+- **Entrance:** fade-in over ~400ms with a tiny rotate wobble at rest (e.g., ±1° over 3s) — playful, not distracting.
+
+## Behavior model
+
+Because stickers live inside the onboarding modal flow, the cross-session / behavioral-trigger model is not needed. Simplifies to:
+
+- **Trigger:** the sticker is mounted when its parent screen (or phase) is mounted.
+- **Dismiss:** user taps the sticker body or the small × — sticker fades out; local state on the screen tracks "dismissed for this run."
+- **Completion:** the underlying action (tapping Save heart, Subscribe button, event card) also dismisses the sticker. In phase A of screen 02, tapping Subscribe additionally transitions to phase B.
+- **Persistence across sessions:** none needed. Onboarding only runs once (`hasCompletedOnboarding`). If a user re-enters onboarding (e.g., dev reset), stickers re-appear — that's acceptable.
+- **Non-blocking:** Continue button is always usable regardless of sticker state. A user who ignores the sticker and taps Continue proceeds normally.
+
+## Screen-by-screen spec
+
+### Screen 01 `01-try-it.tsx` (phase: `result`)
+
+**Current state:** title "That's it!", single `UserEventListItem` for Lloyd Mall Crawl with `isSaved={false}`, Continue button.
+
+**Change:**
+- Mount a `<SaveSticker />` inside the result phase, positioned relative to the event row so the arrow tip lands near the Save heart (top-right of the card).
+- The existing Save heart remains functional in demo mode (tapping it marks the local demo event as saved and dismisses the sticker).
+
+**Caption:** "save it!"
+
+### Screen 02 `02-your-list.tsx` (reframe + phase-ify)
+
+**Current state:** title "Meet your Soonlist", subtitle "All in one place. Share with just a link.", fake frame showing `soonlist.com/you` URL bar, `UserEventsList` with three demo events, Continue button.
+
+**Changes — framing:**
+- Title: "Meet your Soonlist" → **"Meet a Soonlist"**.
+- Subtitle: to be rewritten to match the new framing (e.g., *"Subscribe to follow a curator's events"*). Exact copy deferred to implementation PR review.
+- URL bar: `soonlist.com/you` → a demo curator handle (e.g., `soonlist.com/portland`). Chosen to match the Portland-area demo events already on screen.
+
+**Changes — layout:**
+- Add a demo **Subscribe** button inside the fake frame, positioned below the URL bar and above the event list, visually consistent with the real `SubscribeButton` on `list/[slug].tsx`. Demo-only — tapping it updates local phase state and does not hit the server. The outer Continue button remains in its current position below the fake frame.
+
+**Changes — phases:**
+Introduce local `phase` state (`'meet'` → `'subscribed'`), mirroring the pattern already used by `01-try-it.tsx`:
+
+- **Phase A (`meet`):**
+  - Subscribe button reads "Subscribe" / "+ Subscribe".
+  - `<SubscribeSticker />` points at the Subscribe button.
+  - URL bar shows no subscribed indicator.
+- **Phase B (`subscribed`):**
+  - Subscribe button reads "Subscribed ✓" (disabled or transitioned into a confirmation row).
+  - URL bar shows a small "subscribed" pill next to the share icon.
+  - Title changes to "Subscribed ✓" (or subtitle changes — exact placement decided during implementation); subtitle updates to *"Tap any event to see details"* or similar.
+  - `<SubscribeSticker />` is unmounted.
+  - `<EventDetailSticker />` mounts on the first event in the list (Lloyd Mall Crawl, maintaining continuity with screen 01).
+
+**Phase transitions:**
+- `'meet'` → `'subscribed'` when the user taps the demo Subscribe button.
+- No transition from `'subscribed'` back to `'meet'`.
+
+**Captions:**
+- Subscribe sticker: "start here!"
+- Open-it-up sticker: "open it up!"
+
+## Component architecture
+
+Per approach **A2** (one primitive + thin wrappers):
+
+```
+apps/expo/src/components/onboarding-stickers/
+├── Sticker.tsx              // primitive: SVG arrow + caption + × + fade/wobble
+├── SaveSticker.tsx          // wrapper: id, caption, orientation, anchor offsets
+├── SubscribeSticker.tsx     // wrapper
+├── EventDetailSticker.tsx   // wrapper
+└── index.ts
+```
+
+**`<Sticker>` props:**
+- `caption: string`
+- `orientation: 'down-left' | 'down-right' | 'up-left' | 'up-right'` — controls arrow path + arrowhead direction + caption side.
+- `offset: { x: number; y: number }` — pixel offset from the parent anchor element.
+- `onDismiss?: () => void` — called on tap-to-dismiss; parent screen uses this to update local dismissed state if desired (for onboarding, dismissal is usually just component-local).
+- Optional visual overrides (color, rotation) deferred unless they become needed.
+
+**Anchoring:** because layouts are static in onboarding, stickers are absolutely-positioned children of known layout containers. No measured refs, no portals. The `<Sticker>` accepts an `anchorSlot` (one of a handful of named positions like `"event-row-save"`, `"subscribe-button-top"`) and the wrapper components compute the appropriate `offset` for the given screen's layout. If future refactors move anchors, the spec's anchor names stay stable; only offsets change.
+
+**Tap-to-dismiss:** the whole sticker (arrow + caption + ×) is wrapped in a `Pressable` that sets a local `dismissed` state and triggers a fade-out animation.
+
+## State & persistence
+
+- **No global store changes.** Sticker visibility is local to each onboarding screen component.
+- **No Convex writes.** Stickers do not sync to the backend.
+- **No AsyncStorage / MMKV.** Cross-session persistence is not required — onboarding itself gates re-entry.
+
+## Acceptance criteria
+
+1. A user going through onboarding for the first time sees, in sequence:
+   - Screen 01 `result`: Save heart with "save it!" sticker. Tapping the heart dismisses the sticker; tapping the sticker (or ×) also dismisses it. Continue always works.
+   - Screen 02 phase A: Subscribe button with "start here!" sticker. Tapping Subscribe transitions to phase B and dismisses the sticker. Tapping the sticker (or ×) dismisses it but does not transition phases. Continue always works.
+   - Screen 02 phase B: Open-it-up sticker on the first event. Tapping the event card dismisses the sticker (no actual navigation — demo only). Tapping the sticker (or ×) dismisses it. Continue always works.
+2. Screen 02's title reads "Meet a Soonlist"; URL bar reads a demo curator handle, not `soonlist.com/you`.
+3. All three stickers use the same visual language (marker stroke, red-ish color, Kalam caption, × glyph) and differ only by orientation / caption / anchor.
+4. Stickers are never shown outside the onboarding flow. Returning users (with `hasCompletedOnboarding = true`) never see them.
+5. Each sticker is positioned **next to** (not over) its target affordance. Taps on the Save heart, Subscribe button, or event card always hit the target, never the sticker. Tapping the sticker's own arrow/caption/× dismisses the sticker without triggering the target's action.
+6. VoiceOver: each sticker exposes its caption as the accessibility label and announces itself as a hint. The ×-icon has an independent "Dismiss" accessibility action. The target affordances retain their own accessibility labels unchanged.
+
+## Out of scope (restated)
+
+- Stickers on real app screens (feed, list detail, event detail).
+- Cross-session persistence / re-appearance based on user behavior.
+- Lottie animations or hand-drawn PNG assets.
+- A reusable coach-mark / tooltip framework.
+- Featured Lists screen changes ([#1009](https://github.com/jaronheard/soonlist-turbo/issues/1009)).
+- Paywall, sign-in, notifications screens.
+
+## Open questions (for implementation plan)
+
+1. **Exact subtitle copy** for screen 02 phase A and phase B — defer to implementation PR review.
+2. **Exact demo curator handle** on the URL bar (e.g., `soonlist.com/portland` vs. something specific) — defer to content decision during implementation.
+3. **Demo Save heart interaction on screen 01** — does tapping it visually mark the event as saved (filled heart) and also dismiss the sticker, or does it only dismiss? Implementation plan should choose; default is "fill the heart + dismiss."
+4. **Accessibility announcement** when a sticker's phase transition occurs (e.g., VoiceOver focus moves to the new sticker after Subscribe) — implementation plan to decide focus management.
+5. **Color contrast** — red-ish (`#FF4D4D`) against the `interactive-1` purple background needs a WCAG check during implementation; may shift to a slightly different warm hue.
+
+## Related
+
+- Granola meeting 2026-04-18 — *Soonlist onboarding flow user experience review*: source of the "Meet a Soonlist" copy shift and the tutorial-element intent.
+- Parent issue [#1005](https://github.com/jaronheard/soonlist-turbo/issues/1005) — onboarding polish.
+- Sibling issue [#1009](https://github.com/jaronheard/soonlist-turbo/issues/1009) — Featured Lists (upstream of this tutorial in the journey).


### PR DESCRIPTION
Closes #1010.

## Summary

Adds three hand-drawn marker-style sticker arrows inside the onboarding flow to teach the core loop (**subscribe → save → open**), per issue #1010 and the 2026-04-18 onboarding UX review.

Full design: [`docs/brainstorms/2026-04-18-first-run-sticker-tutorial.md`](docs/brainstorms/2026-04-18-first-run-sticker-tutorial.md).

## What changed

**Screen 01 `01-try-it.tsx`** (`result` phase): Adds a `SaveSticker` pointing at the Save heart on the captured demo event ("Lloyd Mall Crawl").

**Screen 02 `02-your-list.tsx`** — reframed from "Meet your Soonlist" to "**Meet a Soonlist**":
- URL bar changed from `soonlist.com/you` to `soonlist.com/portland` (demo curator).
- New demo **Subscribe** button (pressable, local-only, does not hit the server).
- New local `phase` state: `meet` → `subscribed`.
- **Phase A (`meet`)**: `SubscribeSticker` points at the Subscribe button. Subtitle: *"Subscribe to follow a curator's events."*
- **Phase B (`subscribed`)**: Subscribe row becomes "Subscribed ✓", URL bar gets a "✓ subscribed" pill, `EventDetailSticker` appears above the first event. Subtitle: *"Tap any event to see details."*
- `Continue` button always works regardless of phase or sticker state.

**New directory `apps/expo/src/components/onboarding-stickers/`:**
- `Sticker.tsx` — primitive: inline `react-native-svg` marker-stroke arrow + Kalam-font caption + small `×` dismiss glyph, fade-in entrance, four orientations (`down-left | down-right | up-left | up-right`).
- `SaveSticker.tsx` — "save it!" wrapper.
- `SubscribeSticker.tsx` — "start here!" wrapper.
- `EventDetailSticker.tsx` — "open it up!" wrapper.
- `index.ts` — barrel export.

## Design decisions from the brainstorm

All three stickers share the same visual language (bold `#FF4D4D` marker stroke ~3.5pt, Kalam 700 Bold caption, small × dismiss). Tapping the sticker body or the × dismisses it; completing the underlying action (tapping Subscribe) also progresses the screen. Stickers live **only** inside the onboarding modal — no cross-session state, no Convex writes, no real-app changes.

Component architecture is approach **A2** from the spec: one shared primitive + three thin wrappers. This is deliberately *not* a reusable tooltip framework — just shared rendering logic for three specific stickers.

## Assumptions I made in your absence

User asked me to push through to PR without per-decision review. Open questions from the spec resolved as:

1. **Subtitle copy (screen 02)**: Phase A = *"Subscribe to follow a curator's events."*; Phase B = *"Tap any event to see details."*
2. **Demo curator handle**: `soonlist.com/portland` (matches the Portland-area demo events already on screen).
3. **Demo Save heart on screen 01**: Kept existing `useEventSaveActions` demoMode behavior (shows "Demo mode: action disabled" toast on tap). Did **not** expand scope to intercept that for a visual fill. User can dismiss sticker by tapping the sticker itself or by hitting Continue.
4. **Accessibility**: each sticker exposes its caption via `accessibilityLabel` and has `accessibilityHint: "Dismisses the onboarding hint"`. No programmatic VoiceOver focus management on phase transitions.
5. **Color**: `#FF4D4D` against `interactive-1` purple; quick eye-check only — WCAG contrast not verified.
6. **Skipped**: idle "wobble" animation mentioned in spec (kept just fade-in entrance for simplicity; can add in a follow-up).

## Worth reviewer attention

- **Sticker anchor offsets** (`top`, `right`, `left` values in 01/02) are best-guess positions — I couldn't visually tune them against the simulator. They may need a few-pixel nudges to land the arrowhead precisely on each target.
- **Tap through**: the sticker's Pressable covers a 120×92 container; taps inside that area dismiss the sticker rather than reaching underlying UI. Target affordances (Save heart, Subscribe button, event card) are positioned to not overlap the sticker body, but edge cases on smaller screens/fonts are worth a look.
- **Demo toast on Save tap** (screen 01 result): pre-existing behavior, but the sticker's presence makes it more likely a user actually taps the heart, potentially triggering "Demo mode: action disabled." May want to suppress this toast in onboarding demo mode in a follow-up.

## Test plan

- [ ] Fresh install → onboarding screen 01: after capture animation, SaveSticker appears above the event row, "save it!" caption visible, × tappable.
- [ ] Tap SaveSticker → fades out.
- [ ] Tap × inside SaveSticker → fades out.
- [ ] Continue without interacting with sticker → advances to screen 02 cleanly.
- [ ] Screen 02 shows title "Meet a Soonlist", subtitle about subscribing, URL `soonlist.com/portland`, a "+ Subscribe" button, SubscribeSticker above it.
- [ ] Tap Subscribe → phase transitions: title "Subscribed ✓", subtitle about tapping events, "✓ subscribed" pill in URL bar, "Subscribed ✓" replaces the button, EventDetailSticker appears above the first event.
- [ ] Tap sticker/× in either phase → fades out.
- [ ] Continue button works in both phases.
- [ ] Returning user (`hasCompletedOnboarding = true`) doesn't see any stickers anywhere.
- [ ] VoiceOver reads each sticker caption as a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hand‑drawn “sticker” arrows to the Expo onboarding to teach the core loop (subscribe → save → open). Implements #1010 by guiding users on screens 01 and 02 with lightweight, dismissible hints.

- **New Features**
  - Screen 01: Added `SaveSticker` pointing at the demo event’s Save heart.
  - Screen 02: Reframed to “Meet a Soonlist”; URL shows `soonlist.com/portland`; added demo “+ Subscribe” button with local `phase` state (`meet` → `subscribed`).
  - Phase A: `SubscribeSticker` points to the Subscribe button; subtitle explains subscribing.
  - Phase B: Shows “Subscribed ✓”, a “✓ subscribed” pill in the URL bar, and an `EventDetailSticker` above the first event; subtitle prompts opening an event.
  - New `onboarding-stickers/` components: `Sticker` primitive (SVG arrow, Kalam caption, × dismiss, 4 orientations) plus thin wrappers (`SaveSticker`, `SubscribeSticker`, `EventDetailSticker`).
  - Stickers live only in onboarding, are dismissible, do not block Continue, and have accessibility labels/hints. No backend or cross‑session state.

<sup>Written for commit c5dc33ebefce0c3e740185769639f9d6478148df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three hand-drawn marker-style onboarding stickers (`SaveSticker`, `SubscribeSticker`, `EventDetailSticker`) built on a shared `Sticker` primitive, and reframes screen 02 from a static display to a two-phase interactive demo (meet → subscribed). The `Kalam_700Bold` font and SVG arrow rendering are well-integrated with existing infrastructure.

- **P1 — `EventDetailSticker` blocks its own target**: positioned at `top: -24` inside the events container, the 92 px tall `Pressable` overlaps the first event card by ~68 px. Tapping the first event in that zone dismisses the sticker instead of opening event detail, directly contradicting acceptance criterion #5.
- **P2 — `SubscribeSticker` orientation**: all three wrappers hard-code `orientation=\"down-right\"`; the `SubscribeSticker` at `{ top: -54, right: 0 }` would point more naturally with `down-left` so the arrow sweeps toward the button center rather than its far-right edge.

<h3>Confidence Score: 4/5</h3>

One P1 issue where the EventDetailSticker's Pressable intercepts taps on the first event card before the user can act on the sticker's own instruction — needs a position fix before merging.

The sticker architecture, animation, font, and accessibility wiring are solid. The only blocking concern is the EventDetailSticker anchor math: at top:-24 the 92px Pressable covers ~68px of the first event card, defeating the "tap any event" instructional goal. All other findings are P2 visual polish that can be iterated in a follow-up.

apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx — EventDetailSticker anchor offset needs adjustment to clear the first event card

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/onboarding-stickers/Sticker.tsx | Core sticker primitive: inline SVG marker arrow + Kalam caption + dismiss Pressable with fade-in/out Reanimated animations; font already loaded in _layout.tsx, pointer-events correctly set to box-none on outer Animated.View |
| apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx | Screen reframed with phase state (meet → subscribed); EventDetailSticker positioned at top:-24 overlaps first event card by ~68px, blocking the tap target the sticker is instructing users to tap |
| apps/expo/src/app/(onboarding)/onboarding/01-try-it.tsx | SaveSticker added in result phase above the demo event row at top:-80; parent View doesn't clip overflow so positioning should be fine |
| apps/expo/src/components/onboarding-stickers/SubscribeSticker.tsx | Thin wrapper hardcodes orientation="down-right"; arrow points to the Subscribe button's far-right edge rather than its center — down-left would be more visually accurate |
| apps/expo/src/components/onboarding-stickers/EventDetailSticker.tsx | Thin wrapper for event-detail sticker; orientation is down-right which may need adjustment based on final anchor position tuning |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Screen 01: Capture any event] -->|phase=screenshot| B[SampleScreenshot]
    B -->|Tap Capture| C[phase=parsing\nParsingAnimation]
    C -->|1.5s timeout| D[phase=result\nUserEventListItem]
    D --- SA[SaveSticker\ntop:-80 right:-4]
    D -->|Continue| E

    E[Screen 02: Meet a Soonlist\nphase=meet] --- SB[SubscribeSticker\ntop:-54 right:0]
    E -->|Tap Subscribe| F[phase=subscribed\nSubscribed ✓]
    F --- SD[EventDetailSticker\ntop:-24 left:16]
    E -->|Continue| G[Screen 03: Notifications]
    F -->|Continue| G

    SA -->|Tap sticker or ×| SA2[dismissed=true\nFadeOut]
    SB -->|Tap sticker or ×| SB2[dismissed=true\nFadeOut]
    SD -->|Tap sticker or ×| SD2[dismissed=true\nFadeOut]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
Line: 231-233

Comment:
**`EventDetailSticker` overlaps the first event card it instructs users to tap**

The sticker is positioned at `top: -24` inside the events list container, but the `Sticker` component's inner `Pressable` spans a fixed 120×92 px area. With `top: -24`, the bottom of the sticker lands 68 px *inside* the container — covering the top ~68 px of the first event card. The outer `Animated.View` has `pointerEvents="box-none"`, but the inner `Pressable` still captures all taps in that 120×92 zone, so tapping the top portion of the first event card dismisses the sticker instead of navigating to event detail. This directly contradicts acceptance criterion #5 ("Taps on the event card always hit the target, never the sticker"). Moving the sticker higher (e.g., `top: -96`) so it clears the event row would fix the issue.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/onboarding-stickers/SubscribeSticker.tsx
Line: 11-21

Comment:
**`SubscribeSticker` orientation doesn't match its anchor position**

All three sticker wrappers hard-code `orientation="down-right"`, which places the arrowhead at the sticker container's bottom-right corner. `SubscribeSticker` is mounted at `{ top: -54, right: 0 }` — meaning its right edge aligns with the right edge of the Subscribe button parent. With `down-right`, the arrow curves from the top-left of the sticker and terminates at the button's far-right edge, pointing away from the button center. A `down-left` orientation would start from the top-right and sweep toward the button's body, producing a more intuitive "start here!" pointer. Worth visual-tuning against the simulator before shipping.

```suggestion
  return (
    <Sticker
      caption="start here!"
      orientation="down-left"
      style={style}
      onDismiss={onDismiss}
      testID="onboarding-sticker-subscribe"
    />
  );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): first-run sticker tutorial o..."](https://github.com/jaronheard/soonlist-turbo/commit/c5dc33ebefce0c3e740185769639f9d6478148df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28891649)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->