### PR TITLE
Refactor batch progress tracking to use Zustand store

### DIFF
--- a/apps/web/app/(base)/layout.tsx
+++ b/apps/web/app/(base)/layout.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from "@soonlist/ui/sonner";
 
+import { BatchStatusToastContainer } from "~/components/BatchStatusToast";
 import { DragAndDropProvider } from "~/components/DragAndDropProvider";
 import { Footer } from "~/components/Footer";
 import { Header } from "~/components/Header";
@@ -16,6 +17,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="h-14" aria-hidden />
         <Toaster />
         <WorkflowStatusToastContainer />
+        <BatchStatusToastContainer />
         <main className="mx-auto min-h-[calc(100vh-4.5rem)] w-full max-w-2xl px-6 pb-16 pt-6 sm:min-h-[calc(100vh-5.75rem)] lg:px-8 lg:py-24">
           {children}
         </main>

--- a/apps/web/app/(minimal)/layout.tsx
+++ b/apps/web/app/(minimal)/layout.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from "@soonlist/ui/sonner";
 
+import { BatchStatusToastContainer } from "~/components/BatchStatusToast";
 import { DragAndDropProvider } from "~/components/DragAndDropProvider";
 import { ImagePasteProvider } from "~/components/ImagePasteProvider";
 import { WorkflowStatusToastContainer } from "~/components/WorkflowStatusToast";
@@ -11,6 +12,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <div className="flex min-h-screen flex-col">
           <Toaster />
           <WorkflowStatusToastContainer />
+          <BatchStatusToastContainer />
           <main className="flex-grow overflow-auto">
             <div className="relative mx-auto w-full max-w-7xl px-6 pb-[7rem] pt-[4.5rem]">
               {children}

--- a/apps/web/components/BatchStatusToast.tsx
+++ b/apps/web/components/BatchStatusToast.tsx
@@ -8,29 +8,24 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-interface UseBatchProgressOptions {
-  batchId: string | null;
+import { useBatchStore } from "~/hooks/useBatchStore";
+
+interface BatchStatusToastProps {
+  batchId: string;
 }
 
-/**
- * Hook to track batch upload progress with updating toast
- * Updates the same toast from loading to success/error state
- */
-export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
+function BatchStatusToast({ batchId }: BatchStatusToastProps) {
   const router = useRouter();
+  const { removeBatchId } = useBatchStore();
   const toastIdRef = useRef<string | number | null>(null);
   const hasShownCompletionRef = useRef(false);
+  const cleanupTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Use Convex query to reactively track batch status
-  const batchStatus = useQuery(
-    api.eventBatches.getBatchStatus,
-    batchId ? { batchId } : "skip",
-  );
+  const batchStatus = useQuery(api.eventBatches.getBatchStatus, { batchId });
 
   useEffect(() => {
     if (!batchStatus) return;
 
-    // Show initial loading toast
     if (batchStatus.status === "processing" && !toastIdRef.current) {
       toastIdRef.current = toast.loading(
         <div className="flex items-center gap-2">
@@ -40,13 +35,11 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
             {batchStatus.totalCount === 1 ? "event" : "events"}...
           </span>
         </div>,
-        {
-          duration: Infinity,
-        },
+        { duration: Infinity },
       );
+      return;
     }
 
-    // Update the same toast when completed/failed (or create a new one if no loading toast exists)
     if (
       (batchStatus.status === "completed" || batchStatus.status === "failed") &&
       !hasShownCompletionRef.current
@@ -56,10 +49,10 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
       const hasErrors = batchStatus.failureCount > 0;
 
       if (hasErrors) {
-        const successCount = batchStatus.successCount;
-        const totalCount = batchStatus.totalCount;
         toast.error(
-          `${successCount} out of ${totalCount} ${totalCount === 1 ? "event" : "events"} captured successfully`,
+          `${batchStatus.successCount} out of ${batchStatus.totalCount} ${
+            batchStatus.totalCount === 1 ? "event" : "events"
+          } captured successfully`,
           {
             id: toastIdRef.current ?? undefined,
             duration: 6000,
@@ -85,19 +78,46 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
         });
       }
 
-      // Clear the ref since the toast is now handled
       toastIdRef.current = null;
-    }
-  }, [batchStatus]);
 
-  // Cleanup: dismiss toast when component unmounts or batchId changes
+      // Remove from store after the toast has had a chance to display
+      cleanupTimeoutRef.current = setTimeout(
+        () => removeBatchId(batchId),
+        6000,
+      );
+    }
+  }, [batchStatus, batchId, router, removeBatchId]);
+
   useEffect(() => {
     return () => {
       if (toastIdRef.current) {
         toast.dismiss(toastIdRef.current);
         toastIdRef.current = null;
       }
-      hasShownCompletionRef.current = false;
+      if (cleanupTimeoutRef.current) {
+        clearTimeout(cleanupTimeoutRef.current);
+        cleanupTimeoutRef.current = null;
+      }
     };
-  }, [batchId]);
+  }, []);
+
+  return null;
+}
+
+export function BatchStatusToastContainer() {
+  const { batchIds } = useBatchStore();
+
+  if (batchIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {batchIds
+        .filter((batchId) => batchId && typeof batchId === "string")
+        .map((batchId) => (
+          <BatchStatusToast key={batchId} batchId={batchId} />
+        ))}
+    </>
+  );
 }

--- a/apps/web/components/BatchStatusToast.tsx
+++ b/apps/web/components/BatchStatusToast.tsx
@@ -81,7 +81,10 @@ function BatchStatusToast({ batchId }: BatchStatusToastProps) {
       toastIdRef.current = null;
 
       cleanupTimeoutRef.current = setTimeout(
-        () => removeBatchId(batchId),
+        () => {
+          cleanupTimeoutRef.current = null;
+          removeBatchId(batchId);
+        },
         hasErrors ? 6000 : 4000,
       );
     }
@@ -96,9 +99,10 @@ function BatchStatusToast({ batchId }: BatchStatusToastProps) {
       if (cleanupTimeoutRef.current) {
         clearTimeout(cleanupTimeoutRef.current);
         cleanupTimeoutRef.current = null;
+        removeBatchId(batchId);
       }
     };
-  }, []);
+  }, [batchId, removeBatchId]);
 
   return null;
 }

--- a/apps/web/components/BatchStatusToast.tsx
+++ b/apps/web/components/BatchStatusToast.tsx
@@ -16,7 +16,7 @@ interface BatchStatusToastProps {
 
 function BatchStatusToast({ batchId }: BatchStatusToastProps) {
   const router = useRouter();
-  const { removeBatchId } = useBatchStore();
+  const removeBatchId = useBatchStore((state) => state.removeBatchId);
   const toastIdRef = useRef<string | number | null>(null);
   const hasShownCompletionRef = useRef(false);
   const cleanupTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -80,7 +80,6 @@ function BatchStatusToast({ batchId }: BatchStatusToastProps) {
 
       toastIdRef.current = null;
 
-      // Remove from store after the toast has had a chance to display
       cleanupTimeoutRef.current = setTimeout(
         () => removeBatchId(batchId),
         6000,
@@ -105,19 +104,13 @@ function BatchStatusToast({ batchId }: BatchStatusToastProps) {
 }
 
 export function BatchStatusToastContainer() {
-  const { batchIds } = useBatchStore();
-
-  if (batchIds.length === 0) {
-    return null;
-  }
+  const batchIds = useBatchStore((state) => state.batchIds);
 
   return (
     <>
-      {batchIds
-        .filter((batchId) => batchId && typeof batchId === "string")
-        .map((batchId) => (
-          <BatchStatusToast key={batchId} batchId={batchId} />
-        ))}
+      {batchIds.map((batchId) => (
+        <BatchStatusToast key={batchId} batchId={batchId} />
+      ))}
     </>
   );
 }

--- a/apps/web/components/BatchStatusToast.tsx
+++ b/apps/web/components/BatchStatusToast.tsx
@@ -82,7 +82,7 @@ function BatchStatusToast({ batchId }: BatchStatusToastProps) {
 
       cleanupTimeoutRef.current = setTimeout(
         () => removeBatchId(batchId),
-        6000,
+        hasErrors ? 6000 : 4000,
       );
     }
   }, [batchStatus, batchId, router, removeBatchId]);

--- a/apps/web/components/DragAndDropProvider.tsx
+++ b/apps/web/components/DragAndDropProvider.tsx
@@ -7,7 +7,6 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useBatchProgress } from "~/hooks/useBatchProgress";
 import { useDragAndDropHandler } from "~/hooks/useDragAndDropHandler";
 import { isTargetPage } from "~/lib/pasteEventUtils";
 
@@ -22,19 +21,13 @@ export function DragAndDropProvider({ children }: DragAndDropProviderProps) {
   // Only enable the drag and drop handler on target pages and when user is authenticated
   const shouldEnable = isTargetPage(pathname) && !!currentUser;
 
-  const { isDragging, imageCount, currentBatchId, hasValidationError } =
-    useDragAndDropHandler({
-      enabled: shouldEnable,
-      onError: (error) => {
-        toast.error(`Failed to process images: ${error.message}`, {
-          duration: 6000, // Increased duration for error toasts
-        });
-      },
-    });
-
-  // Track batch progress with toast notifications
-  useBatchProgress({
-    batchId: currentBatchId,
+  const { isDragging, imageCount, hasValidationError } = useDragAndDropHandler({
+    enabled: shouldEnable,
+    onError: (error) => {
+      toast.error(`Failed to process images: ${error.message}`, {
+        duration: 6000, // Increased duration for error toasts
+      });
+    },
   });
 
   return (

--- a/apps/web/components/ImagePasteProvider.tsx
+++ b/apps/web/components/ImagePasteProvider.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useBatchProgress } from "~/hooks/useBatchProgress";
 import { useImagePasteHandler } from "~/hooks/useImagePasteHandler";
 import { isTargetPage } from "~/lib/pasteEventUtils";
 
@@ -21,18 +20,13 @@ export function ImagePasteProvider({ children }: ImagePasteProviderProps) {
   // Only enable the paste handler on target pages and when user is authenticated
   const shouldEnable = isTargetPage(pathname) && !!currentUser;
 
-  const { currentBatchId } = useImagePasteHandler({
+  useImagePasteHandler({
     enabled: shouldEnable,
     onError: (error) => {
       toast.error(`Failed to process images: ${error.message}`, {
         duration: 6000, // Increased duration for error toasts
       });
     },
-  });
-
-  // Track batch progress with toast notifications
-  useBatchProgress({
-    batchId: currentBatchId,
   });
 
   return <>{children}</>;

--- a/apps/web/hooks/useBatchStore.ts
+++ b/apps/web/hooks/useBatchStore.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { create } from "zustand";
+
+interface BatchStore {
+  batchIds: string[];
+  addBatchId: (batchId: string) => void;
+  removeBatchId: (batchId: string) => void;
+}
+
+export const useBatchStore = create<BatchStore>((set) => ({
+  batchIds: [],
+  addBatchId: (batchId) =>
+    set((state) => ({
+      batchIds: state.batchIds.includes(batchId)
+        ? state.batchIds
+        : [...state.batchIds, batchId],
+    })),
+  removeBatchId: (batchId) =>
+    set((state) => ({
+      batchIds: state.batchIds.filter((id) => id !== batchId),
+    })),
+}));

--- a/apps/web/hooks/useDragAndDropHandler.ts
+++ b/apps/web/hooks/useDragAndDropHandler.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
+import { useBatchStore } from "~/hooks/useBatchStore";
 import {
   generateBatchId,
   generateTempId,
@@ -36,7 +37,6 @@ interface UseDragAndDropHandlerReturn {
   error: string | null;
   lastProcessedImage: string | null;
   imageCount: number; // Number of images being dragged
-  currentBatchId: string | null; // Current batch being processed
   hasValidationError: boolean; // True if dragging too many images
 }
 
@@ -56,7 +56,6 @@ export function useDragAndDropHandler(
     null,
   );
   const [imageCount, setImageCount] = useState(0);
-  const [currentBatchId, setCurrentBatchId] = useState<string | null>(null);
   const [hasValidationError, setHasValidationError] = useState(false);
 
   // Counter to track drag enter/leave for nested elements
@@ -66,6 +65,7 @@ export function useDragAndDropHandler(
   const isProcessingRef = useRef(false);
 
   const createEventBatch = useMutation(api.ai.createEventBatch);
+  const addBatchId = useBatchStore((state) => state.addBatchId);
 
   // Handle drag enter
   const handleDragEnter = useCallback(
@@ -254,8 +254,8 @@ export function useDragAndDropHandler(
         });
 
         if (result.batchId) {
-          // Store the batchId for progress tracking
-          setCurrentBatchId(result.batchId);
+          // Track the batch globally so the status toast survives navigation
+          addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId
           // The backend processes them asynchronously
@@ -287,6 +287,7 @@ export function useDragAndDropHandler(
       currentUser,
       timezone,
       createEventBatch,
+      addBatchId,
       onSuccess,
       onError,
       router,
@@ -350,7 +351,6 @@ export function useDragAndDropHandler(
     error,
     lastProcessedImage,
     imageCount,
-    currentBatchId,
     hasValidationError,
   };
 }

--- a/apps/web/hooks/useDragAndDropHandler.ts
+++ b/apps/web/hooks/useDragAndDropHandler.ts
@@ -254,7 +254,6 @@ export function useDragAndDropHandler(
         });
 
         if (result.batchId) {
-          // Track the batch globally so the status toast survives navigation
           addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId

--- a/apps/web/hooks/useImagePasteHandler.ts
+++ b/apps/web/hooks/useImagePasteHandler.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
+import { useBatchStore } from "~/hooks/useBatchStore";
 import {
   generateBatchId,
   generateTempId,
@@ -33,7 +34,6 @@ interface UseImagePasteHandlerReturn {
   isProcessing: boolean;
   error: string | null;
   lastProcessedImage: string | null;
-  currentBatchId: string | null;
 }
 
 export function useImagePasteHandler(
@@ -50,12 +50,12 @@ export function useImagePasteHandler(
   const [lastProcessedImage, setLastProcessedImage] = useState<string | null>(
     null,
   );
-  const [currentBatchId, setCurrentBatchId] = useState<string | null>(null);
 
   // Synchronous ref lock to prevent duplicate event creation on rapid paste
   const isProcessingRef = useRef(false);
 
   const createEventBatch = useMutation(api.ai.createEventBatch);
+  const addBatchId = useBatchStore((state) => state.addBatchId);
 
   // Helper function to check if paste event should be handled
   const shouldHandlePasteEventInternal = useCallback(
@@ -182,8 +182,8 @@ export function useImagePasteHandler(
         });
 
         if (result.batchId) {
-          // Store the batchId for progress tracking
-          setCurrentBatchId(result.batchId);
+          // Track the batch globally so the status toast survives navigation
+          addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId
           // The backend processes them asynchronously
@@ -215,6 +215,7 @@ export function useImagePasteHandler(
       currentUser,
       timezone,
       createEventBatch,
+      addBatchId,
       onSuccess,
       onError,
       router,
@@ -249,6 +250,5 @@ export function useImagePasteHandler(
     isProcessing,
     error,
     lastProcessedImage,
-    currentBatchId,
   };
 }

--- a/apps/web/hooks/useImagePasteHandler.ts
+++ b/apps/web/hooks/useImagePasteHandler.ts
@@ -182,7 +182,6 @@ export function useImagePasteHandler(
         });
 
         if (result.batchId) {
-          // Track the batch globally so the status toast survives navigation
           addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId


### PR DESCRIPTION
## Summary
Refactored the batch progress tracking system from a hook-based approach to a centralized Zustand store pattern. This improves state management and allows multiple batch operations to be tracked simultaneously with proper cleanup.

## Key Changes
- **Created `useBatchStore`**: New Zustand store to manage active batch IDs with `addBatchId` and `removeBatchId` actions
- **Converted `useBatchProgress` hook to `BatchStatusToast` component**: Changed from a hook that required manual integration to a component-based approach that renders toast notifications
- **Added `BatchStatusToastContainer`**: New container component that renders `BatchStatusToast` for each active batch ID from the store
- **Updated `useDragAndDropHandler` and `useImagePasteHandler`**: Removed `currentBatchId` state and integrated with `useBatchStore` to add batch IDs when processing completes
- **Removed manual hook integration**: Eliminated `useBatchProgress` calls from `DragAndDropProvider` and `ImagePasteProvider`
- **Added container to layouts**: Integrated `BatchStatusToastContainer` into both base and minimal layouts for centralized toast management
- **Improved cleanup**: Added timeout-based cleanup that removes batch IDs from store after toast duration expires

## Implementation Details
- The store prevents duplicate batch IDs using a simple inclusion check
- Toast cleanup now happens automatically via timeout after 6 seconds, removing the batch from the store
- The component-based approach allows multiple concurrent batch operations to display their own toast notifications
- Cleanup refs properly handle timeout cancellation on component unmount

https://claude.ai/code/session_01V9V5U3GTqoZerbxRxx6aeX
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move batch progress tracking to a global `zustand` store so capture status toasts persist across navigation and support multiple concurrent batches. Align cleanup with toast durations and prevent leaked batch IDs to avoid extra subscriptions.

- **Bug Fixes**
  - Toasts persist across route changes and concurrent batches render reliably.
  - Cleanup matches toast durations (4s success, 6s error) and removes IDs on unmount to prevent leaks.

- **Refactors**
  - Added `useBatchStore` with de-duped `addBatchId` and `removeBatchId`.
  - Replaced `useBatchProgress` with `BatchStatusToast` and `BatchStatusToastContainer`; mounted in `(base)` and `(minimal)` layouts.
  - Updated `useDragAndDropHandler` and `useImagePasteHandler` to push batch IDs to the store; removed provider-level progress wiring.

<sup>Written for commit cbad9fef86168fe5fe34fc92e80651580dde012a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors batch progress tracking from a manually-integrated hook (`useBatchProgress`) into a centralized Zustand store (`useBatchStore`) and a headless component pattern (`BatchStatusToast` / `BatchStatusToastContainer`). This lets multiple concurrent batch operations each display their own toast without any per-consumer wiring, and properly cleans up via timeout after toast expiry.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no correctness or data-integrity issues; the one finding is a minor cleanup-timing inefficiency.

All findings are P2 (style/efficiency). The refactoring is logically correct: refs guard against duplicate toasts, store deduplication prevents double-renders, and unmount cleanup properly dismisses loading toasts and cancels pending timeouts.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/components/BatchStatusToast.tsx | Renamed from useBatchProgress hook into a headless component that renders toast notifications per batch ID; logic is sound, minor cleanup-duration mismatch noted |
| apps/web/hooks/useBatchStore.ts | New Zustand store for tracking active batch IDs with dedup guard in addBatchId; correct and minimal |
| apps/web/hooks/useDragAndDropHandler.ts | Replaces local currentBatchId state with addBatchId from Zustand store; dependency array updated correctly |
| apps/web/hooks/useImagePasteHandler.ts | Same store integration as useDragAndDropHandler; currentBatchId state and return value removed cleanly |
| apps/web/components/DragAndDropProvider.tsx | Removed useBatchProgress call and currentBatchId usage; simpler component interface |
| apps/web/components/ImagePasteProvider.tsx | Removed useBatchProgress call; no functional changes beyond cleanup |
| apps/web/app/(base)/layout.tsx | Added BatchStatusToastContainer import and render beside WorkflowStatusToastContainer |
| apps/web/app/(minimal)/layout.tsx | Same BatchStatusToastContainer addition as base layout |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant H as useDragAndDropHandler / useImagePasteHandler
    participant S as useBatchStore
    participant C as BatchStatusToastContainer
    participant T as BatchStatusToast
    participant Q as Convex (getBatchStatus)

    H->>S: addBatchId(batchId)
    S-->>C: batchIds updated → re-render
    C->>T: mount BatchStatusToast
    T->>Q: useQuery(getBatchStatus, {batchId})
    Q-->>T: status = processing
    T->>T: toast.loading(...)
    Q-->>T: status = completed | failed
    T->>T: toast.success / toast.error
    T->>T: setTimeout → removeBatchId
    S-->>C: batchIds updated → re-render
    C->>T: unmount
    T->>T: cleanup: dismiss toast, clearTimeout
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/components/BatchStatusToast.tsx
Line: 83-86

Comment:
**Cleanup timeout doesn't match success toast duration**

The success toast uses `duration: 4000` but the cleanup timeout that unmounts the component is always 6000ms. This keeps the `BatchStatusToast` component mounted (and running a Convex `useQuery`) for 2 extra seconds after the success toast has already dismissed itself.

```suggestion
      cleanupTimeoutRef.current = setTimeout(
        () => removeBatchId(batchId),
        hasErrors ? 6000 : 4000,
      );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): tighten BatchStatusToast ..."](https://github.com/jaronheard/soonlist-turbo/commit/bd265ce75214a102be952bf21c38a69af7415f61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29029129)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->