### PR TITLE
Disable PostHog session replay to fix iOS scroll jank

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -171,15 +171,10 @@ function RootLayout() {
                   options={{
                     host: "https://us.i.posthog.com",
                     disabled: isDev,
-                    enableSessionReplay: !isDev,
-                    sessionReplayConfig: {
-                      maskAllTextInputs: false,
-                      maskAllImages: false,
-                      captureLog: false,
-                      captureNetworkTelemetry: true,
-                      androidDebouncerDelayMs: 500,
-                      iOSdebouncerDelayMs: 1000,
-                    },
+                    // Session replay disabled — causes scroll jank on iOS
+                    // list views (same symptom class as Sentry's
+                    // mobileReplayIntegration, disabled above).
+                    enableSessionReplay: false,
                   }}
                 >
                   <PostHogIdentityTracker />


### PR DESCRIPTION
## Summary
Disabled PostHog session replay functionality to resolve scroll performance issues on iOS list views.

## Changes
- Set `enableSessionReplay` to `false` (previously `!isDev`)
- Removed the entire `sessionReplayConfig` object and its configuration options
- Added explanatory comment noting that session replay causes scroll jank on iOS list views, similar to the previously disabled Sentry mobile replay integration

## Details
Session replay was causing noticeable scroll jank in iOS list views. This issue is similar to performance problems previously encountered with Sentry's `mobileReplayIntegration`, which was also disabled. The session replay feature is now completely disabled rather than being conditionally enabled in production, as the performance impact outweighs the debugging benefits.

https://claude.ai/code/session_01RqkV5hJLgvzBvakkktVe7p
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled PostHog session replay to eliminate scroll jank on iOS list views. Restores smooth scrolling in feed, following, discover, list detail, and profile screens.

- **Bug Fixes**
  - Set `enableSessionReplay` to `false` (was `!isDev`).
  - Removed `sessionReplayConfig`.
  - Added comment noting replay caused iOS jank, similar to the earlier Sentry replay disable.

<sup>Written for commit 5746f68f287f125bb0edbe6618d487b8fcc60c1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables PostHog session replay in the Expo app by setting `enableSessionReplay: false` and removing the `sessionReplayConfig` block. This mirrors the same fix previously applied to Sentry's `mobileReplayIntegration`, which was commented out for the same reason (iOS scroll jank). All other PostHog functionality — event tracking, screen tracking, and identity tracking — remains active.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with no logic risk.

Single-line targeted fix with a clear comment explaining the rationale. The `isDev` variable remains in use for the `disabled` flag, so no dead code is introduced. No new functionality, no security concerns.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/_layout.tsx | Disables PostHog session replay by setting `enableSessionReplay: false` and removes the `sessionReplayConfig` block; `isDev` is still used for the `disabled` flag, so no dead code is introduced. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): disable PostHog session repla..."](https://github.com/jaronheard/soonlist-turbo/commit/5746f68f287f125bb0edbe6618d487b8fcc60c1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29026042)</sub>

<!-- /greptile_comment -->