### PR TITLE
feat(expo): list-primary attribution row on My Scene (#1006)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ dist/
 
 # superpowers (local-only plans/specs)
 docs/superpowers/
+.superpowers/
 
 # claude code
 .claude/worktrees/

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -588,6 +588,7 @@ function FollowingFeedContent() {
         savedEventIds={savedEventIds}
         source="following"
         HeaderComponent={HeaderComponent}
+        attributionVariant="list-primary"
       />
     </>
   );

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -1,0 +1,364 @@
+import React, { useState } from "react";
+import { Pressable, Text, View } from "react-native";
+import { Image as ExpoImage } from "expo-image";
+import { router } from "expo-router";
+
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
+
+import { List, User } from "~/components/icons";
+import { SavedByModal } from "~/components/SavedByModal";
+import { UserProfileFlair } from "~/components/UserProfileFlair";
+
+interface UserForDisplay {
+  id: string;
+  username: string;
+  displayName?: string | null;
+  userImage?: string | null;
+}
+
+export type EventAttributionVariant = "list-primary" | "people-primary";
+
+interface EventAttributionRowProps {
+  creator: UserForDisplay;
+  savers: UserForDisplay[];
+  iconSize: number;
+  currentUserId?: string;
+  sourceListName?: string;
+  sourceListSlug?: string;
+  additionalSourceCount?: number;
+  lists?: Doc<"lists">[];
+  variant?: EventAttributionVariant;
+}
+
+const HIT_SLOP = { top: 8, bottom: 8, left: 4, right: 4 } as const;
+
+function combineUsers(creator: UserForDisplay, savers: UserForDisplay[]) {
+  const out: UserForDisplay[] = [creator];
+  for (const saver of savers) {
+    if (!out.some((u) => u.id === saver.id)) {
+      out.push(saver);
+    }
+  }
+  return out;
+}
+
+function navigateToUser(user: UserForDisplay, currentUserId?: string) {
+  if (currentUserId && user.id === currentUserId) {
+    router.push("/settings/account");
+  } else {
+    router.push(`/${user.username}`);
+  }
+}
+
+function Avatar({
+  user,
+  size,
+}: {
+  user: UserForDisplay;
+  size: number;
+}) {
+  return (
+    <UserProfileFlair username={user.username} size="xs">
+      {user.userImage ? (
+        <ExpoImage
+          source={{ uri: user.userImage }}
+          style={{ width: size, height: size, borderRadius: 9999 }}
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          recyclingKey={user.id}
+        />
+      ) : (
+        <View
+          style={{
+            width: size,
+            height: size,
+            borderRadius: 9999,
+            backgroundColor: "#E0D9FF",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <User size={size * 0.6} color="#627496" />
+        </View>
+      )}
+    </UserProfileFlair>
+  );
+}
+
+function ListChip({ name, slug }: { name?: string; slug?: string }) {
+  const content = (
+    <>
+      <List size={13} color="#5A32FB" />
+      {name ? (
+        <Text
+          className={
+            slug
+              ? "text-xs font-semibold text-interactive-1"
+              : "text-xs text-neutral-2"
+          }
+        >
+          {name}
+        </Text>
+      ) : null}
+    </>
+  );
+  if (slug) {
+    return (
+      <Pressable
+        onPress={() => router.push(`/list/${slug}`)}
+        hitSlop={HIT_SLOP}
+        accessibilityLabel={name ? `Open list ${name}` : "Open list"}
+        className="flex-row items-center gap-1"
+      >
+        {content}
+      </Pressable>
+    );
+  }
+  return <View className="flex-row items-center gap-1">{content}</View>;
+}
+
+function OverflowPill({
+  count,
+  onPress,
+  className,
+}: {
+  count: number;
+  onPress?: () => void;
+  className?: string;
+}) {
+  if (count <= 0) return null;
+  const pillClass = `rounded-full bg-interactive-3 px-1.5 py-0.5${
+    className ? ` ${className}` : ""
+  }`;
+  const text = (
+    <Text className="text-xs font-medium text-interactive-1">+{count}</Text>
+  );
+  if (!onPress) {
+    return <View className={pillClass}>{text}</View>;
+  }
+  return (
+    <Pressable className={pillClass} onPress={onPress} hitSlop={HIT_SLOP}>
+      {text}
+    </Pressable>
+  );
+}
+
+export function EventAttributionRow({
+  creator,
+  savers,
+  iconSize,
+  currentUserId,
+  sourceListName,
+  sourceListSlug,
+  additionalSourceCount,
+  lists,
+  variant = "people-primary",
+}: EventAttributionRowProps) {
+  if (variant === "list-primary" && sourceListSlug) {
+    return (
+      <ListPrimaryRow
+        creator={creator}
+        savers={savers}
+        iconSize={iconSize}
+        currentUserId={currentUserId}
+        sourceListName={sourceListName}
+        sourceListSlug={sourceListSlug}
+        additionalSourceCount={additionalSourceCount}
+        lists={lists}
+      />
+    );
+  }
+
+  // list-primary with no sourceListSlug degrades to people-primary layout,
+  // dropping the "via" connector since there's no list to attribute to.
+  return (
+    <PeoplePrimaryRow
+      creator={creator}
+      savers={savers}
+      iconSize={iconSize}
+      currentUserId={currentUserId}
+      sourceListName={sourceListName}
+      sourceListSlug={sourceListSlug}
+      additionalSourceCount={additionalSourceCount}
+      lists={lists}
+      showListConnector={variant === "people-primary"}
+    />
+  );
+}
+
+function ListPrimaryRow({
+  creator,
+  savers,
+  iconSize,
+  currentUserId,
+  sourceListName,
+  sourceListSlug,
+  additionalSourceCount,
+  lists,
+}: {
+  creator: UserForDisplay;
+  savers: UserForDisplay[];
+  iconSize: number;
+  currentUserId?: string;
+  sourceListName?: string;
+  sourceListSlug: string;
+  additionalSourceCount?: number;
+  lists?: Doc<"lists">[];
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const isOwnEvent = currentUserId === creator.id;
+  const allUsers = combineUsers(creator, savers);
+  const remainingListsCount = additionalSourceCount ?? 0;
+  const avatarSize = iconSize * 0.9;
+  const openModal = () => setShowModal(true);
+
+  const maxStack = 3;
+  const stackUsers = allUsers.slice(0, maxStack);
+  const extraCount = Math.max(allUsers.length - maxStack, 0);
+
+  const ownBadge = (
+    <Pressable
+      onPress={() => navigateToUser(creator, currentUserId)}
+      hitSlop={HIT_SLOP}
+      className="flex-row items-center gap-1"
+    >
+      <Avatar user={creator} size={avatarSize} />
+      <Text className="text-xs text-neutral-2">You</Text>
+    </Pressable>
+  );
+
+  const stack =
+    stackUsers.length > 0 ? (
+      <Pressable
+        onPress={openModal}
+        hitSlop={HIT_SLOP}
+        accessibilityLabel="View everyone who saved this"
+        className="flex-row items-center"
+      >
+        {stackUsers.map((user, index) => (
+          <View key={user.id} style={{ marginLeft: index === 0 ? 0 : -6 }}>
+            <Avatar user={user} size={avatarSize} />
+          </View>
+        ))}
+        <OverflowPill count={extraCount} className="ml-1" />
+      </Pressable>
+    ) : null;
+
+  return (
+    <>
+      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
+        {isOwnEvent ? (
+          <>
+            {ownBadge}
+            <Text className="text-xs text-neutral-2">·</Text>
+          </>
+        ) : null}
+        <ListChip name={sourceListName} slug={sourceListSlug} />
+        <OverflowPill count={remainingListsCount} onPress={openModal} />
+        {!isOwnEvent && stack ? (
+          <>
+            <Text className="text-xs text-neutral-2">·</Text>
+            {stack}
+          </>
+        ) : null}
+      </View>
+      <SavedByModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        creator={creator}
+        savers={savers}
+        lists={lists ?? []}
+        currentUserId={currentUserId}
+      />
+    </>
+  );
+}
+
+function PeoplePrimaryRow({
+  creator,
+  savers,
+  iconSize,
+  currentUserId,
+  sourceListName,
+  sourceListSlug,
+  additionalSourceCount,
+  lists,
+  showListConnector,
+}: {
+  creator: UserForDisplay;
+  savers: UserForDisplay[];
+  iconSize: number;
+  currentUserId?: string;
+  sourceListName?: string;
+  sourceListSlug?: string;
+  additionalSourceCount?: number;
+  lists?: Doc<"lists">[];
+  showListConnector: boolean;
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const isOwnEvent = currentUserId === creator.id;
+  const allUsers = combineUsers(creator, savers);
+  const displayUsers = allUsers.slice(0, 2);
+  const remainingUsersCount = allUsers.length - displayUsers.length;
+  const remainingListsCount = additionalSourceCount ?? 0;
+  const avatarSize = iconSize * 0.9;
+  const openModal = () => setShowModal(true);
+
+  const listConnector = isOwnEvent ? "· Shared to" : "via";
+  const hasAnyListInfo =
+    !!sourceListSlug || !!sourceListName || remainingListsCount > 0;
+
+  return (
+    <>
+      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
+        {isOwnEvent ? (
+          <Pressable
+            onPress={() => navigateToUser(creator, currentUserId)}
+            hitSlop={HIT_SLOP}
+            className="flex-row items-center gap-1"
+          >
+            <Avatar user={creator} size={avatarSize} />
+            <Text className="text-xs text-neutral-2">You</Text>
+          </Pressable>
+        ) : (
+          displayUsers.map((user, index) => (
+            <Pressable
+              key={user.id}
+              onPress={() => navigateToUser(user, currentUserId)}
+              hitSlop={HIT_SLOP}
+              className="flex-row items-center gap-1"
+            >
+              <Avatar user={user} size={avatarSize} />
+              <Text className="text-xs text-neutral-2">
+                {user.displayName || user.username}
+                {index < displayUsers.length - 1 || remainingUsersCount > 0
+                  ? ","
+                  : ""}
+              </Text>
+            </Pressable>
+          ))
+        )}
+        {!isOwnEvent && remainingUsersCount > 0 && (
+          <OverflowPill count={remainingUsersCount} onPress={openModal} />
+        )}
+        {hasAnyListInfo && (
+          <>
+            {showListConnector ? (
+              <Text className="text-xs text-neutral-2">{listConnector}</Text>
+            ) : null}
+            <ListChip name={sourceListName} slug={sourceListSlug} />
+            <OverflowPill count={remainingListsCount} onPress={openModal} />
+          </>
+        )}
+      </View>
+      <SavedByModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        creator={creator}
+        savers={savers}
+        lists={lists ?? []}
+        currentUserId={currentUserId}
+      />
+    </>
+  );
+}

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -50,13 +50,7 @@ function navigateToUser(user: UserForDisplay, currentUserId?: string) {
   }
 }
 
-function Avatar({
-  user,
-  size,
-}: {
-  user: UserForDisplay;
-  size: number;
-}) {
+function Avatar({ user, size }: { user: UserForDisplay; size: number }) {
   return (
     <UserProfileFlair username={user.username} size="xs">
       {user.userImage ? (
@@ -213,13 +207,19 @@ function ListPrimaryRow({
   const openModal = () => setShowModal(true);
 
   const maxStack = 3;
-  const stackUsers = allUsers.slice(0, maxStack);
-  const extraCount = Math.max(allUsers.length - maxStack, 0);
+  // Own-event: "You" is already shown, so the stack surfaces other savers
+  // only. Otherwise the stack combines creator + savers.
+  const stackCandidates = isOwnEvent
+    ? savers.filter((s) => s.id !== creator.id)
+    : allUsers;
+  const stackUsers = stackCandidates.slice(0, maxStack);
+  const extraCount = Math.max(stackCandidates.length - maxStack, 0);
 
   const ownBadge = (
     <Pressable
       onPress={() => navigateToUser(creator, currentUserId)}
       hitSlop={HIT_SLOP}
+      accessibilityLabel="Go to your profile"
       className="flex-row items-center gap-1"
     >
       <Avatar user={creator} size={avatarSize} />
@@ -255,7 +255,7 @@ function ListPrimaryRow({
         ) : null}
         <ListChip name={sourceListName} slug={sourceListSlug} />
         <OverflowPill count={remainingListsCount} onPress={openModal} />
-        {!isOwnEvent && stack ? (
+        {stack ? (
           <>
             <Text className="text-xs text-neutral-2">·</Text>
             {stack}

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -22,7 +22,9 @@ import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { getTimezoneAbbreviation } from "@soonlist/cal";
 
+import type { EventAttributionVariant } from "~/components/EventAttributionRow";
 import type { EventWithSimilarity } from "~/utils/similarEvents";
+import { EventAttributionRow } from "~/components/EventAttributionRow";
 import {
   CalendarPlus,
   Copy,
@@ -30,7 +32,6 @@ import {
   MoreVertical,
   PenSquare,
   ShareIcon,
-  User,
 } from "~/components/icons";
 import { SavedByModal } from "~/components/SavedByModal";
 import { useAddEventFlow } from "~/hooks/useAddEventFlow";
@@ -49,7 +50,6 @@ import { collapseSimilarEvents } from "~/utils/similarEvents";
 import { EventMenu } from "./EventMenu";
 import { EventStats } from "./EventStats";
 import SaveButton from "./SaveButton";
-import { UserProfileFlair } from "./UserProfileFlair";
 
 type ShowCreatorOption = "always" | "otherUsers" | "never" | "savedFromOthers";
 
@@ -63,201 +63,6 @@ interface EnrichedEventFollow {
     displayName?: string | null;
     userImage?: string | null;
   } | null;
-}
-
-// Type for user display in stacked avatars
-interface UserForDisplay {
-  id: string;
-  username: string;
-  displayName?: string | null;
-  userImage?: string | null;
-}
-
-// Inline avatars component for showing multiple users who saved an event
-function EventSaversRow({
-  creator,
-  savers,
-  iconSize,
-  eventId,
-  currentUserId,
-  sourceListName,
-  sourceListSlug,
-  additionalSourceCount,
-  lists,
-}: {
-  creator: UserForDisplay;
-  savers: UserForDisplay[];
-  iconSize: number;
-  eventId: string;
-  currentUserId?: string;
-  sourceListName?: string;
-  sourceListSlug?: string;
-  additionalSourceCount?: number;
-  lists?: Doc<"lists">[];
-}) {
-  const [showModal, setShowModal] = useState(false);
-  const isOwnEvent = currentUserId === creator.id;
-
-  // Combine creator with savers, deduplicate by id
-  const allUsers: UserForDisplay[] = [creator];
-  for (const saver of savers) {
-    if (!allUsers.some((u) => u.id === saver.id)) {
-      allUsers.push(saver);
-    }
-  }
-
-  const displayUsers = allUsers.slice(0, 2);
-  const remainingUsersCount = allUsers.length - displayUsers.length;
-  const remainingListsCount = additionalSourceCount ?? 0;
-
-  const handleUserPress = (user: UserForDisplay) => {
-    if (currentUserId && user.id === currentUserId) {
-      router.push("/settings/account");
-    } else {
-      router.push(`/${user.username}`);
-    }
-  };
-
-  const handleListPress = () => {
-    if (sourceListSlug) {
-      router.push(`/list/${sourceListSlug}`);
-    }
-  };
-
-  const avatarSize = iconSize * 0.9;
-
-  const renderAvatar = (user: UserForDisplay, recyclingKey: string) => (
-    <UserProfileFlair username={user.username} size="xs">
-      {user.userImage ? (
-        <ExpoImage
-          source={{ uri: user.userImage }}
-          style={{
-            width: avatarSize,
-            height: avatarSize,
-            borderRadius: 9999,
-          }}
-          contentFit="cover"
-          cachePolicy="disk"
-          recyclingKey={recyclingKey}
-        />
-      ) : (
-        <View
-          style={{
-            width: avatarSize,
-            height: avatarSize,
-            borderRadius: 9999,
-            backgroundColor: "#E0D9FF",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <User size={avatarSize * 0.6} color="#627496" />
-        </View>
-      )}
-    </UserProfileFlair>
-  );
-
-  const listConnector = isOwnEvent ? "· Shared to" : "via";
-  const hasAnyListInfo =
-    !!sourceListSlug || !!sourceListName || remainingListsCount > 0;
-
-  return (
-    <>
-      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
-        {isOwnEvent ? (
-          <Pressable
-            onPress={() => handleUserPress(creator)}
-            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-            className="flex-row items-center gap-1"
-          >
-            {renderAvatar(creator, `${eventId}-creator-inline`)}
-            <Text className="text-xs text-neutral-2">You</Text>
-          </Pressable>
-        ) : (
-          displayUsers.map((user, index) => (
-            <Pressable
-              key={user.id}
-              onPress={() => handleUserPress(user)}
-              hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-              className="flex-row items-center gap-1"
-            >
-              {renderAvatar(user, `${eventId}-saver-inline-${user.id}`)}
-              <Text className="text-xs text-neutral-2">
-                {user.displayName || user.username}
-                {index < displayUsers.length - 1 || remainingUsersCount > 0
-                  ? ","
-                  : ""}
-              </Text>
-            </Pressable>
-          ))
-        )}
-        {!isOwnEvent && remainingUsersCount > 0 && (
-          <Pressable
-            onPress={() => setShowModal(true)}
-            hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-          >
-            <View className="rounded-full bg-interactive-3 px-1.5 py-0.5">
-              <Text className="text-xs font-medium text-interactive-1">
-                +{remainingUsersCount}
-              </Text>
-            </View>
-          </Pressable>
-        )}
-        {hasAnyListInfo && (
-          <>
-            <Text className="text-xs text-neutral-2">{listConnector}</Text>
-            {sourceListSlug ? (
-              <Pressable
-                onPress={handleListPress}
-                hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-                accessibilityLabel={
-                  sourceListName ? `Open list ${sourceListName}` : "Open list"
-                }
-                className="flex-row items-center gap-1"
-              >
-                <List size={13} color="#5A32FB" />
-                {sourceListName ? (
-                  <Text className="text-xs font-semibold text-interactive-1">
-                    {sourceListName}
-                  </Text>
-                ) : null}
-              </Pressable>
-            ) : (
-              <View className="flex-row items-center gap-1">
-                <List size={13} color="#5A32FB" />
-                {sourceListName ? (
-                  <Text className="text-xs text-neutral-2">
-                    {sourceListName}
-                  </Text>
-                ) : null}
-              </View>
-            )}
-            {remainingListsCount > 0 && (
-              <Pressable
-                onPress={() => setShowModal(true)}
-                hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-              >
-                <View className="rounded-full bg-interactive-3 px-1.5 py-0.5">
-                  <Text className="text-xs font-medium text-interactive-1">
-                    +{remainingListsCount}
-                  </Text>
-                </View>
-              </Pressable>
-            )}
-          </>
-        )}
-      </View>
-
-      <SavedByModal
-        visible={showModal}
-        onClose={() => setShowModal(false)}
-        creator={creator}
-        savers={savers}
-        lists={lists ?? []}
-        currentUserId={currentUserId}
-      />
-    </>
-  );
 }
 
 // Define the type for the stats data based on the expected query output
@@ -284,6 +89,7 @@ interface UserEventListItemProps {
   sourceListName?: string;
   sourceListSlug?: string;
   additionalSourceCount?: number;
+  attributionVariant?: EventAttributionVariant;
 }
 
 export function UserEventListItem(props: UserEventListItemProps) {
@@ -302,6 +108,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
     sourceListName,
     sourceListSlug,
     additionalSourceCount,
+    attributionVariant,
   } = props;
   const { fontScale } = useWindowDimensions();
   const { handleAddToCal, handleShare } = useEventActions({
@@ -676,7 +483,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
             </View>
           </View>
           {shouldShowCreator ? (
-            <EventSaversRow
+            <EventAttributionRow
               creator={{
                 id: eventUser.id,
                 username: eventUser.username,
@@ -700,12 +507,12 @@ export function UserEventListItem(props: UserEventListItemProps) {
                   })) ?? []
               }
               iconSize={iconSize}
-              eventId={event.id}
               currentUserId={currentUser?.id}
               sourceListName={sourceListName}
               sourceListSlug={sourceListSlug}
               additionalSourceCount={additionalSourceCount}
               lists={(event as { lists?: Doc<"lists">[] }).lists}
+              variant={attributionVariant}
             />
           ) : sourceListSlug ||
             sourceListName ||
@@ -1106,6 +913,7 @@ interface UserEventsListProps {
   HeaderComponent?: React.ComponentType<Record<string, never>>;
   EmptyStateComponent?: React.ComponentType<Record<string, never>>;
   source?: string;
+  attributionVariant?: EventAttributionVariant;
 }
 
 export default function UserEventsList(props: UserEventsListProps) {
@@ -1126,6 +934,7 @@ export default function UserEventsList(props: UserEventsListProps) {
     HeaderComponent,
     EmptyStateComponent,
     source,
+    attributionVariant,
   } = props;
   const { user } = useUser();
   // Use pre-grouped events if provided, otherwise collapse client-side
@@ -1266,6 +1075,7 @@ export default function UserEventsList(props: UserEventsListProps) {
             sourceListName={sourceListName}
             sourceListSlug={sourceListSlug}
             additionalSourceCount={additionalSourceCount}
+            attributionVariant={attributionVariant}
           />
         );
       }}


### PR DESCRIPTION
## Summary

Closes #1006. Reduces cognitive load on the **My Scene** (Following) tab by switching its attribution row to **list-primary**: the source list leads, with an overlapping avatar stack as the social signal (no names, no commas). **My Soon List keeps its people-primary treatment** — different contexts, different priority.

The card body (image, date, title, location, actions) is unchanged.

## What changed

- New `apps/expo/src/components/EventAttributionRow.tsx` — extracts the old inline `EventSaversRow` from `UserEventsList.tsx` and adds a `variant: "list-primary" | "people-primary"` prop (defaults to `people-primary` so no existing caller changes behavior).
- `apps/expo/src/app/(tabs)/following/index.tsx` passes `attributionVariant="list-primary"`.
- `apps/expo/src/components/UserEventsList.tsx` loses ~200 lines of inline component; threads the new prop through.

### list-primary layout (My Scene)

```
📋 listName  [+M list pill] · 🟣🟡🟢 [+N saver pill]
```

- Tap the list name/icon → `/list/{slug}`
- Tap any avatar or the `+N` saver pill → `SavedByModal`
- The `+M` list pill (multi-list) → `SavedByModal`
- Own-event edge case (viewer is creator): `You · 📋 listName [+M]`
- No `sourceListSlug` fallback: renders the people-primary row minus the "via" connector. No hard dependency on #974.

### people-primary layout (everywhere else — unchanged)

All other `UserEventsList` call sites (My Soon List feed, list pages, user profile, batch, discover, onboarding) inherit the default and render exactly as today.

## Why diverge from the issue's "same treatment" line?

The original issue asked for consistent treatment across both feeds. I pushed back during brainstorming and the decision was to deliberately diverge: **My Scene = browsing others' events (list is the discovery signal); My Soon List = events you already chose (who else saved is the interesting signal).** Same reasoning worth the divergence.

## Decisions captured from brainstorm

- **Density:** Card body stays as-is; cut is the bottom row only (rejected more aggressive density options).
- **Attribution treatment:** list + avatar stack (no names) for My Scene; full avatars + names unchanged for My Soon List.
- **Tap targets:** keep split (list text → list page; avatars → modal) rather than collapsing to one target.
- **No-list fallback:** degrade to people-primary layout without "via" — lets us ship independently of #974.
- **#974 coupling:** ship independently. Fallback makes this safe.

## Simplify pass applied

After the initial build, ran a three-agent review (reuse / quality / efficiency) and applied in-file cleanups:

- Extracted `Avatar`, `ListChip`, `OverflowPill` helpers — killed 8+ duplicated JSX blocks.
- Extracted `combineUsers` + `navigateToUser` utilities in-file.
- Split into `ListPrimaryRow` + `PeoplePrimaryRow` so each owns its own `useState`/handlers rather than drilling props through.
- `cachePolicy` → `memory-disk`, `recyclingKey` → `user.id` so the same avatar can share its decoded bitmap across cards.
- Deleted refactor-narration comments.

**Skipped** (unrelated or would regress UX): cross-file `UserAvatar` extraction that would touch `SavedByModal` and 4 other files (flagged as a follow-up); gating `SavedByModal` on `{showModal && ...}` (breaks its `animationType="slide"` dismiss animation); `#5A32FB` → theme constant (pre-existing pattern across ~15 files).

## Test plan

All manual on iOS simulator. **Metro already running at http://localhost:8124**; reload the app.

### My Scene — the changed surface
- [ ] Single saver + single list → `📋 list · 🟣`
- [ ] 4+ savers + single list → `📋 list · 🟣🟡🟢 +N`
- [ ] Savers across multiple lists → `📋 list +M · 🟣🟡🟢`
- [ ] Tap list name/icon → navigates to list page
- [ ] Tap any avatar or `+N` pill → opens saved-by modal
- [ ] Tap `+M` list pill → opens saved-by modal
- [ ] Card body (image, date, title, location, Save/Share/More) visually identical to `main`
- [ ] Own event in My Scene (if encountered): `You · 📋 list`

### My Soon List — regression
- [ ] Own captures: bottom row blank (unchanged)
- [ ] Events saved from other users: `{avatar} {name} via 📋 {list}` exactly as on `main`
- [ ] Tap avatar → user profile (unchanged)
- [ ] Tap list → list page (unchanged)

### Other surfaces using `UserEventsList` — should be unchanged
- [ ] Discover tab
- [ ] List page (`/list/{slug}`)
- [ ] User profile (`/{username}`)
- [ ] Batch page
- [ ] Onboarding try-it / your-list screens

### Accessibility
- [ ] VoiceOver on a My Scene row announces two distinct targets ("Open list X", "View everyone who saved this")

## Related

- #1006 (this)
- #974 — data-level fix for missing `sourceListId`. Decoupled from this PR; the no-list fallback degrades gracefully for any remaining bad data.
- Follow-up spawned: shared `UserAvatar` component to unify avatar rendering across `EventAttributionRow`, `SavedByModal`, and `event/[id]/index.tsx`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Following (My Scene) feed to a list‑primary attribution row that highlights the source list with an avatar stack, reducing visual noise. Adds a reusable `EventAttributionRow` with variants; all other feeds keep the current people‑primary layout.

- **New Features**
  - `list-primary` variant: list name/icon first; overlapping avatar stack as the social signal; `+M`/`+N` pills open the saved‑by modal.
  - Fallback when no `sourceListSlug`: render people‑primary without the “via” connector.
  - Following passes `attributionVariant="list-primary"`; tap targets remain split (list → list page, avatars/pills → modal).

- **Bug Fixes**
  - Own‑event in list‑primary now shows the stack for other savers, keeping `SavedByModal` reachable even when `additionalSourceCount=0`.
  - Added `accessibilityLabel="Go to your profile"` to the own‑badge pressable for VoiceOver.

<sup>Written for commit be8c2b5c6f2944a687340bec0c2bae60adfb103f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the inline `EventSaversRow` from `UserEventsList.tsx` into a new `EventAttributionRow` component with a `variant` prop (`"list-primary"` | `"people-primary"`), then wires `"list-primary"` into the My Scene (Following) tab so the source list leads and an overlapping avatar stack serves as the social signal. All other call sites default to `"people-primary"` and are unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/edge-case suggestions with no impact on the primary user path.

The refactor is clean, the variant fallback is safe, existing callers are unaffected, and the two findings (missing accessibilityLabel and an unreachable modal in a narrow own-event edge case) are both P2 quality improvements that do not block functionality.

apps/expo/src/components/EventAttributionRow.tsx — own-event modal reachability and accessibilityLabel on ownBadge

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/EventAttributionRow.tsx | New component implementing list-primary / people-primary attribution row variants; two minor issues: missing accessibilityLabel on ownBadge pressable and unreachable SavedByModal when own-event is in a single list |
| apps/expo/src/components/UserEventsList.tsx | Removes inline EventSaversRow (~200 lines), threads attributionVariant prop through UserEventListItem and UserEventsList; SavedByModal import remains valid for the existing fallback state |
| apps/expo/src/app/(tabs)/following/index.tsx | Single-line change passing attributionVariant="list-primary" to UserEventsList for the Following/My Scene tab |
| .gitignore | Adds .superpowers/ to gitignore alongside the existing docs/superpowers/ entry |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UserEventsList] -->|attributionVariant prop| B[UserEventListItem]
    B -->|variant prop| C{EventAttributionRow}
    C -->|list-primary AND sourceListSlug present| D[ListPrimaryRow]
    C -->|people-primary OR no sourceListSlug| E[PeoplePrimaryRow]

    D --> D1[ListChip → /list/slug]
    D --> D2[OverflowPill +M → SavedByModal]
    D --> D3{isOwnEvent?}
    D3 -->|yes| D4[ownBadge You · ListChip +M]
    D3 -->|no| D5[ListChip +M · AvatarStack +N → SavedByModal]

    E --> E1[Avatars + names → user profile]
    E --> E2[via ListChip]
    E --> E3[SavedByModal]

    F[following/index.tsx] -->|attributionVariant=list-primary| A
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 219-228

Comment:
**Missing `accessibilityLabel` on own-badge pressable**

The `ownBadge` `Pressable` in `ListPrimaryRow` has no `accessibilityLabel`, so VoiceOver will fall back to announcing child text content ("You"). The parallel `stack` pressable gets `"View everyone who saved this"`, and `ListChip` gets `"Open list X"` — the own-badge is the odd one out. A label like `"Go to your profile"` keeps it consistent with the accessibility test-plan item.

```suggestion
  const ownBadge = (
    <Pressable
      onPress={() => navigateToUser(creator, currentUserId)}
      hitSlop={HIT_SLOP}
      accessibilityLabel="Go to your profile"
      className="flex-row items-center gap-1"
    >
      <Avatar user={creator} size={avatarSize} />
      <Text className="text-xs text-neutral-2">You</Text>
    </Pressable>
  );
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 157-186

Comment:
**Own-event savers unreachable when `additionalSourceCount` is 0**

In `ListPrimaryRow` when `isOwnEvent` is true, the avatar stack is hidden and the only interactive element that opens `SavedByModal` is the `+M` list overflow pill (`OverflowPill count={remainingListsCount}`). If `additionalSourceCount` is `0` (the event is in only one list), `OverflowPill` returns `null`, so there is no tap target that opens the modal — savers are silently unreachable. This is an edge case (own events in a single list that have been saved by others), but it means the "View everyone who saved this" path is entirely absent for the creator in that configuration.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): list-primary attribution row..."](https://github.com/jaronheard/soonlist-turbo/commit/ae5407a80b6cfb7e66e73e7df706c46630065dbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28891935)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->