### PR TITLE
Add dedicated list feed for efficient pagination

### DIFF
--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -21,7 +21,10 @@ import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useEventActions } from "~/hooks/useEventActions";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import { useStableTimestamp } from "~/store";
+import {
+  useLoadMoreHandler,
+  useUpcomingEventsFilter,
+} from "~/hooks/useUpcomingFeed";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 
@@ -91,7 +94,6 @@ function ProfileSaveShareActionButton({
 
 export default function UserProfilePage() {
   const { username } = useLocalSearchParams<{ username: string }>();
-  const stableTimestamp = useStableTimestamp();
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
 
@@ -157,19 +159,9 @@ export default function UserProfilePage() {
     { initialNumItems: 50 },
   );
 
-  const filteredEvents = useMemo(() => {
-    const currentTime = new Date(stableTimestamp).getTime();
-    return events.filter((event) => {
-      const eventEndTime = new Date(event.endDateTime).getTime();
-      return eventEndTime >= currentTime;
-    });
-  }, [events, stableTimestamp]);
+  const filteredEvents = useUpcomingEventsFilter(events);
 
-  const handleLoadMore = () => {
-    if (status === "CanLoadMore") {
-      loadMore(25);
-    }
-  };
+  const handleLoadMore = useLoadMoreHandler(status, loadMore);
 
   const followedLists = useQuery(
     api.lists.getFollowedLists,

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -15,7 +15,10 @@ import { List as ListIcon, ShareIcon } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import { useStableTimestamp } from "~/store";
+import {
+  useLoadMoreHandler,
+  useUpcomingEventsFilter,
+} from "~/hooks/useUpcomingFeed";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 
@@ -25,7 +28,6 @@ export default function ListDetailScreen() {
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const currentUser = useQuery(api.users.getCurrentUser);
-  const stableTimestamp = useStableTimestamp();
 
   const listResult = useQuery(
     api.lists.getBySlug,
@@ -44,12 +46,7 @@ export default function ListDetailScreen() {
     { initialNumItems: 50 },
   );
 
-  const upcomingEvents = useMemo(() => {
-    const currentTime = new Date(stableTimestamp).getTime();
-    return listEvents.filter(
-      (event) => new Date(event.endDateTime).getTime() >= currentTime,
-    );
-  }, [listEvents, stableTimestamp]);
+  const upcomingEvents = useUpcomingEventsFilter(listEvents);
 
   const followListMutation = useMutation(
     api.lists.followList,
@@ -126,11 +123,7 @@ export default function ListDetailScreen() {
     }
   }, [listData, normalizedSlug]);
 
-  const handleLoadMore = useCallback(() => {
-    if (status === "CanLoadMore") {
-      loadMore(25);
-    }
-  }, [status, loadMore]);
+  const handleLoadMore = useLoadMoreHandler(status, loadMore);
 
   const ListHeader = useCallback(
     () => (

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -15,6 +15,7 @@ import { List as ListIcon, ShareIcon } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
+import { useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 
@@ -24,6 +25,7 @@ export default function ListDetailScreen() {
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const currentUser = useQuery(api.users.getCurrentUser);
+  const stableTimestamp = useStableTimestamp();
 
   const listResult = useQuery(
     api.lists.getBySlug,
@@ -36,9 +38,18 @@ export default function ListDetailScreen() {
     loadMore,
   } = useStablePaginatedQuery(
     api.lists.getEventsForList,
-    normalizedSlug ? { slug: normalizedSlug } : "skip",
+    normalizedSlug
+      ? { slug: normalizedSlug, filter: "upcoming" as const }
+      : "skip",
     { initialNumItems: 50 },
   );
+
+  const upcomingEvents = useMemo(() => {
+    const currentTime = new Date(stableTimestamp).getTime();
+    return listEvents.filter(
+      (event) => new Date(event.endDateTime).getTime() >= currentTime,
+    );
+  }, [listEvents, stableTimestamp]);
 
   const followListMutation = useMutation(
     api.lists.followList,
@@ -193,7 +204,7 @@ export default function ListDetailScreen() {
     return null;
   }
 
-  const events = listEvents.map((event) => ({
+  const events = upcomingEvents.map((event) => ({
     event,
     similarEvents: [],
     similarityGroupId: event.id,

--- a/apps/expo/src/hooks/useUpcomingFeed.ts
+++ b/apps/expo/src/hooks/useUpcomingFeed.ts
@@ -30,13 +30,13 @@ export function useUpcomingEventsFilter<T extends { endDateTime: string }>(
 }
 
 /**
- * Wraps `useStablePaginatedQuery`'s `loadMore` in the standard 25-item page
+ * Wraps `useStablePaginatedQuery`'s `loadMore` in the standard 50-item page
  * size + `CanLoadMore` guard used by every upcoming-events list screen.
  */
 export function useLoadMoreHandler(
   status: PaginationStatus,
   loadMore: (numItems: number) => void,
-  pageSize = 25,
+  pageSize = 50,
 ) {
   return useCallback(() => {
     if (status === "CanLoadMore") {

--- a/apps/expo/src/hooks/useUpcomingFeed.ts
+++ b/apps/expo/src/hooks/useUpcomingFeed.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo } from "react";
+
+import { useStableTimestamp } from "~/store";
+
+type PaginationStatus =
+  | "LoadingFirstPage"
+  | "LoadingMore"
+  | "CanLoadMore"
+  | "Exhausted";
+
+/**
+ * Drop events whose `endDateTime` is in the past relative to the app's stable
+ * timestamp. Paired with the server-side `filter: "upcoming"` query, this is
+ * a safety net that catches the window between an event ending and the
+ * `updateHasEndedFlags` cron flipping its feed entry.
+ *
+ * Shared between the list detail view (`/list/[slug]`) and the public user
+ * profile view (`/[username]`) so both feeds stay in lock-step.
+ */
+export function useUpcomingEventsFilter<T extends { endDateTime: string }>(
+  events: T[],
+): T[] {
+  const stableTimestamp = useStableTimestamp();
+  return useMemo(() => {
+    const currentTime = new Date(stableTimestamp).getTime();
+    return events.filter(
+      (event) => new Date(event.endDateTime).getTime() >= currentTime,
+    );
+  }, [events, stableTimestamp]);
+}
+
+/**
+ * Wraps `useStablePaginatedQuery`'s `loadMore` in the standard 25-item page
+ * size + `CanLoadMore` guard used by every upcoming-events list screen.
+ */
+export function useLoadMoreHandler(
+  status: PaginationStatus,
+  loadMore: (numItems: number) => void,
+  pageSize = 25,
+) {
+  return useCallback(() => {
+    if (status === "CanLoadMore") {
+      loadMore(pageSize);
+    }
+  }, [status, loadMore, pageSize]);
+}

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillListFeeds from "../migrations/backfillListFeeds.js";
 import type * as migrations_backfillSourceListId from "../migrations/backfillSourceListId.js";
 import type * as migrations_backfillUserFeedVisibility from "../migrations/backfillUserFeedVisibility.js";
 import type * as migrations_fix2027Dates from "../migrations/fix2027Dates.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillListFeeds": typeof migrations_backfillListFeeds;
   "migrations/backfillSourceListId": typeof migrations_backfillSourceListId;
   "migrations/backfillUserFeedVisibility": typeof migrations_backfillUserFeedVisibility;
   "migrations/fix2027Dates": typeof migrations_fix2027Dates;

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -205,8 +205,12 @@ export const removeEventFromFeeds = internalMutation({
   args: {
     eventId: v.string(),
     keepCreatorFeed: v.optional(v.boolean()),
+    keepListFeeds: v.optional(v.boolean()),
   },
-  handler: async (ctx, { eventId, keepCreatorFeed = true }) => {
+  handler: async (
+    ctx,
+    { eventId, keepCreatorFeed = true, keepListFeeds = true },
+  ) => {
     // Get all feed entries for this event
     const feedEntries = await ctx.db
       .query("userFeeds")
@@ -228,6 +232,16 @@ export const removeEventFromFeeds = internalMutation({
     for (const entry of feedEntries) {
       // If keepCreatorFeed is true, skip only the creator's feed
       if (keepCreatorFeed && event && entry.feedId === `user_${event.userId}`) {
+        continue;
+      }
+
+      // List-detail feeds (`list_${listId}`) are persistent membership records,
+      // not fan-out targets — they live as long as the eventToLists junction
+      // does. Removing them here would lose membership across visibility
+      // toggles (private→public), since the restore path doesn't recreate
+      // them. getEventsForList filters by eventVisibility="public", so private
+      // events stay invisible without needing to delete the entry.
+      if (keepListFeeds && entry.feedId.startsWith("list_")) {
         continue;
       }
 
@@ -993,14 +1007,14 @@ export async function addEventToListFeedInline(
   ctx: MutationCtx,
   eventId: string,
   listId: string,
-): Promise<void> {
+): Promise<boolean> {
   const event = await ctx.db
     .query("events")
     .withIndex("by_custom_id", (q) => q.eq("id", eventId))
     .first();
 
   if (!event) {
-    return;
+    return false;
   }
 
   const eventStartTime = new Date(event.startDateTime).getTime();
@@ -1017,6 +1031,7 @@ export async function addEventToListFeedInline(
     event.similarityGroupId,
     event.visibility,
   );
+  return true;
 }
 
 export async function removeEventFromListFeedInline(

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -902,6 +902,10 @@ export const addEventToContributorLists = internalMutation({
           listId: membership.listId,
         });
 
+        // Maintain the list's own feed (list_${listId}) alongside the
+        // eventToLists insert so getEventsForList stays consistent.
+        await addEventToListFeedInline(ctx, eventId, membership.listId);
+
         // Schedule follower feed fan-out atomically with the insert.
         // Both the insert and this schedule commit in the same transaction,
         // matching the pattern in backfillContributorEventsBatch (lists.ts).
@@ -960,6 +964,169 @@ export const removeUserEventsFromUserFeed = internalMutation({
       }
     }
 
+    return null;
+  },
+});
+
+/**
+ * List detail feed: `list_${listId}`
+ *
+ * Every list has a feed mirroring its eventToLists membership so the list
+ * detail query can paginate directly off `userFeeds.by_feed_visibility_hasEnded_startTime`,
+ * matching how `getPublicUserFeed` reads `user_${userId}`. This avoids the
+ * sparse-page problem where paginating `eventToLists` and filtering after
+ * produced partial pages on large lists with many past or private events.
+ *
+ * Write-path rules:
+ * - Added on `addEventToList` / `addEventToContributorLists` / `backfillContributorEventsBatch`.
+ * - Removed on `removeEventFromList` / `removeContributorEventsBatch` and when a list is deleted.
+ * - Time/visibility/deletion of the underlying event are already fanned out
+ *   across every `userFeeds` entry by `updateEventTimesInAllFeeds`,
+ *   `updateEventVisibilityInFeeds`, and `removeEventFromFeeds`, so no extra
+ *   wiring is needed there.
+ */
+export function listFeedId(listId: string): string {
+  return `list_${listId}`;
+}
+
+export async function addEventToListFeedInline(
+  ctx: MutationCtx,
+  eventId: string,
+  listId: string,
+): Promise<void> {
+  const event = await ctx.db
+    .query("events")
+    .withIndex("by_custom_id", (q) => q.eq("id", eventId))
+    .first();
+
+  if (!event) {
+    return;
+  }
+
+  const eventStartTime = new Date(event.startDateTime).getTime();
+  const eventEndTime = new Date(event.endDateTime).getTime();
+  const currentTime = Date.now();
+
+  await upsertFeedEntry(
+    ctx,
+    listFeedId(listId),
+    eventId,
+    eventStartTime,
+    eventEndTime,
+    currentTime,
+    event.similarityGroupId,
+    event.visibility,
+  );
+}
+
+export async function removeEventFromListFeedInline(
+  ctx: MutationCtx,
+  eventId: string,
+  listId: string,
+): Promise<void> {
+  const feedId = listFeedId(listId);
+  const entry = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_feed_event", (q) =>
+      q.eq("feedId", feedId).eq("eventId", eventId),
+    )
+    .first();
+
+  if (!entry) return;
+
+  const similarityGroupId = entry.similarityGroupId;
+  await userFeedsAggregate.deleteIfExists(ctx, entry);
+  await ctx.db.delete(entry._id);
+
+  if (similarityGroupId) {
+    await ctx.runMutation(internal.feedGroupHelpers.upsertGroupedFeedEntry, {
+      feedId,
+      similarityGroupId,
+    });
+  }
+}
+
+/**
+ * Batch-delete every `list_${listId}` feed entry. Used by the user-deletion
+ * cascade and by the migration's cleanup path. Idempotent and paginated to
+ * stay within Convex transaction limits.
+ */
+export const removeListFeedBatch = internalMutation({
+  args: {
+    listId: v.string(),
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    removed: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { listId, cursor, batchSize }) => {
+    const feedId = listFeedId(listId);
+    const result = await ctx.db
+      .query("userFeeds")
+      .withIndex("by_feed_hasEnded_startTime", (q) => q.eq("feedId", feedId))
+      .paginate({ numItems: batchSize, cursor });
+
+    const affectedGroups = new Set<string>();
+    let removed = 0;
+
+    for (const entry of result.page) {
+      if (entry.similarityGroupId) {
+        affectedGroups.add(entry.similarityGroupId);
+      }
+      await userFeedsAggregate.deleteIfExists(ctx, entry);
+      await ctx.db.delete(entry._id);
+      removed++;
+    }
+
+    for (const similarityGroupId of affectedGroups) {
+      await ctx.runMutation(internal.feedGroupHelpers.upsertGroupedFeedEntry, {
+        feedId,
+        similarityGroupId,
+      });
+    }
+
+    return {
+      processed: result.page.length,
+      removed,
+      nextCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+/**
+ * Orchestrator for `removeListFeedBatch`. Called by the user-deletion cascade
+ * where we don't want the caller to block waiting for many batches.
+ */
+export const removeListFeedAction = internalAction({
+  args: { listId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { listId }) => {
+    let cursor: string | null = null;
+    while (true) {
+      const result: {
+        processed: number;
+        removed: number;
+        nextCursor: string | null;
+        isDone: boolean;
+      } = await ctx.runMutation(internal.feedHelpers.removeListFeedBatch, {
+        listId,
+        cursor,
+        batchSize: 100,
+      });
+      if (result.isDone) break;
+      if (result.nextCursor === cursor) {
+        console.error(
+          `Cursor stalled in removeListFeed for listId=${listId} — aborting`,
+        );
+        break;
+      }
+      cursor = result.nextCursor;
+    }
     return null;
   },
 });

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -1062,33 +1062,32 @@ export async function removeEventFromListFeedInline(
 }
 
 /**
- * Batch-delete every `list_${listId}` feed entry. Used by the user-deletion
- * cascade and by the migration's cleanup path. Idempotent and paginated to
- * stay within Convex transaction limits.
+ * Batch-delete up to `batchSize` `list_${listId}` feed entries. Used by the
+ * user-deletion cascade. Uses `.take()` rather than `.paginate()` because
+ * we delete every row we pull on the index prefix — a paginate cursor
+ * would point at a deleted document in the next transaction, which is
+ * unsafe. The caller loops until `processed === 0`.
  */
 export const removeListFeedBatch = internalMutation({
   args: {
     listId: v.string(),
-    cursor: v.union(v.string(), v.null()),
     batchSize: v.number(),
   },
   returns: v.object({
     processed: v.number(),
     removed: v.number(),
-    nextCursor: v.union(v.string(), v.null()),
-    isDone: v.boolean(),
   }),
-  handler: async (ctx, { listId, cursor, batchSize }) => {
+  handler: async (ctx, { listId, batchSize }) => {
     const feedId = listFeedId(listId);
-    const result = await ctx.db
+    const entries = await ctx.db
       .query("userFeeds")
       .withIndex("by_feed_hasEnded_startTime", (q) => q.eq("feedId", feedId))
-      .paginate({ numItems: batchSize, cursor });
+      .take(batchSize);
 
     const affectedGroups = new Set<string>();
     let removed = 0;
 
-    for (const entry of result.page) {
+    for (const entry of entries) {
       if (entry.similarityGroupId) {
         affectedGroups.add(entry.similarityGroupId);
       }
@@ -1105,10 +1104,8 @@ export const removeListFeedBatch = internalMutation({
     }
 
     return {
-      processed: result.page.length,
+      processed: entries.length,
       removed,
-      nextCursor: result.continueCursor,
-      isDone: result.isDone,
     };
   },
 });
@@ -1121,26 +1118,18 @@ export const removeListFeedAction = internalAction({
   args: { listId: v.string() },
   returns: v.null(),
   handler: async (ctx, { listId }) => {
-    let cursor: string | null = null;
+    // take()/delete-everything pattern: loop until the batch returns zero
+    // rows. No cursor to track because each batch re-queries from the
+    // start of the index prefix.
     while (true) {
       const result: {
         processed: number;
         removed: number;
-        nextCursor: string | null;
-        isDone: boolean;
       } = await ctx.runMutation(internal.feedHelpers.removeListFeedBatch, {
         listId,
-        cursor,
         batchSize: 100,
       });
-      if (result.isDone) break;
-      if (result.nextCursor === cursor) {
-        console.error(
-          `Cursor stalled in removeListFeed for listId=${listId} — aborting`,
-        );
-        break;
-      }
-      cursor = result.nextCursor;
+      if (result.processed === 0) break;
     }
     return null;
   },

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1205,12 +1205,28 @@ async function enrichListEventsForViewer(
 }
 
 /**
+ * Continuation cursors emitted by the backfill-window fallback are tagged
+ * with this prefix so the next paginate call routes back to the fallback
+ * path. Without it, page 2 would feed an `eventToLists` cursor into the
+ * `userFeeds` index — Convex would reject it as an invalid cursor.
+ */
+const FALLBACK_CURSOR_PREFIX = "etl:";
+
+function isFallbackCursor(cursor: string | null): cursor is string {
+  return cursor?.startsWith(FALLBACK_CURSOR_PREFIX) ?? false;
+}
+
+/**
  * Backfill-window fallback: paginate `eventToLists` directly and filter
  * events in memory. Reproduces the pre-feed behavior — sparse pages and
  * all — but only fires when `list_${listId}` has zero `userFeeds` entries
  * for a list that still has membership rows. The migration drains this
  * branch into the feed; once it completes for a list the dense feed path
  * takes over.
+ *
+ * Once a request enters this path, every subsequent page must stay on it —
+ * the returned `continueCursor` is wrapped with `FALLBACK_CURSOR_PREFIX`
+ * and the main handler re-routes wrapped cursors back here.
  */
 async function getEventsForListBackfillFallback(
   ctx: QueryCtx,
@@ -1245,6 +1261,11 @@ async function getEventsForListBackfillFallback(
 
   return {
     ...eventToLists,
+    // Tag the cursor only when there's more data to fetch; once isDone the
+    // client won't call back, so leave the original (possibly empty) value.
+    continueCursor: eventToLists.isDone
+      ? eventToLists.continueCursor
+      : `${FALLBACK_CURSOR_PREFIX}${eventToLists.continueCursor}`,
     page: await enrichListEventsForViewer(ctx, visibleEvents, viewerId),
   };
 }
@@ -1299,6 +1320,22 @@ export const getEventsForList = query({
     const accessResult = await checkListAccess(ctx, list.id, viewerId);
     if (accessResult.status !== "ok") {
       return emptyResults();
+    }
+
+    // If the previous page came from the backfill fallback, its cursor is
+    // tagged so we stay on the same path — feeding an `eventToLists`
+    // cursor into the `userFeeds` index would fail.
+    if (isFallbackCursor(paginationOpts.cursor)) {
+      return getEventsForListBackfillFallback(
+        ctx,
+        list.id,
+        {
+          numItems: paginationOpts.numItems,
+          cursor: paginationOpts.cursor.slice(FALLBACK_CURSOR_PREFIX.length),
+        },
+        filter,
+        viewerId,
+      );
     }
 
     const feedId = listFeedId(list.id);

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -11,6 +11,11 @@ import {
   query,
 } from "./_generated/server";
 import { listFollowsAggregate } from "./aggregates";
+import {
+  addEventToListFeedInline,
+  listFeedId,
+  removeEventFromListFeedInline,
+} from "./feedHelpers";
 import { enrichEventsAndFilterNulls } from "./model/events";
 import { getViewableListIds } from "./model/lists";
 import { generatePublicId } from "./utils";
@@ -1020,6 +1025,9 @@ export const removeContributorEventsBatch = internalMutation({
       if (event?.userId === contributorUserId) {
         await ctx.db.delete(entry._id);
 
+        // Keep the list's own feed (list_${listId}) in sync with eventToLists.
+        await removeEventFromListFeedInline(ctx, entry.eventId, listId);
+
         // Schedule feed cleanup in a separate transaction to reduce bandwidth
         // of this batch mutation — removeEventFromListFollowersFeeds does
         // multiple queries per follower
@@ -1138,6 +1146,11 @@ export const backfillContributorEventsBatch = internalMutation({
           listId,
         });
 
+        // Maintain the list's own feed (list_${listId}) inline in this
+        // batch — addEventToListFeedInline is a single upsert on userFeeds
+        // and stays well within the per-mutation transaction budget.
+        await addEventToListFeedInline(ctx, event.id, listId);
+
         // Schedule feed population in a separate transaction to avoid
         // hitting transaction limits when there are many followers
         await ctx.scheduler.runAfter(
@@ -1162,23 +1175,31 @@ export const backfillContributorEventsBatch = internalMutation({
 });
 
 /**
- * Get events for a list by slug, paginated to stay within Convex limits.
+ * Get events for a list by slug.
+ *
+ * Paginates the list's dedicated feed (`list_${listId}`) in `userFeeds` so
+ * every page comes back densely filled with matching events — previously we
+ * paginated the `eventToLists` junction and then discarded past/private
+ * events, which produced sparse pages on large lists.
+ *
+ * Write-path wiring that keeps the feed in sync lives in `feedHelpers.ts`
+ * (`addEventToListFeedInline` / `removeEventFromListFeedInline` /
+ * `removeListFeedAction`). Existing `eventToLists` rows are backfilled by
+ * `migrations/backfillListFeeds.ts`.
  */
 export const getEventsForList = query({
   args: {
     slug: v.string(),
     paginationOpts: paginationOptsValidator,
     filter: v.optional(v.union(v.literal("upcoming"), v.literal("past"))),
-    beforeThisDateTime: v.optional(v.string()),
   },
-  handler: async (
-    ctx,
-    { slug, paginationOpts, filter = "upcoming", beforeThisDateTime },
-  ) => {
+  handler: async (ctx, { slug, paginationOpts, filter = "upcoming" }) => {
     const emptyResults = async () => {
       const emptyPage = await ctx.db
-        .query("eventToLists")
-        .withIndex("by_list", (q) => q.eq("listId", "__missing_list__"))
+        .query("userFeeds")
+        .withIndex("by_feed_hasEnded_startTime", (q) =>
+          q.eq("feedId", "__missing_list__"),
+        )
         .paginate(paginationOpts);
       return {
         ...emptyPage,
@@ -1204,32 +1225,42 @@ export const getEventsForList = query({
       return emptyResults();
     }
 
-    // Paginate list memberships so large lists don't hydrate every event at once.
-    const eventToLists = await ctx.db
-      .query("eventToLists")
-      .withIndex("by_list", (q) => q.eq("listId", list.id))
+    const feedId = listFeedId(list.id);
+    const hasEnded = filter === "past";
+    const order = filter === "upcoming" ? "asc" : "desc";
+
+    // Filter + sort at the index BEFORE paginating so every page is densely
+    // populated with matching events (no sparse pages from post-filtering).
+    // `eventVisibility` is pinned to "public" to mirror the previous
+    // behavior of dropping private events from list detail views.
+    const feedResults = await ctx.db
+      .query("userFeeds")
+      .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
+        q
+          .eq("feedId", feedId)
+          .eq("eventVisibility", "public")
+          .eq("hasEnded", hasEnded),
+      )
+      .order(order)
       .paginate(paginationOpts);
 
     const events = await Promise.all(
-      eventToLists.page.map((etl) =>
+      feedResults.page.map((entry) =>
         ctx.db
           .query("events")
-          .withIndex("by_custom_id", (q) => q.eq("id", etl.eventId))
+          .withIndex("by_custom_id", (q) => q.eq("id", entry.eventId))
           .unique(),
       ),
     );
 
-    const referenceDateTime = beforeThisDateTime ?? new Date().toISOString();
-    const visibleEvents = events
-      .filter((event): event is NonNullable<typeof event> => event !== null)
-      .filter((event) => event.visibility !== "private")
-      .filter((event) =>
-        filter === "upcoming"
-          ? event.endDateTime >= referenceDateTime
-          : event.endDateTime < referenceDateTime,
-      );
+    const hydratedEvents = events.filter(
+      (event): event is NonNullable<typeof event> => event !== null,
+    );
 
-    const enrichedEvents = await enrichEventsAndFilterNulls(ctx, visibleEvents);
+    const enrichedEvents = await enrichEventsAndFilterNulls(
+      ctx,
+      hydratedEvents,
+    );
 
     // Strip private-unviewable lists from each event.lists before returning.
     // enrichEventsAndFilterNulls hydrates event.lists with ALL lists the
@@ -1249,7 +1280,7 @@ export const getEventsForList = query({
     }));
 
     return {
-      ...eventToLists,
+      ...feedResults,
       page: filteredEvents,
     };
   },

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1168,8 +1168,13 @@ export const getEventsForList = query({
   args: {
     slug: v.string(),
     paginationOpts: paginationOptsValidator,
+    filter: v.optional(v.union(v.literal("upcoming"), v.literal("past"))),
+    beforeThisDateTime: v.optional(v.string()),
   },
-  handler: async (ctx, { slug, paginationOpts }) => {
+  handler: async (
+    ctx,
+    { slug, paginationOpts, filter = "upcoming", beforeThisDateTime },
+  ) => {
     const emptyResults = async () => {
       const emptyPage = await ctx.db
         .query("eventToLists")
@@ -1214,9 +1219,15 @@ export const getEventsForList = query({
       ),
     );
 
+    const referenceDateTime = beforeThisDateTime ?? new Date().toISOString();
     const visibleEvents = events
       .filter((event): event is NonNullable<typeof event> => event !== null)
-      .filter((event) => event.visibility !== "private");
+      .filter((event) => event.visibility !== "private")
+      .filter((event) =>
+        filter === "upcoming"
+          ? event.endDateTime >= referenceDateTime
+          : event.endDateTime < referenceDateTime,
+      );
 
     const enrichedEvents = await enrichEventsAndFilterNulls(ctx, visibleEvents);
 

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1342,6 +1342,27 @@ export const getEventsForList = query({
       );
     }
 
+    // Backfill-window safety: a list is only known to have its `list_*`
+    // feed fully mirrored from `eventToLists` once `list.feedBackfilledAt`
+    // is populated. New lists set this at creation; pre-existing lists get
+    // it set by `migrations/backfillListFeeds.runBackfillListFeeds`. When
+    // the marker is absent we fall back to the junction scan unconditionally
+    // — the feed may already have some entries (partial migration) but we
+    // can't trust that they're complete, so returning a partial first page
+    // would silently hide unmigrated events.
+    //
+    // Gated on cursor=null because subsequent pages within a fallback run
+    // already route via `isFallbackCursor` above.
+    if (paginationOpts.cursor === null && !list.feedBackfilledAt) {
+      return getEventsForListBackfillFallback(
+        ctx,
+        list.id,
+        paginationOpts,
+        filter,
+        viewerId,
+      );
+    }
+
     const feedId = listFeedId(list.id);
     const hasEnded = filter === "past";
     const order = filter === "upcoming" ? "asc" : "desc";
@@ -1360,29 +1381,6 @@ export const getEventsForList = query({
       )
       .order(order)
       .paginate(paginationOpts);
-
-    // Backfill-window safety: a list is only known to have its `list_*`
-    // feed fully mirrored from `eventToLists` once `list.feedBackfilledAt`
-    // is populated. New lists set this at creation; pre-existing lists get
-    // it set by `migrations/backfillListFeeds.runBackfillListFeeds`. When
-    // the marker is absent we fall back to the junction scan to cover the
-    // deploy/backfill window — including partial-migration states where
-    // the feed already has some entries but not all for this list. Once
-    // the marker is populated this branch is an O(1) field check.
-    if (
-      paginationOpts.cursor === null &&
-      feedResults.page.length === 0 &&
-      feedResults.isDone &&
-      !list.feedBackfilledAt
-    ) {
-      return getEventsForListBackfillFallback(
-        ctx,
-        list.id,
-        paginationOpts,
-        filter,
-        viewerId,
-      );
-    }
 
     const events = await Promise.all(
       feedResults.page.map((entry) =>

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -185,6 +185,10 @@ export async function getOrCreatePersonalList(
     slug: `user-${username}`,
     created_at: new Date().toISOString(),
     updatedAt: null,
+    // New lists never need the backfill fallback — the write path
+    // (addEventToList → addEventToListFeedInline) keeps the list feed in
+    // lockstep with eventToLists from day one.
+    feedBackfilledAt: new Date().toISOString(),
   });
 
   return (await ctx.db.get(docId))!;
@@ -1357,43 +1361,27 @@ export const getEventsForList = query({
       .order(order)
       .paginate(paginationOpts);
 
-    // Backfill-window safety: fall back to the legacy junction scan when
-    // the list's feed is missing entries relative to `eventToLists`. Covers
-    // both the pre-migration case (feed entirely empty) and the partial-
-    // migration case (some entries present but not all, e.g. the user
-    // filters for "upcoming" and only past events have been migrated so
-    // far). Once the counts match, the feed is authoritative and this
-    // branch is skipped on subsequent queries.
-    //
-    // Guarded on the first page only (`cursor === null`) and on a fully
-    // exhausted `feedResults` to avoid double-scanning on every paginated
-    // call post-migration.
+    // Backfill-window safety: a list is only known to have its `list_*`
+    // feed fully mirrored from `eventToLists` once `list.feedBackfilledAt`
+    // is populated. New lists set this at creation; pre-existing lists get
+    // it set by `migrations/backfillListFeeds.runBackfillListFeeds`. When
+    // the marker is absent we fall back to the junction scan to cover the
+    // deploy/backfill window — including partial-migration states where
+    // the feed already has some entries but not all for this list. Once
+    // the marker is populated this branch is an O(1) field check.
     if (
       paginationOpts.cursor === null &&
       feedResults.page.length === 0 &&
-      feedResults.isDone
+      feedResults.isDone &&
+      !list.feedBackfilledAt
     ) {
-      const [junctionEntries, feedEntries] = await Promise.all([
-        ctx.db
-          .query("eventToLists")
-          .withIndex("by_list", (q) => q.eq("listId", list.id))
-          .collect(),
-        ctx.db
-          .query("userFeeds")
-          .withIndex("by_feed_hasEnded_startTime", (q) =>
-            q.eq("feedId", feedId),
-          )
-          .collect(),
-      ]);
-      if (feedEntries.length < junctionEntries.length) {
-        return getEventsForListBackfillFallback(
-          ctx,
-          list.id,
-          paginationOpts,
-          filter,
-          viewerId,
-        );
-      }
+      return getEventsForListBackfillFallback(
+        ctx,
+        list.id,
+        paginationOpts,
+        filter,
+        viewerId,
+      );
     }
 
     const events = await Promise.all(

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1175,6 +1175,81 @@ export const backfillContributorEventsBatch = internalMutation({
 });
 
 /**
+ * Enrich a page of raw event docs with user / follows / lists data and
+ * strip lists the viewer can't see — shared by both the feed-backed path
+ * and the backfill-window fallback so they return the same shape.
+ */
+async function enrichListEventsForViewer(
+  ctx: QueryCtx,
+  events: Doc<"events">[],
+  viewerId: string | null,
+) {
+  const enrichedEvents = await enrichEventsAndFilterNulls(ctx, events);
+
+  // Strip private-unviewable lists from each event.lists before returning.
+  // enrichEventsAndFilterNulls hydrates event.lists with ALL lists the
+  // event belongs to, including ones this viewer can't see. The client
+  // (SavedByModal) trusts the server's filtering, so we must enforce
+  // visibility here — same contract as queryFeed/queryGroupedFeed in
+  // feeds.ts.
+  const allListsAcrossEvents = enrichedEvents.flatMap((e) => e.lists ?? []);
+  const viewableListIds = await getViewableListIds(
+    ctx,
+    allListsAcrossEvents,
+    viewerId,
+  );
+  return enrichedEvents.map((event) => ({
+    ...event,
+    lists: (event.lists ?? []).filter((l) => viewableListIds.has(l.id)),
+  }));
+}
+
+/**
+ * Backfill-window fallback: paginate `eventToLists` directly and filter
+ * events in memory. Reproduces the pre-feed behavior — sparse pages and
+ * all — but only fires when `list_${listId}` has zero `userFeeds` entries
+ * for a list that still has membership rows. The migration drains this
+ * branch into the feed; once it completes for a list the dense feed path
+ * takes over.
+ */
+async function getEventsForListBackfillFallback(
+  ctx: QueryCtx,
+  listId: string,
+  paginationOpts: { numItems: number; cursor: string | null },
+  filter: "upcoming" | "past",
+  viewerId: string | null,
+) {
+  const eventToLists = await ctx.db
+    .query("eventToLists")
+    .withIndex("by_list", (q) => q.eq("listId", listId))
+    .paginate(paginationOpts);
+
+  const events = await Promise.all(
+    eventToLists.page.map((etl) =>
+      ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", etl.eventId))
+        .unique(),
+    ),
+  );
+
+  const referenceDateTime = new Date().toISOString();
+  const visibleEvents = events
+    .filter((event): event is NonNullable<typeof event> => event !== null)
+    .filter((event) => event.visibility !== "private")
+    .filter((event) =>
+      filter === "upcoming"
+        ? event.endDateTime >= referenceDateTime
+        : event.endDateTime < referenceDateTime,
+    );
+
+  return {
+    ...eventToLists,
+    page: await enrichListEventsForViewer(ctx, visibleEvents, viewerId),
+  };
+}
+
+/**
  * Get events for a list by slug.
  *
  * Paginates the list's dedicated feed (`list_${listId}`) in `userFeeds` so
@@ -1185,7 +1260,8 @@ export const backfillContributorEventsBatch = internalMutation({
  * Write-path wiring that keeps the feed in sync lives in `feedHelpers.ts`
  * (`addEventToListFeedInline` / `removeEventFromListFeedInline` /
  * `removeListFeedAction`). Existing `eventToLists` rows are backfilled by
- * `migrations/backfillListFeeds.ts`.
+ * `migrations/backfillListFeeds.ts`; lists not yet reached by the migration
+ * fall back to a legacy scan so the deploy window doesn't show empty lists.
  */
 export const getEventsForList = query({
   args: {
@@ -1244,6 +1320,38 @@ export const getEventsForList = query({
       .order(order)
       .paginate(paginationOpts);
 
+    // Backfill-window safety: if the feed is fully empty AND the list has
+    // eventToLists membership, the migration hasn't reached this list yet.
+    // Fall back to the legacy junction scan so users don't see an empty
+    // list during deploy. Only checked on the first page (cursor=null) and
+    // when the entire feed is empty (isDone) — once any feed entry exists
+    // for this list this branch is skipped.
+    if (
+      paginationOpts.cursor === null &&
+      feedResults.page.length === 0 &&
+      feedResults.isDone
+    ) {
+      const anyFeedEntry = await ctx.db
+        .query("userFeeds")
+        .withIndex("by_feed_hasEnded_startTime", (q) => q.eq("feedId", feedId))
+        .first();
+      if (!anyFeedEntry) {
+        const anyMembership = await ctx.db
+          .query("eventToLists")
+          .withIndex("by_list", (q) => q.eq("listId", list.id))
+          .first();
+        if (anyMembership) {
+          return getEventsForListBackfillFallback(
+            ctx,
+            list.id,
+            paginationOpts,
+            filter,
+            viewerId,
+          );
+        }
+      }
+    }
+
     const events = await Promise.all(
       feedResults.page.map((entry) =>
         ctx.db
@@ -1257,31 +1365,9 @@ export const getEventsForList = query({
       (event): event is NonNullable<typeof event> => event !== null,
     );
 
-    const enrichedEvents = await enrichEventsAndFilterNulls(
-      ctx,
-      hydratedEvents,
-    );
-
-    // Strip private-unviewable lists from each event.lists before returning.
-    // enrichEventsAndFilterNulls hydrates event.lists with ALL lists the
-    // event belongs to, including ones this viewer can't see. The client
-    // (SavedByModal) trusts the server's filtering, so we must enforce
-    // visibility here — same contract as queryFeed/queryGroupedFeed in
-    // feeds.ts.
-    const allListsAcrossEvents = enrichedEvents.flatMap((e) => e.lists ?? []);
-    const viewableListIds = await getViewableListIds(
-      ctx,
-      allListsAcrossEvents,
-      viewerId,
-    );
-    const filteredEvents = enrichedEvents.map((event) => ({
-      ...event,
-      lists: (event.lists ?? []).filter((l) => viewableListIds.has(l.id)),
-    }));
-
     return {
       ...feedResults,
-      page: filteredEvents,
+      page: await enrichListEventsForViewer(ctx, hydratedEvents, viewerId),
     };
   },
 });

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1296,12 +1296,16 @@ export const getEventsForList = query({
   },
   handler: async (ctx, { slug, paginationOpts, filter = "upcoming" }) => {
     const emptyResults = async () => {
+      // Pass a null cursor rather than the incoming one: the page is empty
+      // anyway (isDone=true), and a tagged fallback cursor (`etl:...`) or
+      // any stale cursor from a deleted/inaccessible list would otherwise
+      // be rejected by `userFeeds.paginate` as invalid.
       const emptyPage = await ctx.db
         .query("userFeeds")
         .withIndex("by_feed_hasEnded_startTime", (q) =>
           q.eq("feedId", "__missing_list__"),
         )
-        .paginate(paginationOpts);
+        .paginate({ numItems: paginationOpts.numItems, cursor: null });
       return {
         ...emptyPage,
         page: [] as EnrichedEvent[],

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -1357,35 +1357,42 @@ export const getEventsForList = query({
       .order(order)
       .paginate(paginationOpts);
 
-    // Backfill-window safety: if the feed is fully empty AND the list has
-    // eventToLists membership, the migration hasn't reached this list yet.
-    // Fall back to the legacy junction scan so users don't see an empty
-    // list during deploy. Only checked on the first page (cursor=null) and
-    // when the entire feed is empty (isDone) — once any feed entry exists
-    // for this list this branch is skipped.
+    // Backfill-window safety: fall back to the legacy junction scan when
+    // the list's feed is missing entries relative to `eventToLists`. Covers
+    // both the pre-migration case (feed entirely empty) and the partial-
+    // migration case (some entries present but not all, e.g. the user
+    // filters for "upcoming" and only past events have been migrated so
+    // far). Once the counts match, the feed is authoritative and this
+    // branch is skipped on subsequent queries.
+    //
+    // Guarded on the first page only (`cursor === null`) and on a fully
+    // exhausted `feedResults` to avoid double-scanning on every paginated
+    // call post-migration.
     if (
       paginationOpts.cursor === null &&
       feedResults.page.length === 0 &&
       feedResults.isDone
     ) {
-      const anyFeedEntry = await ctx.db
-        .query("userFeeds")
-        .withIndex("by_feed_hasEnded_startTime", (q) => q.eq("feedId", feedId))
-        .first();
-      if (!anyFeedEntry) {
-        const anyMembership = await ctx.db
+      const [junctionEntries, feedEntries] = await Promise.all([
+        ctx.db
           .query("eventToLists")
           .withIndex("by_list", (q) => q.eq("listId", list.id))
-          .first();
-        if (anyMembership) {
-          return getEventsForListBackfillFallback(
-            ctx,
-            list.id,
-            paginationOpts,
-            filter,
-            viewerId,
-          );
-        }
+          .collect(),
+        ctx.db
+          .query("userFeeds")
+          .withIndex("by_feed_hasEnded_startTime", (q) =>
+            q.eq("feedId", feedId),
+          )
+          .collect(),
+      ]);
+      if (feedEntries.length < junctionEntries.length) {
+        return getEventsForListBackfillFallback(
+          ctx,
+          list.id,
+          paginationOpts,
+          filter,
+          viewerId,
+        );
       }
     }
 

--- a/packages/backend/convex/migrations/backfillListFeeds.ts
+++ b/packages/backend/convex/migrations/backfillListFeeds.ts
@@ -1,0 +1,90 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalAction, internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
+
+/**
+ * Backfill `list_${listId}` userFeeds entries from the current `eventToLists`
+ * junction so the list-detail query can paginate efficiently on the
+ * `by_feed_visibility_hasEnded_startTime` index.
+ *
+ * Must be run once after deploying the write-path changes in
+ * `addEventToList` / `removeEventFromList` / `addEventToContributorLists` /
+ * `backfillContributorEventsBatch` / `removeContributorEventsBatch`. New
+ * writes after those changes maintain the feed themselves; this only catches
+ * up existing data.
+ *
+ * Idempotent: `addEventToListFeedInline` upserts via `by_feed_event`, so
+ * re-running the migration just refreshes timestamps on already-populated
+ * entries.
+ */
+export const backfillListFeedsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    upserted: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("eventToLists")
+      .paginate({ numItems: batchSize, cursor });
+
+    let upserted = 0;
+
+    for (const etl of result.page) {
+      await addEventToListFeedInline(ctx, etl.eventId, etl.listId);
+      upserted++;
+    }
+
+    return {
+      processed: result.page.length,
+      upserted,
+      nextCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+export const runBackfillListFeeds = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    let totalProcessed = 0;
+    let totalUpserted = 0;
+    let cursor: string | null = null;
+    const batchSize = 50;
+
+    while (true) {
+      const result: {
+        processed: number;
+        upserted: number;
+        nextCursor: string | null;
+        isDone: boolean;
+      } = await ctx.runMutation(
+        internal.migrations.backfillListFeeds.backfillListFeedsBatch,
+        { cursor, batchSize },
+      );
+
+      totalProcessed += result.processed;
+      totalUpserted += result.upserted;
+
+      if (result.isDone) break;
+      if (result.nextCursor === cursor) {
+        console.error("Cursor stalled in backfillListFeeds — aborting");
+        break;
+      }
+      cursor = result.nextCursor;
+    }
+
+    console.log(
+      `list feed backfill: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted`,
+    );
+    return null;
+  },
+});

--- a/packages/backend/convex/migrations/backfillListFeeds.ts
+++ b/packages/backend/convex/migrations/backfillListFeeds.ts
@@ -27,6 +27,7 @@ export const backfillListFeedsBatch = internalMutation({
   returns: v.object({
     processed: v.number(),
     upserted: v.number(),
+    skipped: v.number(),
     nextCursor: v.union(v.string(), v.null()),
     isDone: v.boolean(),
   }),
@@ -36,15 +37,29 @@ export const backfillListFeedsBatch = internalMutation({
       .paginate({ numItems: batchSize, cursor });
 
     let upserted = 0;
+    let skipped = 0;
 
     for (const etl of result.page) {
-      await addEventToListFeedInline(ctx, etl.eventId, etl.listId);
-      upserted++;
+      // addEventToListFeedInline returns false when the event row is
+      // missing — eventToLists can outlive its event during cascades or
+      // partial cleanups. Track those separately so the orchestrator log
+      // distinguishes real upserts from dangling-junction skips.
+      const didUpsert = await addEventToListFeedInline(
+        ctx,
+        etl.eventId,
+        etl.listId,
+      );
+      if (didUpsert) {
+        upserted++;
+      } else {
+        skipped++;
+      }
     }
 
     return {
       processed: result.page.length,
       upserted,
+      skipped,
       nextCursor: result.continueCursor,
       isDone: result.isDone,
     };
@@ -57,6 +72,7 @@ export const runBackfillListFeeds = internalAction({
   handler: async (ctx) => {
     let totalProcessed = 0;
     let totalUpserted = 0;
+    let totalSkipped = 0;
     let cursor: string | null = null;
     const batchSize = 50;
 
@@ -64,6 +80,7 @@ export const runBackfillListFeeds = internalAction({
       const result: {
         processed: number;
         upserted: number;
+        skipped: number;
         nextCursor: string | null;
         isDone: boolean;
       } = await ctx.runMutation(
@@ -73,6 +90,7 @@ export const runBackfillListFeeds = internalAction({
 
       totalProcessed += result.processed;
       totalUpserted += result.upserted;
+      totalSkipped += result.skipped;
 
       if (result.isDone) break;
       if (result.nextCursor === cursor) {
@@ -83,7 +101,7 @@ export const runBackfillListFeeds = internalAction({
     }
 
     console.log(
-      `list feed backfill: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted`,
+      `list feed backfill: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted, ${totalSkipped} skipped (missing event)`,
     );
     return null;
   },

--- a/packages/backend/convex/migrations/backfillListFeeds.ts
+++ b/packages/backend/convex/migrations/backfillListFeeds.ts
@@ -136,8 +136,15 @@ export const runBackfillListFeeds = internalAction({
 
       if (result.isDone) break;
       if (result.nextCursor === cursor) {
-        console.error("Cursor stalled in backfillListFeeds — aborting");
-        break;
+        // Throwing instead of breaking: stalling here means phase 1 only
+        // partially populated the feed. If we fell through to phase 2 we'd
+        // stamp `feedBackfilledAt` on every list, silencing the
+        // getEventsForList fallback even though many list_* feeds are
+        // still incomplete. Fail loud so an operator can investigate and
+        // re-run rather than leave users with quietly-wrong lists.
+        throw new Error(
+          `Cursor stalled in backfillListFeeds after ${totalProcessed} rows — phase 2 not run`,
+        );
       }
       cursor = result.nextCursor;
     }

--- a/packages/backend/convex/migrations/backfillListFeeds.ts
+++ b/packages/backend/convex/migrations/backfillListFeeds.ts
@@ -66,10 +66,52 @@ export const backfillListFeedsBatch = internalMutation({
   },
 });
 
+/**
+ * Phase 2: once the feed entries are populated, mark every list so
+ * `getEventsForList` can trust the feed directly (O(1) field check)
+ * instead of falling back to a junction scan. Idempotent: only lists
+ * missing `feedBackfilledAt` get patched.
+ */
+export const markListsBackfilledBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    marked: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("lists")
+      .paginate({ numItems: batchSize, cursor });
+
+    const now = new Date().toISOString();
+    let marked = 0;
+
+    for (const list of result.page) {
+      if (list.feedBackfilledAt) continue;
+      await ctx.db.patch(list._id, { feedBackfilledAt: now });
+      marked++;
+    }
+
+    return {
+      processed: result.page.length,
+      marked,
+      nextCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
 export const runBackfillListFeeds = internalAction({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
+    // Phase 1: mirror every eventToLists row into a `list_${listId}` feed
+    // entry. Safe to re-run; upserts are keyed on (feedId, eventId).
     let totalProcessed = 0;
     let totalUpserted = 0;
     let totalSkipped = 0;
@@ -101,7 +143,41 @@ export const runBackfillListFeeds = internalAction({
     }
 
     console.log(
-      `list feed backfill: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted, ${totalSkipped} skipped (missing event)`,
+      `list feed backfill phase 1: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted, ${totalSkipped} skipped (missing event)`,
+    );
+
+    // Phase 2: stamp every list with `feedBackfilledAt`. Once phase 1
+    // committed its last row, this marker is safe — it tells
+    // getEventsForList that the feed is authoritative for this list and
+    // the junction-scan fallback can be skipped.
+    let totalListsProcessed = 0;
+    let totalMarked = 0;
+    let listCursor: string | null = null;
+
+    while (true) {
+      const result: {
+        processed: number;
+        marked: number;
+        nextCursor: string | null;
+        isDone: boolean;
+      } = await ctx.runMutation(
+        internal.migrations.backfillListFeeds.markListsBackfilledBatch,
+        { cursor: listCursor, batchSize },
+      );
+
+      totalListsProcessed += result.processed;
+      totalMarked += result.marked;
+
+      if (result.isDone) break;
+      if (result.nextCursor === listCursor) {
+        console.error("Cursor stalled in markListsBackfilledBatch — aborting");
+        break;
+      }
+      listCursor = result.nextCursor;
+    }
+
+    console.log(
+      `list feed backfill phase 2: ${totalListsProcessed} lists processed, ${totalMarked} marked backfilled`,
     );
     return null;
   },

--- a/packages/backend/convex/migrations/personalListMigration.ts
+++ b/packages/backend/convex/migrations/personalListMigration.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 
 import { internal } from "../_generated/api";
 import { internalAction, internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
 import { getOrCreatePersonalList } from "../lists";
 
 const EVENTS_PER_BATCH = 100;
@@ -100,6 +101,12 @@ export const backfillUserEventsBatch = internalMutation({
           eventId: event.id,
           listId,
         });
+        // Keep the list's `list_${listId}` feed in lockstep with the
+        // junction. `getOrCreatePersonalList` stamps `feedBackfilledAt`
+        // at creation, so `getEventsForList` trusts the feed for these
+        // lists — skipping this call would leave migrated personal lists
+        // with an empty feed and return empty pages to users.
+        await addEventToListFeedInline(ctx, event.id, listId);
         linked++;
       }
     }

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -13,6 +13,10 @@ import {
   userFeedsAggregate,
 } from "../aggregates";
 import { DEFAULT_TIMEZONE } from "../constants";
+import {
+  addEventToListFeedInline,
+  removeEventFromListFeedInline,
+} from "../feedHelpers";
 import { getOrCreatePersonalList } from "../lists";
 import { generateNumericId, generatePublicId } from "../utils";
 import {
@@ -1383,6 +1387,10 @@ export async function addEventToList(
       listId,
     });
 
+    // Maintain the list's own feed (list_${listId}) so getEventsForList can
+    // paginate efficiently by the userFeeds visibility/hasEnded index.
+    await addEventToListFeedInline(ctx, eventId, listId);
+
     // Add event to followers' feeds
     await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
       eventId,
@@ -1447,6 +1455,10 @@ export async function removeEventFromList(
     for (const link of existingLinks) {
       await ctx.db.delete(link._id);
     }
+
+    // Drop this event from the list's own feed before fanning out to
+    // followers, mirroring the symmetric write in addEventToList.
+    await removeEventFromListFeedInline(ctx, eventId, listId);
 
     // Remove event from followers' feeds
     await ctx.runMutation(

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1102,6 +1102,17 @@ export async function updateEvent(
       similarityGroupId,
     });
 
+    if (visibilityChanged) {
+      // updateEventInFeeds only touches creator/follower/discover feeds, but
+      // the event also lives in list_${listId} entries that removeEventFromFeeds
+      // intentionally preserves. Sync their `eventVisibility` so the
+      // index-level filter in getEventsForList stays correct after toggles.
+      await ctx.runMutation(internal.feedHelpers.updateEventVisibilityInFeeds, {
+        eventId,
+        visibility: visibility || existingEvent.visibility,
+      });
+    }
+
     // If changing to public, fan out to list followers
     if (visibility === "public" && existingEvent.visibility === "private") {
       const eventToLists = await ctx.db
@@ -1185,10 +1196,13 @@ export async function deleteEvent(
     await ctx.db.delete(etl._id);
   }
 
-  // Remove event from all feeds
+  // Remove event from all feeds, including the list_${listId} membership
+  // entries — the event row itself is going away, so its dedicated list
+  // feeds must too.
   await ctx.runMutation(internal.feedHelpers.removeEventFromFeeds, {
     eventId,
     keepCreatorFeed: false,
+    keepListFeeds: false,
   });
 
   // Remove from aggregates before deleting the event
@@ -1532,6 +1546,14 @@ export async function toggleEventVisibility(
         );
       }
     }
+
+    // Sync eventVisibility on persistent feed entries (creator + list_*).
+    // updateEventInFeeds / removeEventFromFeeds don't touch list_* visibility,
+    // so the getEventsForList index filter would otherwise read a stale value.
+    await ctx.runMutation(internal.feedHelpers.updateEventVisibilityInFeeds, {
+      eventId,
+      visibility,
+    });
   }
 
   return event;

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -146,6 +146,13 @@ export default defineSchema({
     slug: v.optional(v.string()),
     created_at: v.string(), // ISO date string
     updatedAt: v.union(v.string(), v.null()), // ISO date string or null
+    // Set once the list's `list_${id}` userFeeds entries are known to mirror
+    // `eventToLists` — populated immediately on list creation (new lists
+    // never need the backfill fallback) and retroactively by
+    // `migrations/backfillListFeeds`. Absence signals getEventsForList to
+    // use the junction-scan fallback during the backfill window. Field is
+    // optional so pre-existing docs validate until the migration runs.
+    feedBackfilledAt: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
     .index("by_custom_id", ["id"])

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -1133,6 +1133,22 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(etl._id);
       }
 
+      // Remove the event from every userFeeds entry it lives in — including
+      // list_${listId} entries in OTHER users' lists, followedLists_* and
+      // followedUsers_* entries in their followers' feeds, and the discover
+      // feed. Without this, those rows hydrate as null in future queries
+      // (sparse pagination and dead data growth). Scheduled so the
+      // user-deletion mutation stays within transaction limits.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.removeEventFromFeeds,
+        {
+          eventId: event.id,
+          keepCreatorFeed: false,
+          keepListFeeds: false,
+        },
+      );
+
       // Delete the event itself
       await ctx.db.delete(event._id);
     }

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -1492,16 +1492,6 @@ export const bulkUpdateEventVisibilityBatch = internalMutation({
         );
       }
 
-      // Sync eventVisibility on the persistent list_${listId} feed entries
-      // that removeEventFromFeeds preserves; without this their index value
-      // stays stale and getEventsForList returns the wrong set after a
-      // bulk toggle.
-      await ctx.scheduler.runAfter(
-        0,
-        internal.feedHelpers.updateEventVisibilityInFeeds,
-        { eventId: event.id, visibility },
-      );
-
       updated++;
     }
 

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -1171,6 +1171,15 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(etl._id);
       }
 
+      // Schedule cleanup of the list's own feed (list_${listId}) entries.
+      // Deferring to an action keeps this user-deletion mutation within
+      // transaction limits for users who own many lists with large feeds.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.removeListFeedAction,
+        { listId: list.id },
+      );
+
       // Delete the list itself
       await ctx.db.delete(list._id);
     }

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -1492,6 +1492,16 @@ export const bulkUpdateEventVisibilityBatch = internalMutation({
         );
       }
 
+      // Sync eventVisibility on the persistent list_${listId} feed entries
+      // that removeEventFromFeeds preserves; without this their index value
+      // stays stale and getEventsForList returns the wrong set after a
+      // bulk toggle.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.updateEventVisibilityInFeeds,
+        { eventId: event.id, visibility },
+      );
+
       updated++;
     }
 


### PR DESCRIPTION
## Summary
Introduces a dedicated feed for each list (`list_${listId}`) in the `userFeeds` table to enable efficient pagination of list events. Previously, paginating list events required reading the sparse `eventToLists` junction table and filtering out past/private events post-query, resulting in sparse pages. The new approach mirrors the user feed pattern and paginates directly on the indexed `by_feed_visibility_hasEnded_startTime` index.

## Key Changes

- **Feed Infrastructure** (`feedHelpers.ts`):
  - Added `listFeedId()` helper to generate feed identifiers
  - Added `addEventToListFeedInline()` to upsert events into a list's feed
  - Added `removeEventFromListFeedInline()` to remove events from a list's feed
  - Added `removeListFeedBatch()` mutation and `removeListFeedAction()` action for batch cleanup during user deletion

- **Write-Path Wiring** (`lists.ts`, `model/events.ts`):
  - Updated `addEventToList()` to maintain list feed via `addEventToListFeedInline()`
  - Updated `removeEventFromList()` to maintain list feed via `removeEventFromListFeedInline()`
  - Updated `addEventToContributorLists()` to maintain list feed inline
  - Updated `removeContributorEventsBatch()` to maintain list feed inline
  - Updated `backfillContributorEventsBatch()` to maintain list feed inline

- **Query Optimization** (`lists.ts`):
  - Refactored `getEventsForList()` to paginate `userFeeds` instead of `eventToLists`
  - Added optional `filter` parameter to support "upcoming" vs "past" events
  - Filters at the index level (`by_feed_visibility_hasEnded_startTime`) to ensure dense pagination
  - Removed post-query filtering of private events (now handled at index level)

- **Migration** (`migrations/backfillListFeeds.ts`):
  - Added `backfillListFeedsBatch()` mutation to backfill existing `eventToLists` entries
  - Added `runBackfillListFeeds()` action to orchestrate the backfill process
  - Idempotent design allows safe re-runs

- **User Deletion** (`users.ts`):
  - Integrated `removeListFeedAction()` into user deletion cascade to clean up list feeds

- **Client-Side Utilities** (`useUpcomingFeed.ts`):
  - Added `useUpcomingEventsFilter()` hook to filter events by end time (safety net for timing windows)
  - Added `useLoadMoreHandler()` hook to standardize pagination behavior

- **UI Updates** (`[username]/index.tsx`, `list/[slug].tsx`):
  - Updated user profile and list detail screens to use new filter utilities
  - Integrated `useUpcomingEventsFilter()` and `useLoadMoreHandler()` for consistent pagination

## Implementation Details

- The list feed is maintained symmetrically: added when events join a list, removed when they leave
- Event visibility, time, and deletion changes are already fanned out across all feeds by existing mechanisms (`updateEventTimesInAllFeeds`, `updateEventVisibilityInFeeds`, `removeEventFromFeeds`)
- The migration is idempotent—`addEventToListFeedInline()` upserts via the `by_feed_event` index, so re-running refreshes timestamps on existing entries
- Batch operations stay within Convex transaction limits by using pagination and deferring follower feed updates to separate transactions
- Client-side filtering provides a safety net for the window between an event ending and the `updateHasEndedFlags` cron updating feed entries

https://claude.ai/code/session_01HtwjBrFxwDb7y5qZ3sqz4q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated per-list feed in `userFeeds` for dense, filterable list pagination with an upcoming/past toggle. Preserves list membership across visibility changes and hardens cleanup and backfill behavior; standardizes client pagination to 50 items.

- **New Features**
  - Per-list feed in `userFeeds` (`list_${listId}`) with `listFeedId`, `addEventToListFeedInline`, `removeEventFromListFeedInline`, and `removeListFeedAction`; maintained on all add/remove paths, preserved via `keepListFeeds` + visibility sync, and cleaned on event/list delete and user-cascade.
  - `getEventsForList` paginates `userFeeds.by_feed_visibility_hasEnded_startTime` with `filter: "upcoming" | "past"`; private events filtered at the index. Fallback always runs on unmarked lists (`!list.feedBackfilledAt`) and tags cursors with `etl:` to keep pagination on the same path; empty-result responses return a null cursor. Batch list-feed cleanup uses `.take()` in `removeListFeedBatch`.
  - Expo: extracted `useUpcomingEventsFilter` and `useLoadMoreHandler`; list detail passes `filter: "upcoming"` and both the list detail and public profile apply the client safety net. `useLoadMoreHandler` defaults to 50 items to match initial loads.

- **Migration**
  - Run `migrations/backfillListFeeds:runBackfillListFeeds` once post-deploy. Phase 1 backfills `list_${listId}` entries from `eventToLists` (tracks `upserted` vs `skipped`, idempotent) and throws on cursor stall to prevent premature marking. Phase 2 stamps `lists.feedBackfilledAt` so reads trust the feed and skip the fallback.
  - Personal-list backfill: `migrations/personalListMigration.backfillUserEventsBatch` now upserts into `list_${listId}` after each `eventToLists` insert to keep newly created personal lists (which set `feedBackfilledAt` at creation) consistent; safe to re-run.

<sup>Written for commit 674685c6ffe97df6bcc5ebb416b26ecd6a083f9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a dedicated `list_${listId}` feed in `userFeeds` for each list, enabling dense pagination of list events via the existing `by_feed_visibility_hasEnded_startTime` index — mirroring the user feed pattern. Write-path wiring is symmetric across add/remove/contributor operations, client-side filtering is extracted into shared hooks, and an idempotent backfill migration handles existing data.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 observability and deployment-window notes with no blocking correctness issues.

The architecture is sound and the feed is kept in sync symmetrically. The only concerns are a misleading upserted counter in backfill logs and the known transient data gap during the backfill window — both are P2 and neither causes persistent data loss or incorrect behavior.

packages/backend/convex/migrations/backfillListFeeds.ts (counter accuracy) and packages/backend/convex/lists.ts (backfill deployment ordering).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/feedHelpers.ts | Adds listFeedId, addEventToListFeedInline, removeEventFromListFeedInline, removeListFeedBatch, and removeListFeedAction — follows existing feed patterns cleanly; cursor-stall guard and aggregate cleanup are correct. |
| packages/backend/convex/lists.ts | Refactors getEventsForList to paginate userFeeds instead of eventToLists, and wires addEventToListFeedInline/removeEventFromListFeedInline into contributor batch mutations; data gap exists during the backfill window. |
| packages/backend/convex/migrations/backfillListFeeds.ts | Idempotent migration to backfill list_${listId} feed entries from eventToLists; upserted counter is always equal to processed due to unconditional increment. |
| packages/backend/convex/model/events.ts | Adds list feed maintenance calls to addEventToList and removeEventFromList symmetrically; straightforward wiring with no issues. |
| packages/backend/convex/users.ts | Schedules removeListFeedAction before deleting each list in the user-deletion cascade; correctly deferred to avoid transaction-limit issues. |
| apps/expo/src/hooks/useUpcomingFeed.ts | New shared hooks useUpcomingEventsFilter and useLoadMoreHandler correctly extract duplicated logic; dependency arrays and memoization are correct. |
| apps/expo/src/app/list/[slug].tsx | Passes filter: 'upcoming' to server query and applies client-side useUpcomingEventsFilter as a safety net; migration to shared hooks is clean. |
| apps/expo/src/app/[username]/index.tsx | Replaces inline filter and loadMore logic with shared hooks; removes stale stableTimestamp dependency. |
| packages/backend/convex/_generated/api.d.ts | Auto-generated file updated to register migrations/backfillListFeeds module. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Expo Client
    participant Query as getEventsForList
    participant UF as userFeeds (list_${listId})
    participant Events as events table
    participant WP as Write-Path

    Note over WP,UF: Write path (new)
    WP->>UF: addEventToListFeedInline (upsert)
    WP->>UF: removeEventFromListFeedInline (delete)

    Note over Client,Events: Read path (new)
    Client->>Query: slug + filter:upcoming
    Query->>UF: paginate by_feed_visibility_hasEnded_startTime
    UF-->>Query: dense page of feed entries
    Query->>Events: hydrate each eventId in parallel
    Events-->>Query: event docs
    Query-->>Client: enriched + visibility-filtered events

    Note over Client,Client: Client safety net
    Client->>Client: useUpcomingEventsFilter (endDateTime >= now)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/migrations/backfillListFeeds.ts
Line: 38-43

Comment:
**`upserted` always equals `processed` in final log**

`addEventToListFeedInline` returns early (without upserting) when the referenced event no longer exists, but `upserted` is still incremented unconditionally. The final log message `"${totalUpserted} feed entries upserted"` will always match `totalProcessed`, making it impossible to tell how many events were skipped due to dangling `eventToLists` references.

A cleaner fix would be to have `addEventToListFeedInline` return a boolean indicating whether the upsert occurred, or track a separate `skipped` counter so the final log is accurate.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/lists.ts
Line: 1236-1245

Comment:
**Incomplete list data during backfill window**

`getEventsForList` now reads exclusively from `userFeeds` (`list_${listId}`). Between deploying this code and completing `runBackfillListFeeds`, existing lists whose `eventToLists` rows haven't been backfilled yet will return an empty or partial feed — the new write-path only populates entries for events added/removed after the deploy. Users visiting any pre-existing list during this window will see fewer events than they should.

The migration docstring mentions "must be run once after deploying", but there's no guard to indicate the feed is still warming up. Consider running the migration immediately after deploying before re-enabling traffic, or explicitly communicating the transient gap during rollout.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(list): back list detail with dedicat..."](https://github.com/jaronheard/soonlist-turbo/commit/6ba3dfdd08792f43a383e513524175e492431c93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28918737)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->