### PR TITLE
refactor: stop propagating AddToCalendar shape as canonical event type

### DIFF
--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -27,9 +27,8 @@ import { useUser } from "@clerk/clerk-expo";
 import { useQuery } from "convex/react";
 
 import type { EventMetadata } from "@soonlist/cal";
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
-import { getTimezoneAbbreviation } from "@soonlist/cal";
+import { getEventDetails, getTimezoneAbbreviation } from "@soonlist/cal";
 
 import { EventMenu } from "~/components/EventMenu";
 import { HeaderLogo } from "~/components/HeaderLogo";
@@ -205,25 +204,25 @@ function EventDetail({ id }: { id: string }) {
 
   // Pre-calculate the image URI for the event image
   const imageUri = useMemo(() => {
-    if (!event?.event) return null;
+    if (!event) return null;
 
-    const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const eventImage = eventData?.images?.[3];
+    const { images } = getEventDetails(event);
+    const eventImage = images?.[3];
     if (!eventImage) {
       return null;
     }
     return `${eventImage}?max-w=1284&fit=contain&f=webp&q=80`;
-  }, [event?.event?.images]);
+  }, [event]);
 
   // Thumbnail URI matching what the list items cache (used as a placeholder)
   const thumbnailUri = useMemo(() => {
-    if (!event?.event) return null;
+    if (!event) return null;
 
-    const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const eventImage = eventData?.images?.[3];
+    const { images } = getEventDetails(event);
+    const eventImage = images?.[3];
     if (!eventImage) return null;
     return `${eventImage}?w=160&h=160&fit=cover&f=webp&q=80`;
-  }, [event?.event?.images]);
+  }, [event]);
 
   // Build the header-left UI if we can't go back
   const HeaderLeft = useCallback(() => {
@@ -345,7 +344,6 @@ function EventDetail({ id }: { id: string }) {
   }
 
   // Normal render
-  const eventData = event.event as AddToCalendarButtonPropsRestricted;
   const isCurrentUserEvent = currentUser?.id === event.userId;
 
   // Normalize timezones for comparison
@@ -354,7 +352,7 @@ function EventDetail({ id }: { id: string }) {
     return tz.trim().toLowerCase();
   };
 
-  const normalizedEventTz = normalizeTimezone(eventData.timeZone);
+  const normalizedEventTz = normalizeTimezone(event.timeZone);
   const normalizedUserTz = normalizeTimezone(userTimezone);
 
   // Get timezone abbreviation if timezones differ
@@ -362,18 +360,18 @@ function EventDetail({ id }: { id: string }) {
     normalizedEventTz &&
     normalizedUserTz &&
     normalizedEventTz !== normalizedUserTz &&
-    eventData.startTime; // Only show for timed events
+    event.startTime; // Only show for timed events
 
   const timezoneAbbreviation = shouldShowTimezone
-    ? getTimezoneAbbreviation(eventData.timeZone || "")
+    ? getTimezoneAbbreviation(event.timeZone || "")
     : undefined;
 
   // Compute event date/time strings
   const { date, time, eventTime } = formatEventDateRange(
-    eventData.startDate || "",
-    eventData.startTime,
-    eventData.endTime,
-    eventData.timeZone || "",
+    event.startDate || "",
+    event.startTime,
+    event.endTime,
+    event.timeZone || "",
     timezoneAbbreviation,
   );
 
@@ -418,18 +416,18 @@ function EventDetail({ id }: { id: string }) {
               </Text>
             </View>
             <Text className="font-heading text-3xl font-bold text-neutral-1">
-              {eventData.name}
+              {event.name}
             </Text>
           </View>
 
           {/* Meta rows (venue + visibility/author) */}
-          {(eventData.location || showDiscover) && (
+          {(event.location || showDiscover) && (
             <View className="mt-4 flex flex-col gap-2">
               {/* Location link */}
-              {eventData.location && (
+              {event.location && (
                 <Link
                   href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                    eventData.location,
+                    event.location,
                   )}`}
                   asChild
                 >
@@ -437,7 +435,7 @@ function EventDetail({ id }: { id: string }) {
                     <View className="flex-row items-center">
                       <MapPinned size={16} color="#5A32FB" />
                       <Text className="ml-1 text-interactive-1">
-                        {eventData.location}
+                        {event.location}
                       </Text>
                     </View>
                   </Pressable>
@@ -491,7 +489,7 @@ function EventDetail({ id }: { id: string }) {
 
           {/* Description */}
           <View className="mb-3 mt-6">
-            <Text className="text-neutral-1">{eventData.description}</Text>
+            <Text className="text-neutral-1">{event.description}</Text>
           </View>
 
           {/* Metadata Section */}

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -3,8 +3,8 @@ import QRCode from "react-native-qrcode-svg";
 import { router, useLocalSearchParams } from "expo-router";
 import { useQuery } from "convex/react";
 
-import type { AddToCalendarButtonProps } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
+import { getEventDetails } from "@soonlist/cal";
 
 import { X } from "~/components/icons";
 import { Logo } from "~/components/Logo";
@@ -17,10 +17,9 @@ export default function QRModal() {
 
   if (!event) return null;
 
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const eventData = event.event as AddToCalendarButtonProps;
+  const { images } = getEventDetails(event);
   const qrValue = `${Config.apiBaseUrl}/event/${id}`;
-  const eventImage = eventData.images?.[0];
+  const eventImage = images?.[0];
 
   return (
     <View className="flex-1 bg-interactive-3">
@@ -65,7 +64,7 @@ export default function QRModal() {
           />
 
           <Text className="mt-6 text-center text-xl font-semibold text-black">
-            {eventData.name}
+            {event.name}
           </Text>
 
           <Text className="mt-2 text-sm text-zinc-600">

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -19,8 +19,7 @@ import { useUser } from "@clerk/clerk-expo";
 
 import type { api } from "@soonlist/backend/convex/_generated/api";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
-import { getTimezoneAbbreviation } from "@soonlist/cal";
+import { getEventDetails, getTimezoneAbbreviation } from "@soonlist/cal";
 
 import type { EventAttributionVariant } from "~/components/EventAttributionRow";
 import type { EventWithSimilarity } from "~/utils/similarEvents";
@@ -118,7 +117,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
     source,
   });
   const id = event.id;
-  const e = event.event as AddToCalendarButtonPropsRestricted;
+  const { images: eventImages } = getEventDetails(event);
   const userTimezone = useUserTimezone();
 
   // Normalize timezones for comparison
@@ -127,7 +126,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
     return tz.trim().toLowerCase();
   };
 
-  const normalizedEventTz = normalizeTimezone(e.timeZone);
+  const normalizedEventTz = normalizeTimezone(event.timeZone);
   const normalizedUserTz = normalizeTimezone(userTimezone);
 
   // Get timezone abbreviation if timezones differ
@@ -135,32 +134,32 @@ export function UserEventListItem(props: UserEventListItemProps) {
     normalizedEventTz &&
     normalizedUserTz &&
     normalizedEventTz !== normalizedUserTz &&
-    e.startTime; // Only show for timed events
+    event.startTime; // Only show for timed events
 
   const timezoneAbbreviation = shouldShowTimezone
-    ? getTimezoneAbbreviation(e.timeZone || "")
+    ? getTimezoneAbbreviation(event.timeZone || "")
     : undefined;
 
   const dateString = formatEventDateRange(
-    e.startDate || "",
-    e.startTime,
-    e.endTime,
-    e.timeZone || "",
+    event.startDate || "",
+    event.startTime,
+    event.endTime,
+    event.timeZone || "",
     timezoneAbbreviation,
   );
 
   const startDateInfo = useMemo(
-    () => getDateTimeInfo(e.startDate || "", e.startTime || ""),
-    [e.startDate, e.startTime],
+    () => getDateTimeInfo(event.startDate || "", event.startTime || ""),
+    [event.startDate, event.startTime],
   );
 
   const endDateInfo = useMemo(
     () =>
       getDateTimeInfo(
-        e.endDate || e.startDate || "",
-        e.endTime || e.startTime || "",
+        event.endDate || event.startDate || "",
+        event.endTime || event.startTime || "",
       ),
-    [e.endDate, e.startDate, e.endTime, e.startTime],
+    [event.endDate, event.startDate, event.endTime, event.startTime],
   );
 
   const eventIsOver = useMemo(() => {
@@ -182,11 +181,11 @@ export function UserEventListItem(props: UserEventListItemProps) {
 
   // Prefetch the full-size image for the detail screen so it loads instantly
   useEffect(() => {
-    const imageUrl = e.images?.[3];
+    const imageUrl = eventImages?.[3];
     if (imageUrl && typeof imageUrl === "string") {
       void ExpoImage.prefetch(`${imageUrl}?max-w=1284&fit=contain&f=webp&q=80`);
     }
-  }, [e.images]);
+  }, [eventImages]);
 
   const isRecent = useMemo(() => {
     const threeHoursAgoTimestamp = Date.now() - 3 * 60 * 60 * 1000;
@@ -294,15 +293,11 @@ export function UserEventListItem(props: UserEventListItemProps) {
                 backgroundColor: "white",
               }}
             >
-              {e.images?.[3] ? (
+              {eventImages?.[3] ? (
                 <ExpoImage
-                  source={
-                    typeof e.images[3] === "number"
-                      ? e.images[3]
-                      : {
-                          uri: `${e.images[3]}?w=160&h=160&fit=cover&f=webp&q=80`,
-                        }
-                  }
+                  source={{
+                    uri: `${eventImages[3]}?w=160&h=160&fit=cover&f=webp&q=80`,
+                  }}
                   style={{
                     width: imageWidth,
                     height: imageHeight,
@@ -368,16 +363,16 @@ export function UserEventListItem(props: UserEventListItemProps) {
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              {e.name}
+              {event.name}
             </Text>
-            {e.location ? (
+            {event.location ? (
               <View className="mb-1 flex-shrink flex-row items-center">
                 <Text
                   className="text-sm text-neutral-2"
                   numberOfLines={1}
                   ellipsizeMode="tail"
                 >
-                  {e.location}
+                  {event.location}
                 </Text>
               </View>
             ) : null}

--- a/apps/expo/src/hooks/useCalendar.ts
+++ b/apps/expo/src/hooks/useCalendar.ts
@@ -5,7 +5,6 @@ import * as Calendar from "expo-calendar";
 import { Temporal } from "@js-temporal/polyfill";
 
 import type { api } from "@soonlist/backend/convex/_generated/api";
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 
 import type { CalendarAppInfo } from "~/utils/calendarAppDetection";
 import { usePreferredCalendarApp, useSetPreferredCalendarApp } from "~/store";
@@ -105,10 +104,6 @@ export function useCalendar() {
         }
       }
 
-      // The event.event comes from Convex and should match our expected interface
-
-      const calendarEvent = event.event as AddToCalendarButtonPropsRestricted;
-
       // Build enriched description (used for Google Calendar as well)
       const baseUrlForDesc = Config.apiBaseUrl;
       const eventUrlForDesc =
@@ -123,7 +118,7 @@ export function useCalendar() {
           : baseUrlForDesc
             ? `Captured on Soonlist\n(${baseUrlForDesc})`
             : "Captured on Soonlist";
-      const fullDescriptionForGoogle = `${calendarEvent.description}\n\n${additionalTextForDesc}`;
+      const fullDescriptionForGoogle = `${event.description ?? ""}\n\n${additionalTextForDesc}`;
 
       // If Google Calendar is preferred and installed, use it
       if (currentPreferred === "google") {
@@ -132,14 +127,14 @@ export function useCalendar() {
           sourceApps.find((app) => app.id === "google")?.isInstalled === true;
         if (googleInstalled) {
           const googleCalendarUrl = createGoogleCalendarLink({
-            name: calendarEvent.name,
+            name: event.name,
             description: fullDescriptionForGoogle,
-            location: calendarEvent.location,
-            startDate: calendarEvent.startDate,
-            startTime: calendarEvent.startTime,
-            endDate: calendarEvent.endDate,
-            endTime: calendarEvent.endTime,
-            timeZone: calendarEvent.timeZone,
+            location: event.location,
+            startDate: event.startDate,
+            startTime: event.startTime,
+            endDate: event.endDate,
+            endTime: event.endTime,
+            timeZone: event.timeZone,
           });
 
           const canOpen = await Linking.canOpenURL(googleCalendarUrl);
@@ -201,31 +196,23 @@ export function useCalendar() {
         }
       };
 
-      const eventTimezone = calendarEvent.timeZone || Temporal.Now.timeZoneId();
+      const eventTimezone = event.timeZone || Temporal.Now.timeZoneId();
 
       let startDate: Date;
       let endDate: Date;
 
-      if (calendarEvent.startDate && calendarEvent.startTime) {
-        startDate = parseDate(
-          calendarEvent.startDate,
-          calendarEvent.startTime,
-          eventTimezone,
-        );
-      } else if (calendarEvent.startDate) {
-        startDate = parseDate(calendarEvent.startDate, "00:00", eventTimezone);
+      if (event.startDate && event.startTime) {
+        startDate = parseDate(event.startDate, event.startTime, eventTimezone);
+      } else if (event.startDate) {
+        startDate = parseDate(event.startDate, "00:00", eventTimezone);
       } else {
         throw new Error("Start date is required");
       }
 
-      if (calendarEvent.endDate && calendarEvent.endTime) {
-        endDate = parseDate(
-          calendarEvent.endDate,
-          calendarEvent.endTime,
-          eventTimezone,
-        );
-      } else if (calendarEvent.endDate) {
-        endDate = parseDate(calendarEvent.endDate, "23:59", eventTimezone);
+      if (event.endDate && event.endTime) {
+        endDate = parseDate(event.endDate, event.endTime, eventTimezone);
+      } else if (event.endDate) {
+        endDate = parseDate(event.endDate, "23:59", eventTimezone);
       } else {
         endDate = new Date(startDate.getTime() + 60 * 60 * 1000);
       }
@@ -249,13 +236,13 @@ export function useCalendar() {
           ? `Captured by ${displayName} on Soonlist. \nFull details: ${eventUrl}`
           : `Captured on Soonlist\n(${baseUrl})`;
 
-      const fullDescription = `${calendarEvent.description}\n\n${additionalText}`;
+      const fullDescription = `${event.description ?? ""}\n\n${additionalText}`;
 
       const eventDetails = {
-        title: calendarEvent.name,
+        title: event.name,
         startDate,
         endDate,
-        location: calendarEvent.location,
+        location: event.location,
         notes: fullDescription,
         timeZone: eventTimezone,
         url: eventUrl, // iOS only, but included for platforms that support it

--- a/apps/expo/src/hooks/useEventActions.ts
+++ b/apps/expo/src/hooks/useEventActions.ts
@@ -10,7 +10,6 @@ import {
 } from "convex/react";
 import { usePostHog } from "posthog-react-native";
 
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { useToast } from "~/components/Toast";
@@ -160,17 +159,15 @@ export function useEventActions({
     if (!event || checkDemoMode()) return;
     void hapticSuccess();
 
-    const eventData = event.event as AddToCalendarButtonPropsRestricted;
-
     try {
       // Track share initiated
       posthog.capture("share_event_initiated", {
         event_id: event.id,
-        event_title: eventData.name ?? "Unknown",
+        event_title: event.name ?? "Unknown",
         source: source ?? "event_detail",
         is_owner: Boolean(isOwner),
         is_saved: Boolean(isSaved),
-        has_location: !!eventData.location,
+        has_location: !!event.location,
       });
 
       const result = await Share.share({
@@ -181,7 +178,7 @@ export function useEventActions({
       if (result.action === Share.sharedAction) {
         posthog.capture("share_event_completed", {
           event_id: event.id,
-          event_title: eventData.name ?? "Unknown",
+          event_title: event.name ?? "Unknown",
           source: source ?? "event_detail",
           is_owner: Boolean(isOwner),
           is_saved: Boolean(isSaved),
@@ -193,7 +190,7 @@ export function useEventActions({
       } else if (result.action === Share.dismissedAction) {
         posthog.capture("share_event_dismissed", {
           event_id: event.id,
-          event_title: eventData.name ?? "Unknown",
+          event_title: event.name ?? "Unknown",
           source: source ?? "event_detail",
           is_owner: Boolean(isOwner),
           is_saved: Boolean(isSaved),
@@ -212,10 +209,9 @@ export function useEventActions({
   const handleDirections = () => {
     if (!event || checkDemoMode()) return;
     void hapticSuccess();
-    const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    if (eventData.location) {
+    if (event.location) {
       const url = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
-        eventData.location,
+        event.location,
       )}`;
       void Linking.openURL(url);
     } else {

--- a/apps/expo/src/utils/dates.ts
+++ b/apps/expo/src/utils/dates.ts
@@ -1,8 +1,6 @@
 import * as Localization from "expo-localization";
 import { Temporal } from "@js-temporal/polyfill";
 
-import type { AddToCalendarButtonProps } from "@soonlist/cal/types";
-
 import { logError } from "./errorLogging";
 
 // Existing event defaults
@@ -15,17 +13,15 @@ export const blankEvent = {
     "MicrosoftTeams",
     "Outlook.com",
     "Yahoo",
-  ] as
-    | (
-        | "Apple"
-        | "Google"
-        | "iCal"
-        | "Microsoft365"
-        | "MicrosoftTeams"
-        | "Outlook.com"
-        | "Yahoo"
-      )[]
-    | undefined,
+  ] as (
+    | "Apple"
+    | "Google"
+    | "iCal"
+    | "Microsoft365"
+    | "MicrosoftTeams"
+    | "Outlook.com"
+    | "Yahoo"
+  )[],
   buttonStyle: "text" as const,
   name: "Manual entry" as const,
   description: "" as const,
@@ -35,7 +31,7 @@ export const blankEvent = {
   startTime: "" as const,
   endTime: "" as const,
   timeZone: "" as const,
-} as AddToCalendarButtonProps;
+};
 
 const daysOfWeekTemporal = [
   "Monday",

--- a/apps/web/app/(base)/[userName]/PublicListClient.tsx
+++ b/apps/web/app/(base)/[userName]/PublicListClient.tsx
@@ -68,6 +68,15 @@ function transformConvexEventsAsPublic(
       eventFollows: [],
       comments: [],
       eventToLists: [],
+      name: event.name,
+      image: event.image,
+      startDate: event.startDate,
+      startTime: event.startTime,
+      endDate: event.endDate,
+      endTime: event.endTime,
+      location: event.location,
+      timeZone: event.timeZone,
+      description: event.description,
     }));
 }
 

--- a/apps/web/app/(base)/[userName]/upcoming/page.tsx
+++ b/apps/web/app/(base)/[userName]/upcoming/page.tsx
@@ -53,6 +53,15 @@ function transformConvexEvents(
     eventFollows: event.eventFollows,
     comments: [],
     eventToLists: [],
+    name: event.name,
+    image: event.image,
+    startDate: event.startDate,
+    startTime: event.startTime,
+    endDate: event.endDate,
+    endTime: event.endTime,
+    location: event.location,
+    timeZone: event.timeZone,
+    description: event.description,
   }));
 }
 

--- a/apps/web/app/(base)/event/[eventId]/EventPageClient.tsx
+++ b/apps/web/app/(base)/event/[eventId]/EventPageClient.tsx
@@ -5,9 +5,9 @@ import { useQuery } from "convex/react";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import type { EventMetadata } from "@soonlist/cal";
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import type { User } from "@soonlist/validators";
 import { api } from "@soonlist/backend/convex/_generated/api";
+import { getEventDetails } from "@soonlist/cal";
 import { Skeleton } from "@soonlist/ui/skeleton";
 
 import { EventPage } from "~/components/EventDisplays";
@@ -75,10 +75,9 @@ export default function EventPageClient({ eventId }: { eventId: string }) {
     );
   }
 
-  const calendarData = event.event as AddToCalendarButtonPropsRestricted;
   const metadata = event.eventMetadata as EventMetadata;
 
-  const fullImageUrl = calendarData.images?.[3] || null;
+  const fullImageUrl = getEventDetails(event).images?.[3] || null;
 
   const user = event.user ? transformConvexUser(event.user) : undefined;
   const createdAt = new Date(event._creationTime);
@@ -92,7 +91,7 @@ export default function EventPageClient({ eventId }: { eventId: string }) {
         comments={event.comments ?? []}
         key={event.id}
         id={event.id}
-        event={calendarData}
+        event={event}
         eventMetadata={metadata}
         createdAt={createdAt}
         visibility={event.visibility}

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
+import { getEventDetails } from "@soonlist/cal";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
 import EventPageClient from "./EventPageClient";
@@ -33,18 +33,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       };
     }
 
-    const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const eventImage = eventData.images?.[0];
+    const eventImage = getEventDetails(event).images?.[0];
+    const eventName = event.name;
+    const eventDescription = event.description;
 
     // Generate Open Graph metadata with Smart App Banner for iOS
     return {
-      title: `${eventData.name} | Soonlist`,
-      description:
-        eventData.description || `Join ${eventData.name} on Soonlist`,
+      title: `${eventName} | Soonlist`,
+      description: eventDescription || `Join ${eventName} on Soonlist`,
       openGraph: {
-        title: eventData.name || "Event on Soonlist",
-        description:
-          eventData.description || `Join ${eventData.name} on Soonlist`,
+        title: eventName || "Event on Soonlist",
+        description: eventDescription || `Join ${eventName} on Soonlist`,
         type: "website",
         images: eventImage
           ? [
@@ -52,7 +51,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
                 url: eventImage,
                 width: 1200,
                 height: 630,
-                alt: eventData.name || "Event image",
+                alt: eventName || "Event image",
               },
             ]
           : [],
@@ -61,9 +60,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       },
       twitter: {
         card: eventImage ? "summary_large_image" : "summary",
-        title: eventData.name || "Event on Soonlist",
-        description:
-          eventData.description || `Join ${eventData.name} on Soonlist`,
+        title: eventName || "Event on Soonlist",
+        description: eventDescription || `Join ${eventName} on Soonlist`,
         images: eventImage ? [eventImage] : undefined,
       },
       // iOS Smart App Banner - prompts users to open in the Soonlist app

--- a/apps/web/app/(base)/explore/page.tsx
+++ b/apps/web/app/(base)/explore/page.tsx
@@ -45,6 +45,15 @@ function transformConvexEvents(
     eventFollows: [],
     comments: [],
     eventToLists: [],
+    name: event.name,
+    image: event.image,
+    startDate: event.startDate,
+    startTime: event.startTime,
+    endDate: event.endDate,
+    endTime: event.endTime,
+    location: event.location,
+    timeZone: event.timeZone,
+    description: event.description,
   }));
 }
 

--- a/apps/web/app/(base)/explore/posters/page.tsx
+++ b/apps/web/app/(base)/explore/posters/page.tsx
@@ -6,8 +6,8 @@ import Link from "next/link";
 import { usePaginatedQuery } from "convex/react";
 import { Globe2, Grid3X3, List } from "lucide-react";
 
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
+import { getEventDetails } from "@soonlist/cal";
 
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStableTimestamp } from "~/hooks/useStableQuery";
@@ -25,30 +25,18 @@ interface PosterEvent {
   startDateTime: Date;
 }
 
-// Extract first image from event
-function getFirstImage(
-  event: AddToCalendarButtonPropsRestricted,
-): string | null {
-  if (!event.images) return null;
-  if (typeof event.images === "string") return event.images;
-  if (Array.isArray(event.images) && event.images.length > 0)
-    return event.images[0]!;
-  return null;
-}
-
 // Transform Convex events to poster format
 function transformToPosterEvents(
   events: FunctionReturnType<typeof api.feeds.getDiscoverFeed>["page"],
 ): PosterEvent[] {
   return events
     .map((event) => {
-      const eventData = event.event as AddToCalendarButtonPropsRestricted;
-      const image = getFirstImage(eventData);
+      const image = getEventDetails(event).images?.[0];
       if (!image || !event.user) return null;
 
       return {
         id: event.id,
-        name: eventData.name || "Untitled Event",
+        name: event.name || "Untitled Event",
         images: [image],
         user: {
           username: event.user.username,

--- a/apps/web/app/(base)/list/[slug]/ListPageClient.tsx
+++ b/apps/web/app/(base)/list/[slug]/ListPageClient.tsx
@@ -54,6 +54,15 @@ function transformListEvents(
       eventFollows: event.eventFollows ?? [],
       comments: [],
       eventToLists: [],
+      name: event.name,
+      image: event.image,
+      startDate: event.startDate,
+      startTime: event.startTime,
+      endDate: event.endDate,
+      endTime: event.endTime,
+      location: event.location,
+      timeZone: event.timeZone,
+      description: event.description,
     }));
 }
 

--- a/apps/web/components/EventDisplays.tsx
+++ b/apps/web/components/EventDisplays.tsx
@@ -8,16 +8,14 @@ import { atcb_action } from "add-to-calendar-button-react";
 import { Copy, Earth, EyeOff, Instagram, MapPin } from "lucide-react";
 
 import type { DateInfo, EventMetadata, SimilarityDetails } from "@soonlist/cal";
-import type {
-  AddToCalendarButtonPropsRestricted,
-  ATCBActionEventConfig,
-} from "@soonlist/cal/types";
+import type { ATCBActionEventConfig } from "@soonlist/cal/types";
 import type { Comment, EventFollow, List, User } from "@soonlist/validators";
 import {
   eventTimesAreDefined,
   formatRelativeTime,
   getDateInfoUTC,
   getDateTimeInfo,
+  getEventDetails,
 } from "@soonlist/cal";
 
 import type { AddToCalendarCardProps } from "./AddToCalendarCard";
@@ -174,6 +172,22 @@ export function EventMetadataDisplay({
   );
 }
 
+// Narrow shape describing the event fields these display components read.
+// Fulfilled by both `EventWithUser` rows from Convex and
+// `AddToCalendarCardProps` used in the new-event preview flow.
+export interface EventDisplayData {
+  name?: string;
+  description?: string;
+  startDate?: string;
+  startTime?: string;
+  endDate?: string;
+  endTime?: string;
+  timeZone?: string;
+  location?: string;
+  // Raw calendar event blob, used to pull `images` via getEventDetails.
+  event?: unknown;
+}
+
 interface EventListItemProps {
   list?: List; // this is the list that this is a part of
   variant?: "card" | "minimal";
@@ -182,7 +196,7 @@ interface EventListItemProps {
   comments: Comment[];
   id: string;
   createdAt?: Date | string;
-  event: AddToCalendarCardProps;
+  event: EventDisplayData;
   visibility: "public" | "private";
   hideCurator?: boolean;
   showOtherCurators?: boolean;
@@ -202,7 +216,7 @@ interface EventPageProps {
   comments: Comment[];
   id: string;
   createdAt?: Date | string;
-  event: AddToCalendarButtonPropsRestricted;
+  event: EventDisplayData;
   image?: string | null;
   visibility: "public" | "private";
   singleEvent?: boolean;
@@ -575,7 +589,7 @@ function EventActionButtons({
   size,
 }: {
   user?: User;
-  event: AddToCalendarButtonPropsRestricted;
+  event: EventDisplayData;
   id: string;
   isOwner: boolean;
   isFollowing?: boolean;
@@ -590,6 +604,17 @@ function EventActionButtons({
     return <></>;
   }
 
+  const atcbEventConfig: ATCBActionEventConfig = {
+    name: event.name,
+    description: event.description,
+    startDate: event.startDate,
+    startTime: event.startTime,
+    endDate: event.endDate,
+    endTime: event.endTime,
+    timeZone: event.timeZone,
+    location: event.location,
+  };
+
   if (variant === "minimal") {
     const scale =
       size === "sm" ? "transform scale-[0.55] origin-bottom-right" : "";
@@ -598,7 +623,7 @@ function EventActionButtons({
         <ShareButton type="icon" event={event} id={id} />
         <CalendarButton
           type="icon"
-          event={event as ATCBActionEventConfig}
+          event={atcbEventConfig}
           id={id}
           username={user.username}
         />
@@ -648,7 +673,7 @@ function EventActionButtons({
       <ShareButton type="icon" event={event} id={id} />
       <CalendarButton
         type="icon"
-        event={event as ATCBActionEventConfig}
+        event={atcbEventConfig}
         id={id}
         username={user.username}
       />
@@ -678,7 +703,7 @@ export function EventListItem(props: EventListItemProps) {
     (item) => item.userId === clerkUser?.id,
   );
   const image =
-    event.images?.[3] ||
+    getEventDetails(event).images?.[3] ||
     (filePath ? buildDefaultUrl(props.filePath || "") : undefined);
 
   if (!props.variant || props.variant === "minimal") {
@@ -1107,7 +1132,7 @@ export function EventListItem(props: EventListItemProps) {
       <div className="absolute bottom-2 right-2 z-20">
         <EventActionButtons
           user={user}
-          event={event as AddToCalendarButtonPropsRestricted}
+          event={event}
           id={id}
           isOwner={!!isOwner}
           isFollowing={isFollowing}
@@ -1372,8 +1397,19 @@ export function EventPage(props: EventPageProps) {
     return null;
   }
 
+  const atcbEventConfig: ATCBActionEventConfig = {
+    name: event.name,
+    description: event.description,
+    startDate: event.startDate,
+    startTime: event.startTime,
+    endDate: event.endDate,
+    endTime: event.endTime,
+    timeZone: event.timeZone,
+    location: event.location,
+  };
+
   const handleAddToCalendar = () => {
-    const eventForCalendar = { ...event } as ATCBActionEventConfig;
+    const eventForCalendar: ATCBActionEventConfig = { ...atcbEventConfig };
     const displayName =
       user?.displayName || (user?.username ? `@${user.username}` : "");
     const additionalText =
@@ -1448,7 +1484,7 @@ export function EventPage(props: EventPageProps) {
       eventMetadata={props.eventMetadata}
       calendarButton={
         <CalendarButton
-          event={event as ATCBActionEventConfig}
+          event={atcbEventConfig}
           id={id}
           username={user?.username}
           type="button"

--- a/apps/web/components/EventList.tsx
+++ b/apps/web/components/EventList.tsx
@@ -3,7 +3,6 @@
 import { clsx } from "clsx";
 import { useQuery } from "convex/react";
 
-import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import type {
   Comment,
   Event,
@@ -150,7 +149,7 @@ export function EventList({
                       eventFollows={item.eventFollows}
                       comments={item.comments}
                       id={item.id}
-                      event={item.event as AddToCalendarButtonPropsRestricted}
+                      event={item}
                       visibility={item.visibility}
                       lists={item.eventToLists?.map(
                         (list: EventToListsWithList) => list.list,
@@ -202,7 +201,7 @@ export function EventList({
                       eventFollows={item.eventFollows}
                       comments={item.comments}
                       id={item.id}
-                      event={item.event as AddToCalendarButtonPropsRestricted}
+                      event={item}
                       visibility={item.visibility}
                       lists={item.eventToLists?.map(
                         (list: EventToListsWithList) => list.list,
@@ -255,7 +254,7 @@ export function EventList({
                     eventFollows={item.eventFollows}
                     comments={item.comments}
                     id={item.id}
-                    event={item.event as AddToCalendarButtonPropsRestricted}
+                    event={item}
                     visibility={item.visibility}
                     lists={item.eventToLists?.map(
                       (list: EventToListsWithList) => list.list,

--- a/apps/web/components/ShareButton.tsx
+++ b/apps/web/components/ShareButton.tsx
@@ -3,15 +3,23 @@
 import { Share } from "lucide-react";
 import { toast } from "sonner";
 
-import type { AddToCalendarButtonProps } from "@soonlist/cal/types";
 import { Button } from "@soonlist/ui/button";
 
 import { env } from "~/env";
 import { DropdownMenuItem } from "./DropdownMenu";
 
+export interface ShareButtonEventData {
+  name?: string;
+  startDate?: string;
+  startTime?: string;
+  endTime?: string;
+  location?: string;
+  description?: string;
+}
+
 export interface ShareButtonProps {
   id: string;
-  event: AddToCalendarButtonProps;
+  event: ShareButtonEventData;
   type: "button" | "dropdown" | "icon";
 }
 

--- a/packages/cal/src/utils.ts
+++ b/packages/cal/src/utils.ts
@@ -2,6 +2,26 @@ import { Temporal } from "@js-temporal/polyfill";
 
 import type { AddToCalendarButtonProps } from "./types";
 
+export interface EventDetails {
+  images?: string[];
+  description?: string;
+}
+
+export function getEventDetails(event: { event?: unknown }): EventDetails {
+  const blob = event.event;
+  if (!blob || typeof blob !== "object") return {};
+  const { images, description } = blob as {
+    images?: unknown;
+    description?: unknown;
+  };
+  return {
+    images: Array.isArray(images)
+      ? images.filter((i): i is string => typeof i === "string")
+      : undefined,
+    description: typeof description === "string" ? description : undefined,
+  };
+}
+
 export const blankEvent = {
   options: [
     "Apple",

--- a/packages/validators/src/db.ts
+++ b/packages/validators/src/db.ts
@@ -21,6 +21,15 @@ export interface Event {
   endDateTime: Date | string;
   startDateTime: Date | string;
   visibility: "public" | "private";
+  name?: string;
+  image?: string | null;
+  startDate?: string;
+  startTime?: string;
+  endDate?: string;
+  endTime?: string;
+  location?: string;
+  timeZone?: string;
+  description?: string;
 }
 
 export interface EventFollow {


### PR DESCRIPTION
## Summary

- Stops treating `AddToCalendarButtonProps[Restricted]` (a 130-field UI-library type) as the app's canonical event shape. Consumers now read top-level denormalized fields (`name`, `startDate`, `location`, etc.) directly from the Convex event row.
- Adds a small `getEventDetails(event)` helper in `@soonlist/cal` for the two fields that aren't denormalized (`images`, `description`).
- Keeps the AddToCalendar shape only where it genuinely feeds `<AddToCalendarCard>` (event edit page).

## What changed

- `packages/cal/src/utils.ts` — export `getEventDetails()` + `EventDetails` interface
- `packages/validators/src/db.ts` — extend `Event` with optional `name`, `image`, `startDate`, `startTime`, `endDate`, `endTime`, `location`, `timeZone`, `description`
- `apps/web/components/EventDisplays.tsx` — introduce narrow `EventDisplayData` prop shape for `EventListItem`, `EventPage`, `EventActionButtons`; build `ATCBActionEventConfig` inline for `<CalendarButton>` from top-level fields
- `apps/web/components/ShareButton.tsx` — narrow prop shape to `ShareButtonEventData`
- `apps/web/components/EventList.tsx`, `app/(base)/explore/page.tsx`, `app/(base)/[userName]/{upcoming,PublicListClient}.tsx`, `app/(base)/list/[slug]/ListPageClient.tsx` — pass the full Convex row through; transform functions now forward denormalized fields
- `apps/web/app/(base)/event/[eventId]/{page,EventPageClient}.tsx`, `app/(base)/explore/posters/page.tsx` — drop casts; use top-level fields + `getEventDetails` for images
- `apps/expo/src/{hooks/useCalendar,hooks/useEventActions,app/event/[id]/index,app/event/[id]/qr,components/UserEventsList,utils/dates}.ts(x)` — drop casts; read top-level Convex fields; use `getEventDetails` for gallery images
- **Unchanged (intentional):** `apps/web/app/(base)/event/[eventId]/edit/page.tsx` keeps its cast — it's the one legitimate consumer of the AddToCalendar shape. `packages/cal/src/similarEvents.ts` + `apps/expo/src/utils/similarEvents.ts` keep their casts (comparison logic is tied to the blob shape).

## Not changed

- No Convex schema / DB migration — `events.event` stays `v.any()`.
- No runtime behavior changes. This is a pure TypeScript + prop-shape refactor.

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format across all 11 packages)
- [ ] Web: event list renders, event detail page renders, Share button works, `<AddToCalendarCard>` still works on edit page
- [ ] Expo: open an event, tap "Add to Calendar" (both Google and Apple paths), "Share", "Directions", QR screen shows gallery images, feed lists render dates correctly
- [ ] Residual cast audit: `as AddToCalendarButtonProps` remains only in `similarEvents.ts` (both copies), the `blankEvent` template in `packages/cal/src/utils.ts`, and `apps/web/app/(base)/event/[eventId]/edit/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor to stop treating the AddToCalendar blob as the canonical event. Components now read top‑level fields (`name`, `startDate`, `location`, etc.) from Convex rows and use `getEventDetails(event)` for `images` and `description` with no runtime changes.

- **Refactors**
  - Added `getEventDetails()` and `EventDetails` to `@soonlist/cal`.
  - Extended `Event` in `@soonlist/validators` with optional denormalized fields (name, image, dates/times, location, timeZone, description).
  - Updated web and Expo consumers to use top-level fields; introduced narrow prop shapes (`EventDisplayData`, `ShareButtonEventData`); build `ATCBActionEventConfig` inline for `CalendarButton`.
  - Kept the AddToCalendar shape only where needed (`<AddToCalendarCard>` on edit and similarity utils); removed casts across affected files.

- **Migration**
  - Read `event.name`, `event.startDate`, `event.location`, etc. directly; use `getEventDetails(event)` for `images`/`description`.
  - Only cast to AddToCalendar when feeding `<AddToCalendarCard>` or similarity helpers.
  - No schema changes or behavior changes.

<sup>Written for commit 490762473cd5d50613f45244495255fb5d34b96a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the 130-field `AddToCalendarButtonProps[Restricted]` type as the app's canonical event shape with a narrow `EventDisplayData` interface, reading denormalized top-level fields (`name`, `startDate`, `location`, etc.) directly from the Convex row and reserving the blob cast only for the edit page. The `getEventDetails()` helper is introduced for `images` (not yet denormalized at the top level).

- The top-level `title` metadata tag in `page.tsx` lacks the `|| \"Event\"` fallback that is correctly applied to `openGraph.title` and `twitter.title`, so an event missing the top-level `name` field would produce `\"undefined | Soonlist\"` in the browser tab.
- The `description` field returned by `getEventDetails()` is never consumed — all callers read `event.description` directly — leaving it as dead code in the `EventDetails` interface.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the missing title fallback — all other changes are clean type narrowing with no runtime regressions.

One genuine defect: the top-level `title` metadata in `page.tsx` can render "undefined | Soonlist" when `event.name` is absent, while the OG/Twitter equivalents already have the guard. Everything else — the EventDisplayData prop shape, getEventDetails helper for images, CalendarButton options (set inside the component itself), and the Expo refactor — is correct and well-scoped.

apps/web/app/(base)/event/[eventId]/page.tsx — missing fallback on the top-level title tag.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/app/(base)/event/[eventId]/page.tsx | Drops blob cast in favour of top-level fields; top-level `title` tag lacks the fallback present on OG/Twitter tags, so undefined `name` renders "undefined | Soonlist". |
| packages/cal/src/utils.ts | Adds `getEventDetails()` helper to safely extract `images` (and `description`) from the raw Convex blob; `description` return field is unused by all callers. |
| packages/validators/src/db.ts | Extends `Event` with optional denormalized fields (`name`, `startDate`, `location`, etc.); correctly mirrors the Convex row shape. |
| apps/web/components/EventDisplays.tsx | Introduces narrow `EventDisplayData` prop interface and builds `ATCBActionEventConfig` inline instead of casting; `CalendarButton` already sets `options`, so no regression there. |
| apps/web/components/ShareButton.tsx | Narrows prop type from full `AddToCalendarButtonProps` to a small `ShareButtonEventData` interface — clean improvement. |
| apps/web/app/(base)/event/[eventId]/EventPageClient.tsx | Drops `AddToCalendarButtonPropsRestricted` cast; uses `getEventDetails(event).images` for the hero image and passes the full Convex row as `EventDisplayData`. |
| apps/expo/src/hooks/useCalendar.ts | Now reads `event.name`, `event.startDate`, etc. directly from the Convex row instead of the blob; date parsing and Google/Apple calendar paths look correct. |
| apps/expo/src/app/event/[id]/qr.tsx | Switches to `getEventDetails(event).images` and `event.name` directly; straightforward drop of the blob cast. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ConvexRow["Convex Event Row\n(top-level fields: name, startDate,\nlocation, timeZone, …\nevent blob: v.any())"]

    subgraph "Before this PR"
        OldCast["as AddToCalendarButtonPropsRestricted\n(130-field cast)"]
        OldComponents["EventListItem / EventPage /\nEventActionButtons"]
        OldCast --> OldComponents
    end

    subgraph "After this PR"
        TopLevel["Top-level denormalized fields\n(name, startDate, location, …)"]
        Blob["event.event blob"]
        Helper["getEventDetails(event)\n→ images"]
        NarrowType["EventDisplayData\n(8 optional fields)"]
        ATCB["ATCBActionEventConfig\n(built inline)"]
        NewComponents["EventListItem / EventPage /\nEventActionButtons"]
        EditPage["Edit Page\n(still uses blob cast ✓)"]

        TopLevel --> NarrowType
        Blob --> Helper
        Helper -->|images| NewComponents
        NarrowType --> NewComponents
        NarrowType --> ATCB
        ATCB --> CalendarButton["CalendarButton /\natcb_action"]
    end

    ConvexRow --> OldCast
    ConvexRow --> TopLevel
    ConvexRow --> Blob
    ConvexRow --> EditPage
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/app/(base)/event/[eventId]/page.tsx
Line: 42

Comment:
**Missing fallback in `title` metadata**

`eventName` is `string | undefined` (the new `Event.name` field is optional), so this template literal produces `"undefined | Soonlist"` for any event that doesn't have the top-level `name` denormalized yet. The `openGraph.title` and `twitter.title` fields already apply the `|| "Event on Soonlist"` guard — the same guard is missing here.

```suggestion
      title: `${eventName ?? "Event"} | Soonlist`,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/cal/src/utils.ts
Line: 5-22

Comment:
**`description` in `EventDetails` is dead code**

The PR description states `description` is one of the two fields "not denormalized," but callers throughout the codebase read `event.description` directly from the top-level Convex row (e.g. `EventDisplays.tsx` builds `atcbEventConfig.description = event.description`, and `page.tsx` reads `const eventDescription = event.description`). The `description` extracted by `getEventDetails()` is never consumed. Either remove `description` from `EventDetails` to keep the helper focused solely on `images`, or switch callers to use `getEventDetails(event).description` to make the intent consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: stop propagating AddToCalendar..."](https://github.com/jaronheard/soonlist-turbo/commit/490762473cd5d50613f45244495255fb5d34b96a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29048767)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->