### PR TITLE
feat(expo): unify screenshot CTA label and add +/✓ to SubscribeButton (#1005)

### DIFF
--- a/apps/expo/src/components/SubscribeButton.tsx
+++ b/apps/expo/src/components/SubscribeButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text, TouchableOpacity } from "react-native";
 
+import { Check, PlusIcon } from "~/components/icons";
 import { hapticLight } from "~/utils/feedback";
 
 interface SubscribeButtonProps {
@@ -20,6 +21,9 @@ export function SubscribeButton({
 }: SubscribeButtonProps) {
   const containerSize = size === "sm" ? "px-3 py-1" : "px-4 py-1.5";
   const textSize = size === "sm" ? "text-xs" : "text-sm";
+  const iconSize = size === "sm" ? 12 : 14;
+  const iconColor = isSubscribed ? "#5A32FB" : "#FFFFFF";
+  const Icon = isSubscribed ? Check : PlusIcon;
 
   return (
     <TouchableOpacity
@@ -33,12 +37,13 @@ export function SubscribeButton({
         accessibilityLabel ??
         (isSubscribed ? "Subscribed to list" : "Subscribe to list")
       }
-      className={`rounded-full ${containerSize} ${
+      className={`flex-row items-center gap-1 rounded-full ${containerSize} ${
         isSubscribed
           ? "border border-interactive-1 bg-white"
           : "bg-interactive-1"
       }`}
     >
+      <Icon size={iconSize} color={iconColor} strokeWidth={2.5} />
       <Text
         className={`${textSize} font-semibold ${
           isSubscribed ? "text-interactive-1" : "text-white"

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -816,7 +816,7 @@ const SourceStickersRow = () => {
             className="font-semibold text-neutral-1"
             style={{ fontSize: 20 * fontScale }}
           >
-            Got screenshots? →
+            Screenshot events →
           </Text>
           <Image
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Summary

Two narrow onboarding polish changes from the April 18 UX review (Issue #1005):

- **Empty-state screenshot CTA** now reads **"Screenshot events → Add"**, matching the populated-state footer CTA. Previously read "Got screenshots? → Add" — same action, different wording between empty and populated views of the events list.
- **`SubscribeButton`** gains a leading icon in both states so users can tell whether a tap did something:
  - Unsubscribed → `[+] Subscribe` (white plus on purple)
  - Subscribed → `[✓] Subscribed` (purple check on white, purple border)

The `SubscribeButton` change is a shared-component tweak, so it ripples to all four call sites — featured lists empty state, user profile, list detail page, and the followed-lists modal.

## Why

Issue #1005 was narrowed from the full onboarding UX review to just these two items: screenshot-capture button consistency and subscribe affordance. Other review items are tracked separately in #1009 (featured-lists screen copy / referral pathway) and #1010 (first-run tutorial stickers). Keeping this PR small and parallel-friendly.

## Scope

- `apps/expo/src/components/UserEventsList.tsx` — one-line string swap in `SourceStickersRow`. Big-and-animated treatment preserved.
- `apps/expo/src/components/SubscribeButton.tsx` — add icon before text, `flex-row items-center gap-1` layout, `PlusIcon`/`Check` from `~/components/icons` sized 12/14px based on `sm`/`md`.

Out of scope: screenshot capture behavior itself, any other copy, the Featured Lists screen rework, or the first-run tutorial.

## Test plan

- [ ] Open "My Soonlist" (feed tab) in an account with zero saved events — empty state shows "Screenshot events → Add" (big, animated) above ghost cards
- [ ] Save an event — footer of the populated feed still shows "Screenshot events → Add" (small pill) — labels match
- [ ] Visit Featured Lists empty state → confirm unsubscribed rows show `[+] Subscribe`; tapping flips to `[✓] Subscribed`
- [ ] Visit a user profile, list detail page, and the followed-lists modal → confirm `+`/`✓` icons render correctly at both `sm` and `md` sizes
- [ ] Confirm a11y labels still read "Subscribe to list" / "Subscribed to list" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the screenshot capture CTA across empty and populated event lists and adds +/✓ icons to `SubscribeButton` for clearer tap feedback. Addresses #1005 onboarding polish.

- **New Features**
  - Empty-state CTA now reads "Screenshot events → Add" to match the populated footer.
  - `SubscribeButton` shows a leading icon: [+] Subscribe (unsubscribed) and [✓] Subscribed (subscribed), applied across all existing call sites.

<sup>Written for commit 32388a4afe9ade2ab2538ccb3b9b00d337e95fc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two targeted UX polish changes: it unifies the empty-state screenshot CTA label to match the populated-state footer ("Screenshot events → Add"), and it adds a `+`/`✓` leading icon to `SubscribeButton` so users get instant visual feedback after tapping. The icon implementation correctly threads `size`, `color`, and `strokeWidth` through the existing custom Lucide icon layer, and the hardcoded hex `#5A32FB` is an expected pattern since SVG props cannot consume Tailwind tokens.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are purely presentational with no logic, state, or API impact.

No P0/P1 findings. The icon props (size, color, strokeWidth) are validated against the custom Lucide implementation and are correct. The copy change is a one-liner. All four call sites receive the icon automatically with no extra changes needed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/SubscribeButton.tsx | Adds a leading PlusIcon/Check icon to both subscribe states; icon sizing, color, and strokeWidth are all correctly wired through the custom Lucide layer. |
| apps/expo/src/components/UserEventsList.tsx | One-line copy swap in SourceStickersRow from "Got screenshots? →" to "Screenshot events →" to match the populated-state footer CTA; no logic changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SB["SubscribeButton\n(size, isSubscribed)"]
    SB -->|isSubscribed = false| UP["PlusIcon (white, 12/14px)\n+ 'Subscribe' text\nbg-interactive-1 (purple)"]
    SB -->|isSubscribed = true| SUB["Check (purple, 12/14px)\n+ 'Subscribed' text\nbg-white, border-interactive-1"]
    UP -->|tap| HAP["hapticLight()"]
    SUB -->|tap| HAP
    HAP --> CB["onPress callback"]

    SSR["SourceStickersRow\n(empty state CTA)"]
    SSR -->|before| OLD["'Got screenshots? →'"]
    SSR -->|after| NEW["'Screenshot events →'\n(matches populated footer)"]
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): unify screenshot CTA label a..."](https://github.com/jaronheard/soonlist-turbo/commit/32388a4afe9ade2ab2538ccb3b9b00d337e95fc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28896993)</sub>

<!-- /greptile_comment -->