### PR TITLE
Enable following users without pre-existing personal lists

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -39,6 +39,7 @@ import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
+import { toast } from "~/utils/feedback";
 
 type Segment = "upcoming" | "past";
 
@@ -203,6 +204,7 @@ function FeaturedListRow({
           logError("followUserByUsername returned failure", {
             reason: result.reason,
           });
+          toast.error("Couldn't update subscription");
         }
       })
       .catch((error) => {

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -120,6 +120,12 @@ function FeaturedListRow({
     ]);
   });
 
+  // Fallback for targets whose personal list doesn't exist yet; the server
+  // creates it on demand.
+  const followUserByUsernameMutation = useMutation(
+    api.lists.followUserByUsername,
+  );
+
   const unfollowListMutation = useMutation(
     api.lists.unfollowList,
   ).withOptimisticUpdate((localStore, args) => {
@@ -174,11 +180,14 @@ function FeaturedListRow({
   const isMutatingRef = useRef(false);
 
   const handleToggleSubscribe = useCallback(() => {
-    if (!personalList || isSelf || isMutatingRef.current) return;
+    if (isSelf || isMutatingRef.current) return;
     isMutatingRef.current = true;
-    const promise = isSubscribed
-      ? unfollowListMutation({ listId: personalList.id })
-      : followListMutation({ listId: personalList.id });
+    const promise =
+      isSubscribed && personalList
+        ? unfollowListMutation({ listId: personalList.id })
+        : personalList
+          ? followListMutation({ listId: personalList.id })
+          : followUserByUsernameMutation({ username });
     promise
       .catch((error) => {
         logError(
@@ -197,6 +206,8 @@ function FeaturedListRow({
     isSubscribed,
     unfollowListMutation,
     followListMutation,
+    followUserByUsernameMutation,
+    username,
   ]);
 
   const upcomingLabel =
@@ -245,7 +256,7 @@ function FeaturedListRow({
           </Text>
         </View>
       </TouchableOpacity>
-      {!isSelf && personalList ? (
+      {!isSelf && targetUserFound ? (
         <SubscribeButton
           isSubscribed={isSubscribed}
           onPress={handleToggleSubscribe}

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -181,14 +181,30 @@ function FeaturedListRow({
 
   const handleToggleSubscribe = useCallback(() => {
     if (isSelf || isMutatingRef.current) return;
-    isMutatingRef.current = true;
+    // personalList === undefined means the Convex query is still loading;
+    // ignore the tap so we don't drop the optimistic-update path for users
+    // whose list just hasn't resolved yet.
     const promise =
       isSubscribed && personalList
         ? unfollowListMutation({ listId: personalList.id })
         : personalList
           ? followListMutation({ listId: personalList.id })
-          : followUserByUsernameMutation({ username });
+          : personalList === null
+            ? followUserByUsernameMutation({ username })
+            : null;
+    if (!promise) return;
+    isMutatingRef.current = true;
     promise
+      .then((result) => {
+        // followUserByUsername returns { success, reason } without throwing;
+        // surface that as an error so the user gets feedback. follow/unfollow
+        // both always return { success: true }.
+        if (result && "reason" in result && !result.success) {
+          logError("followUserByUsername returned failure", {
+            reason: result.reason,
+          });
+        }
+      })
       .catch((error) => {
         logError(
           isSubscribed

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -119,6 +119,14 @@ export default function UserProfilePage() {
     ]);
   });
 
+  // Fallback mutation used when the target user has no personal list yet
+  // (older accounts that pre-date personal lists). The server creates the
+  // list on demand, so no optimistic update is possible — we rely on the
+  // reactive query refresh.
+  const followUserByUsernameMutation = useMutation(
+    api.lists.followUserByUsername,
+  );
+
   const unfollowListMutation = useMutation(
     api.lists.unfollowList,
   ).withOptimisticUpdate((localStore, args) => {
@@ -192,23 +200,32 @@ export default function UserProfilePage() {
     : false;
 
   const handleFollowListPress = useCallback(() => {
-    if (!personalList) return;
+    if (!targetUser) return;
     if (!isAuthenticated) {
       router.push("/(auth)/sign-in");
       return;
     }
-    const run = isFollowingPersonalList
-      ? unfollowListMutation
-      : followListMutation;
-    run({ listId: personalList.id }).catch((error: unknown) => {
+    const onError = (error: unknown) => {
       logError("Toggle follow personal list", error);
       toast.error("Couldn't update subscription");
-    });
+    };
+    if (isFollowingPersonalList && personalList) {
+      unfollowListMutation({ listId: personalList.id }).catch(onError);
+    } else if (personalList) {
+      followListMutation({ listId: personalList.id }).catch(onError);
+    } else {
+      // No personal list yet — ask the server to create and follow it.
+      followUserByUsernameMutation({ username: targetUser.username }).catch(
+        onError,
+      );
+    }
   }, [
+    targetUser,
     personalList,
     isAuthenticated,
     isFollowingPersonalList,
     followListMutation,
+    followUserByUsernameMutation,
     unfollowListMutation,
     router,
   ]);
@@ -277,21 +294,20 @@ export default function UserProfilePage() {
           headerTitleStyle: {
             color: "#5A32FB",
           },
-          unstable_headerRightItems:
-            isOwnProfile || !personalList
-              ? undefined
-              : () => [
-                  {
-                    type: "custom",
-                    element: (
-                      <SubscribeButton
-                        isSubscribed={isFollowingPersonalList}
-                        onPress={handleFollowListPress}
-                      />
-                    ),
-                    hidesSharedBackground: true,
-                  },
-                ],
+          unstable_headerRightItems: isOwnProfile
+            ? undefined
+            : () => [
+                {
+                  type: "custom",
+                  element: (
+                    <SubscribeButton
+                      isSubscribed={isFollowingPersonalList}
+                      onPress={handleFollowListPress}
+                    />
+                  ),
+                  hidesSharedBackground: true,
+                },
+              ],
         }}
       />
       <View className="flex-1 bg-interactive-3">

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -213,12 +213,20 @@ export default function UserProfilePage() {
       unfollowListMutation({ listId: personalList.id }).catch(onError);
     } else if (personalList) {
       followListMutation({ listId: personalList.id }).catch(onError);
-    } else {
-      // No personal list yet — ask the server to create and follow it.
-      followUserByUsernameMutation({ username: targetUser.username }).catch(
-        onError,
-      );
+    } else if (personalList === null) {
+      // Confirmed: no personal list yet — ask the server to create and follow it.
+      followUserByUsernameMutation({ username: targetUser.username })
+        .then((result) => {
+          if (!result.success) {
+            logError("followUserByUsername returned failure", {
+              reason: result.reason,
+            });
+            toast.error("Couldn't update subscription");
+          }
+        })
+        .catch(onError);
     }
+    // personalList === undefined means the query is still loading; ignore the tap.
   }, [
     targetUser,
     personalList,

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -423,6 +423,20 @@ export const addListEventsToUserFeed = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { userId, listId }) => {
+    // Verify the user is still following the list. This guards delayed
+    // hydration jobs (e.g. the on-demand backfill fan-out): a user who
+    // unfollowed between the schedule and the run shouldn't get the
+    // list's events re-added to their feed.
+    const follow = await ctx.db
+      .query("listFollows")
+      .withIndex("by_user_and_list", (q) =>
+        q.eq("userId", userId).eq("listId", listId),
+      )
+      .first();
+    if (!follow) {
+      return;
+    }
+
     const canView = await canUserViewListForFeed(ctx, listId, userId);
     if (!canView) {
       return;

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -386,21 +386,10 @@ export const followUserByUsername = mutation({
       return { success: false as const, reason: "User not found" };
     }
 
-    // Get their personal list
-    const personalList = await ctx.db
-      .query("lists")
-      .withIndex("by_user_and_isSystemList_and_systemListType", (q) =>
-        q
-          .eq("userId", targetUser.id)
-          .eq("isSystemList", true)
-          .eq("systemListType", "personal"),
-      )
-      .first();
-
-    if (!personalList) {
-      return { success: false as const, reason: "User has no personal list" };
-    }
-
+    // Get or create their personal list. Older accounts may pre-date the
+    // personal-list system or have slipped past the migration, which
+    // previously made them un-subscribable.
+    const personalList = await getOrCreatePersonalList(ctx, targetUser.id);
     const listId = personalList.id;
 
     const accessResult = await checkListAccess(ctx, listId, userId);

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -402,17 +402,6 @@ export const followUserByUsername = mutation({
       existingList ?? (await getOrCreatePersonalList(ctx, targetUser.id));
     const listId = personalList.id;
 
-    // If we just created the list on-demand, backfill the target user's
-    // historical events so the new follower's feed isn't empty. Run as a
-    // scheduled job to keep this mutation bounded for power users.
-    if (!existingList) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.migrations.personalListMigration.backfillUserEventsBatch,
-        { userId: targetUser.id, listId, cursor: null },
-      );
-    }
-
     const accessResult = await checkListAccess(ctx, listId, userId);
     if (accessResult.status !== "ok") {
       return {
@@ -440,10 +429,29 @@ export const followUserByUsername = mutation({
     const followDoc = (await ctx.db.get(followId))!;
     await listFollowsAggregate.insert(ctx, followDoc);
 
-    await ctx.runMutation(internal.feedHelpers.addListEventsToUserFeed, {
-      userId,
-      listId,
-    });
+    if (existingList) {
+      // Pre-existing list — eventToLists is already populated, so hydrate
+      // the follower's feed inline.
+      await ctx.runMutation(internal.feedHelpers.addListEventsToUserFeed, {
+        userId,
+        listId,
+      });
+    } else {
+      // List was just created on-demand for an older account. Schedule a
+      // bounded backfill of the owner's historical events; the backfill
+      // chain hydrates this follower's feed when it completes so they
+      // don't see an empty feed.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.personalListMigration.backfillUserEventsBatch,
+        {
+          userId: targetUser.id,
+          listId,
+          cursor: null,
+          hydrateFollowerUserId: userId,
+        },
+      );
+    }
 
     return { success: true as const };
   },

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -439,8 +439,9 @@ export const followUserByUsername = mutation({
     } else {
       // List was just created on-demand for an older account. Schedule a
       // bounded backfill of the owner's historical events; the backfill
-      // chain hydrates this follower's feed when it completes so they
-      // don't see an empty feed.
+      // chain hydrates every current follower's feed when it completes,
+      // so this follower (and anyone else who subscribes during the
+      // backfill window) doesn't see an empty feed.
       await ctx.scheduler.runAfter(
         0,
         internal.migrations.personalListMigration.backfillUserEventsBatch,
@@ -448,7 +449,7 @@ export const followUserByUsername = mutation({
           userId: targetUser.id,
           listId,
           cursor: null,
-          hydrateFollowerUserId: userId,
+          hydrateFollowersOnComplete: true,
         },
       );
     }

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -389,8 +389,29 @@ export const followUserByUsername = mutation({
     // Get or create their personal list. Older accounts may pre-date the
     // personal-list system or have slipped past the migration, which
     // previously made them un-subscribable.
-    const personalList = await getOrCreatePersonalList(ctx, targetUser.id);
+    const existingList = await ctx.db
+      .query("lists")
+      .withIndex("by_user_and_isSystemList_and_systemListType", (q) =>
+        q
+          .eq("userId", targetUser.id)
+          .eq("isSystemList", true)
+          .eq("systemListType", "personal"),
+      )
+      .first();
+    const personalList =
+      existingList ?? (await getOrCreatePersonalList(ctx, targetUser.id));
     const listId = personalList.id;
+
+    // If we just created the list on-demand, backfill the target user's
+    // historical events so the new follower's feed isn't empty. Run as a
+    // scheduled job to keep this mutation bounded for power users.
+    if (!existingList) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.personalListMigration.backfillUserEventsBatch,
+        { userId: targetUser.id, listId, cursor: null },
+      );
+    }
 
     const accessResult = await checkListAccess(ctx, listId, userId);
     if (accessResult.status !== "ok") {

--- a/packages/backend/convex/migrations/personalListMigration.ts
+++ b/packages/backend/convex/migrations/personalListMigration.ts
@@ -68,18 +68,23 @@ export const personalListBatch = internalMutation({
 /**
  * Paginated backfill of a single user's events → personal list.
  * Self-schedules the next page to stay under transaction limits.
+ *
+ * If `hydrateFollowerUserId` is set, the follower's feed is hydrated from
+ * the list once the backfill chain completes — used when a list is created
+ * on-demand at follow time so the new follower's feed isn't empty.
  */
 export const backfillUserEventsBatch = internalMutation({
   args: {
     userId: v.string(),
     listId: v.string(),
     cursor: v.union(v.string(), v.null()),
+    hydrateFollowerUserId: v.optional(v.string()),
   },
   returns: v.object({
     linked: v.number(),
     isDone: v.boolean(),
   }),
-  handler: async (ctx, { userId, listId, cursor }) => {
+  handler: async (ctx, { userId, listId, cursor, hydrateFollowerUserId }) => {
     const result = await ctx.db
       .query("events")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -112,11 +117,18 @@ export const backfillUserEventsBatch = internalMutation({
           userId,
           listId,
           cursor: result.continueCursor,
+          hydrateFollowerUserId,
         },
       );
     } else if (!result.isDone) {
       console.error(
         `backfillUserEventsBatch: cursor stalled for user ${userId} list ${listId} at cursor ${cursor} — aborting`,
+      );
+    } else if (hydrateFollowerUserId) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addListEventsToUserFeed,
+        { userId: hydrateFollowerUserId, listId },
       );
     }
 

--- a/packages/backend/convex/migrations/personalListMigration.ts
+++ b/packages/backend/convex/migrations/personalListMigration.ts
@@ -65,6 +65,8 @@ export const personalListBatch = internalMutation({
   },
 });
 
+const FOLLOWERS_PER_BATCH = 100;
+
 /**
  * Paginated backfill of a single user's events → personal list.
  * Self-schedules the next page to stay under transaction limits.
@@ -130,23 +132,58 @@ export const backfillUserEventsBatch = internalMutation({
         `backfillUserEventsBatch: cursor stalled for user ${userId} list ${listId} at cursor ${cursor} — aborting`,
       );
     } else if (hydrateFollowersOnComplete) {
-      // Fan out to every CURRENT follower so anyone who subscribed during
-      // the backfill window also gets hydrated, and anyone who unfollowed
-      // mid-backfill is skipped.
-      const follows = await ctx.db
-        .query("listFollows")
-        .withIndex("by_list", (q) => q.eq("listId", listId))
-        .collect();
-      for (const follow of follows) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.feedHelpers.addListEventsToUserFeed,
-          { userId: follow.userId, listId },
-        );
-      }
+      // Kick off a paginated follower fan-out. We schedule rather than
+      // inline-collect so we don't blow transaction limits for lists that
+      // accumulated many followers while the backfill was running.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.personalListMigration.hydrateListFollowersBatch,
+        { listId, cursor: null },
+      );
     }
 
     return { linked, isDone: result.isDone };
+  },
+});
+
+/**
+ * Paginated fan-out: schedule `addListEventsToUserFeed` for each current
+ * follower of `listId`. Self-schedules the next page so a list with many
+ * followers doesn't exceed transaction limits.
+ */
+export const hydrateListFollowersBatch = internalMutation({
+  args: {
+    listId: v.string(),
+    cursor: v.union(v.string(), v.null()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { listId, cursor }) => {
+    const result = await ctx.db
+      .query("listFollows")
+      .withIndex("by_list", (q) => q.eq("listId", listId))
+      .paginate({ numItems: FOLLOWERS_PER_BATCH, cursor });
+
+    for (const follow of result.page) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addListEventsToUserFeed,
+        { userId: follow.userId, listId },
+      );
+    }
+
+    if (!result.isDone && result.continueCursor !== cursor) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.personalListMigration.hydrateListFollowersBatch,
+        { listId, cursor: result.continueCursor },
+      );
+    } else if (!result.isDone) {
+      console.error(
+        `hydrateListFollowersBatch: cursor stalled for list ${listId} at cursor ${cursor} — aborting`,
+      );
+    }
+
+    return null;
   },
 });
 

--- a/packages/backend/convex/migrations/personalListMigration.ts
+++ b/packages/backend/convex/migrations/personalListMigration.ts
@@ -69,22 +69,27 @@ export const personalListBatch = internalMutation({
  * Paginated backfill of a single user's events → personal list.
  * Self-schedules the next page to stay under transaction limits.
  *
- * If `hydrateFollowerUserId` is set, the follower's feed is hydrated from
- * the list once the backfill chain completes — used when a list is created
- * on-demand at follow time so the new follower's feed isn't empty.
+ * When `hydrateFollowersOnComplete` is true, every current follower's
+ * feed is hydrated from the list once the backfill chain finishes — used
+ * for lists created on-demand at follow time so followers don't see an
+ * empty feed. Only currently-following users are hydrated, so anyone who
+ * unfollowed mid-backfill is naturally skipped.
  */
 export const backfillUserEventsBatch = internalMutation({
   args: {
     userId: v.string(),
     listId: v.string(),
     cursor: v.union(v.string(), v.null()),
-    hydrateFollowerUserId: v.optional(v.string()),
+    hydrateFollowersOnComplete: v.optional(v.boolean()),
   },
   returns: v.object({
     linked: v.number(),
     isDone: v.boolean(),
   }),
-  handler: async (ctx, { userId, listId, cursor, hydrateFollowerUserId }) => {
+  handler: async (
+    ctx,
+    { userId, listId, cursor, hydrateFollowersOnComplete },
+  ) => {
     const result = await ctx.db
       .query("events")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -117,19 +122,28 @@ export const backfillUserEventsBatch = internalMutation({
           userId,
           listId,
           cursor: result.continueCursor,
-          hydrateFollowerUserId,
+          hydrateFollowersOnComplete,
         },
       );
     } else if (!result.isDone) {
       console.error(
         `backfillUserEventsBatch: cursor stalled for user ${userId} list ${listId} at cursor ${cursor} — aborting`,
       );
-    } else if (hydrateFollowerUserId) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.feedHelpers.addListEventsToUserFeed,
-        { userId: hydrateFollowerUserId, listId },
-      );
+    } else if (hydrateFollowersOnComplete) {
+      // Fan out to every CURRENT follower so anyone who subscribed during
+      // the backfill window also gets hydrated, and anyone who unfollowed
+      // mid-backfill is skipped.
+      const follows = await ctx.db
+        .query("listFollows")
+        .withIndex("by_list", (q) => q.eq("listId", listId))
+        .collect();
+      for (const follow of follows) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.feedHelpers.addListEventsToUserFeed,
+          { userId: follow.userId, listId },
+        );
+      }
     }
 
     return { linked, isDone: result.isDone };


### PR DESCRIPTION
## Summary
This PR enables users to follow other users who don't yet have a personal list, addressing a limitation where older accounts that pre-date the personal-list system or missed migrations couldn't be followed. The server now creates personal lists on-demand when needed.

## Key Changes
- **Backend (`lists.ts`)**: Modified `followUserByUsername` mutation to call `getOrCreatePersonalList()` instead of failing when a personal list doesn't exist, allowing the server to create lists on-demand
- **User Profile (`[username]/index.tsx`)**: 
  - Added `followUserByUsernameMutation` as a fallback when the target user has no personal list yet
  - Updated `handleFollowListPress` to route to the new mutation when `personalList` is undefined
  - Removed the `!personalList` check from the subscribe button visibility condition, allowing the button to display even for users without pre-existing personal lists
- **Following Tab (`following/index.tsx`)**:
  - Added `followUserByUsernameMutation` fallback mutation
  - Updated `handleToggleSubscribe` to use the new mutation when `personalList` doesn't exist
  - Changed subscribe button visibility condition from `personalList && !isSelf` to `targetUserFound && !isSelf`

## Implementation Details
- No optimistic updates are possible for the fallback path since the server creates the list on-demand; the UI relies on reactive query refresh to reflect the new state
- The changes maintain backward compatibility with existing accounts that already have personal lists
- Error handling is consistent across both UI implementations with appropriate user-facing error messages

https://claude.ai/code/session_015NfzDqS2773nYDKedAikFC
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable following users who don’t have a personal list by creating it on subscribe, backfilling their events, and hydrating only current followers’ feeds so no one sees an empty feed. Hydration runs in paginated batches; Subscribe shows for any non-self user, and taps during loading are ignored.

- **Bug Fixes**
  - Backend: `followUserByUsername` in `packages/backend/convex/lists.ts` uses `getOrCreatePersonalList`; if the list exists, hydrate via `internal.feedHelpers.addListEventsToUserFeed` inline; if created on-demand, schedule `personalListMigration.backfillUserEventsBatch` with `hydrateFollowersOnComplete: true` so fan-out runs after backfill.
  - Hydration: `backfillUserEventsBatch` schedules `hydrateListFollowersBatch` to paginate follower hydration (100 per batch), and `internal.feedHelpers.addListEventsToUserFeed` now verifies the user still follows the list before adding events to avoid rehydrating users who unfollowed.
  - Mobile UI: Show Subscribe for `targetUserFound && !isSelf`; ignore taps while `personalList === undefined`; call `api.lists.followUserByUsername` only when `personalList === null`; surface `{ success: false, reason }` with a toast on both Profile and Following rows.

<sup>Written for commit 1d79a3e46efd6d50417d93dd6d9e893955a1330a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a gap where users whose accounts pre-date the personal-list system couldn't be followed. The backend `followUserByUsername` mutation now calls `getOrCreatePersonalList()` to lazily provision a personal list on demand, and both UI screens add a `followUserByUsernameMutation` fallback that is invoked when the client-side `personalList` query returns falsy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the backend change is correct and the two P2 findings are edge-case UX degradations that do not cause data loss or incorrect state.

All findings are P2. The backend logic is sound: Convex's serializable mutation isolation prevents duplicate-list races and the fallback mutation is idempotent. The only concern is that both UI screens use a falsy check that conflates undefined (loading) with null (absent), silently dropping the optimistic update on an early tap — but the mutation still succeeds and the UI corrects via reactive refresh.

apps/expo/src/app/[username]/index.tsx and apps/expo/src/app/(tabs)/following/index.tsx — the else/ternary branches that conflate undefined and null for personalList.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lists.ts | followUserByUsername now calls getOrCreatePersonalList() to lazily provision missing personal lists; logic is correct and Convex's serializable mutation isolation prevents duplicate-creation races. |
| apps/expo/src/app/[username]/index.tsx | Adds followUserByUsernameMutation fallback and removes personalList guard from subscribe button; else branch fires for both undefined (loading) and null (absent), silently dropping optimistic updates on early taps. |
| apps/expo/src/app/(tabs)/following/index.tsx | FeaturedListRow adds followUserByUsernameMutation fallback with same undefined-vs-null ambiguity in handleToggleSubscribe; subscribe button visibility correctly changed to targetUserFound && !isSelf. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI (Profile / Following)
    participant CQ as Convex Query getPersonalListForUser
    participant CM as Convex Mutation

    UI->>CQ: getPersonalListForUser(userId)
    alt personalList exists (Doc returned)
        CQ-->>UI: Doc lists
        UI->>CM: followList with optimistic update
    else personalList is null (confirmed absent)
        CQ-->>UI: null
        UI->>CM: followUserByUsername
        CM->>CM: getOrCreatePersonalList creates list if missing
        CM->>CM: insert listFollows
        CM-->>UI: success true
        UI->>CQ: reactive refresh loads new personalList
    else personalList is undefined (query still loading)
        CQ-->>UI: undefined
        Note over UI: Falls to same branch as null, calls followUserByUsername, skipping optimistic update
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/[username]/index.tsx
Line: 214-221

Comment:
**`else` branch also fires while `personalList` is still loading**

`personalList` is `undefined` while the Convex query is in flight and `null` only when the server confirms the list doesn't exist. Both values reach the `else` branch, so if the user taps the subscribe button before the query resolves, `followUserByUsernameMutation` is called instead of the optimistic `followListMutation` — silently dropping the optimistic update even for accounts that already have a personal list.

Consider guarding the fallback to only the confirmed-missing case:

```suggestion
    if (isFollowingPersonalList && personalList) {
      unfollowListMutation({ listId: personalList.id }).catch(onError);
    } else if (personalList) {
      followListMutation({ listId: personalList.id }).catch(onError);
    } else if (personalList === null) {
      // Confirmed: no personal list yet — ask the server to create and follow it.
      followUserByUsernameMutation({ username: targetUser.username }).catch(
        onError,
      );
    }
    // personalList === undefined means query is still loading; ignore the tap.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/app/(tabs)/following/index.tsx
Line: 185-191

Comment:
**Fallback fires while `personalList` is still loading**

Same pattern as the profile screen: `personalList` is `undefined` while loading and `null` when confirmed absent. In `handleToggleSubscribe`, the `personalList ? … : followUserByUsernameMutation(…)` ternary calls the fallback mutation whenever `personalList` is falsy — including during the load window — which silently skips the optimistic update for users whose list just hasn't resolved yet.

Narrowing to `personalList === null` (and ignoring taps while `undefined`) keeps the optimistic path working for the common case:

```
const promise =
  isSubscribed && personalList
    ? unfollowListMutation({ listId: personalList.id })
    : personalList
      ? followListMutation({ listId: personalList.id })
      : personalList === null
        ? followUserByUsernameMutation({ username })
        : null; // still loading — ignore tap
if (!promise) { isMutatingRef.current = false; return; }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow subscribing to users without ..."](https://github.com/jaronheard/soonlist-turbo/commit/e88b993c9fc7083c3f8b4e559924312868dd9ccd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28918744)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->