### PR TITLE
Optimize ScenePreviewThreeUp image loading with query parameters

### DIFF
--- a/apps/expo/src/components/ScenePreviewThreeUp.tsx
+++ b/apps/expo/src/components/ScenePreviewThreeUp.tsx
@@ -41,7 +41,7 @@ export function ScenePreviewThreeUp({
           {uri ? (
             <Image
               source={{
-                uri: `${uri}?w=168&h=216&fit=cover&f=webp&q=80`,
+                uri: `${uri}${uri.includes("?") ? "&" : "?"}w=168&h=216&fit=cover&f=webp&q=80`,
               }}
               style={{ width: "100%", height: "100%" }}
               contentFit="cover"

--- a/apps/expo/src/components/ScenePreviewThreeUp.tsx
+++ b/apps/expo/src/components/ScenePreviewThreeUp.tsx
@@ -40,7 +40,9 @@ export function ScenePreviewThreeUp({
         >
           {uri ? (
             <Image
-              source={{ uri }}
+              source={{
+                uri: `${uri}?w=168&h=216&fit=cover&f=webp&q=80`,
+              }}
               style={{ width: "100%", height: "100%" }}
               contentFit="cover"
               cachePolicy="disk"


### PR DESCRIPTION
## Summary
Updated the image source URL in ScenePreviewThreeUp component to include query parameters for optimized image delivery.

## Key Changes
- Added query parameters to the image URI in ScenePreviewThreeUp component:
  - `w=168&h=216` - Specifies optimized dimensions for the preview thumbnail
  - `fit=cover` - Ensures the image covers the specified dimensions
  - `f=webp` - Requests WebP format for better compression
  - `q=80` - Sets quality level to 80 for optimal file size vs quality balance

## Implementation Details
The image source now dynamically constructs the URL with optimization parameters, allowing the image service to deliver appropriately sized and formatted assets. This reduces bandwidth usage and improves loading performance for the three-up scene preview layout.

https://claude.ai/code/session_01Pg2huvX62B3NbSHqpiDu5r
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize ScenePreviewThreeUp thumbnail loading by appending CDN params for a 168x216 WebP (fit=cover, q=80) and safely handling URLs that already have query strings. This cuts payload and speeds up the three-up preview.

Params added: w=168&h=216&fit=cover&f=webp&q=80.

<sup>Written for commit db0e64ca4b8fe83b0e2c7d865e4e1aa0a60ac09b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends CDN image-optimization query parameters (`w=168&h=216&fit=cover&f=webp&q=80`) to image source URIs in the `ScenePreviewThreeUp` component, reducing bandwidth by requesting appropriately sized WebP images at 3× the rendered display size (56×72 px) for high-DPI screens. The change is minimal and well-scoped with one minor hardening opportunity noted inline.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line optimization with no logic changes and only a minor defensive-coding suggestion remaining.

The only finding is a P2 style suggestion about guarding against pre-existing query parameters in URIs. Based on the codebase, image URLs are stored as plain CDN base URLs with no existing params, so there is no present defect. All remaining feedback is non-blocking.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/ScenePreviewThreeUp.tsx | Appends CDN image-optimization query params (dimensions 168×216 @ 3x, WebP, q=80, fit=cover) to the image source URI; straightforward performance improvement with one minor robustness concern around URIs that already contain query parameters. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as ScenePreviewThreeUp
    participant CDN as Image CDN

    App->>CDN: GET {uri}?w=168&h=216&fit=cover&f=webp&q=80
    CDN-->>App: Resized WebP image (168×216, q=80)
    Note over App: Rendered at 56×72 px (3× for HiDPI)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/ScenePreviewThreeUp.tsx
Line: 44

Comment:
**URL double query-string if URI already has params**

If any `uri` stored in the database ever contains existing query parameters, the resulting URL becomes `...?existingParam=value?w=168&h=216...` — an invalid second `?`. A more robust construction guards against this:

```suggestion
                uri: `${uri}${uri.includes("?") ? "&" : "?"}w=168&h=216&fit=cover&f=webp&q=80`,
```

Currently the image URLs appear to be stored as clean base URLs, so this is unlikely to cause issues in practice, but it's a fragile assumption worth hardening.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize ScenePreviewThreeUp thumbnail i..."](https://github.com/jaronheard/soonlist-turbo/commit/e938c4227bb807b8c78a0d51d98bcf97f2cad486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29049372)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->