### PR TITLE
Refactor batch status tracking to use Zustand store

### DIFF
--- a/apps/web/app/(base)/layout.tsx
+++ b/apps/web/app/(base)/layout.tsx
@@ -1,10 +1,7 @@
-import { Toaster } from "@soonlist/ui/sonner";
-
 import { DragAndDropProvider } from "~/components/DragAndDropProvider";
 import { Footer } from "~/components/Footer";
 import { Header } from "~/components/Header";
 import { ImagePasteProvider } from "~/components/ImagePasteProvider";
-import { WorkflowStatusToastContainer } from "~/components/WorkflowStatusToast";
 import { ResetNewEventContext } from "~/context/ResetNewEventContext";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -14,8 +11,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <ResetNewEventContext />
         <Header />
         <div className="h-14" aria-hidden />
-        <Toaster />
-        <WorkflowStatusToastContainer />
         <main className="mx-auto min-h-[calc(100vh-4.5rem)] w-full max-w-2xl px-6 pb-16 pt-6 sm:min-h-[calc(100vh-5.75rem)] lg:px-8 lg:py-24">
           {children}
         </main>

--- a/apps/web/app/(marketing)/layout.tsx
+++ b/apps/web/app/(marketing)/layout.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Toaster } from "@soonlist/ui/sonner";
-
 import { Footer } from "~/components/Footer";
 import { Header } from "~/components/Header";
 import { ResetNewEventContext } from "~/context/ResetNewEventContext";
@@ -12,7 +10,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       <ResetNewEventContext />
       <Header />
       <div className="h-14" aria-hidden />
-      <Toaster />
       <main className="min-h-screen">{children}</main>
       <Footer />
     </div>

--- a/apps/web/app/(minimal)/layout.tsx
+++ b/apps/web/app/(minimal)/layout.tsx
@@ -1,16 +1,11 @@
-import { Toaster } from "@soonlist/ui/sonner";
-
 import { DragAndDropProvider } from "~/components/DragAndDropProvider";
 import { ImagePasteProvider } from "~/components/ImagePasteProvider";
-import { WorkflowStatusToastContainer } from "~/components/WorkflowStatusToast";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <ImagePasteProvider>
       <DragAndDropProvider>
         <div className="flex min-h-screen flex-col">
-          <Toaster />
-          <WorkflowStatusToastContainer />
           <main className="flex-grow overflow-auto">
             <div className="relative mx-auto w-full max-w-7xl px-6 pb-[7rem] pt-[4.5rem]">
               {children}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -7,6 +7,10 @@ import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { posthog } from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 
+import { Toaster } from "@soonlist/ui/sonner";
+
+import { BatchStatusToastContainer } from "~/components/BatchStatusToast";
+import { WorkflowStatusToastContainer } from "~/components/WorkflowStatusToast";
 import ContextProvider from "~/context/ContextProvider";
 import { env } from "~/env";
 import { convex } from "~/lib/convex";
@@ -37,7 +41,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
           <Suspense>
             <IntercomProvider> </IntercomProvider>
           </Suspense>
-          <ContextProvider>{children}</ContextProvider>
+          <ContextProvider>
+            {children}
+            <Toaster />
+            <WorkflowStatusToastContainer />
+            <BatchStatusToastContainer />
+          </ContextProvider>
         </QueryClientProvider>
       </ConvexProviderWithClerk>
     </ClerkProvider>

--- a/apps/web/components/BatchStatusToast.tsx
+++ b/apps/web/components/BatchStatusToast.tsx
@@ -8,29 +8,24 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-interface UseBatchProgressOptions {
-  batchId: string | null;
+import { useBatchStore } from "~/hooks/useBatchStore";
+
+interface BatchStatusToastProps {
+  batchId: string;
 }
 
-/**
- * Hook to track batch upload progress with updating toast
- * Updates the same toast from loading to success/error state
- */
-export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
+function BatchStatusToast({ batchId }: BatchStatusToastProps) {
   const router = useRouter();
+  const removeBatchId = useBatchStore((state) => state.removeBatchId);
   const toastIdRef = useRef<string | number | null>(null);
   const hasShownCompletionRef = useRef(false);
+  const cleanupTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Use Convex query to reactively track batch status
-  const batchStatus = useQuery(
-    api.eventBatches.getBatchStatus,
-    batchId ? { batchId } : "skip",
-  );
+  const batchStatus = useQuery(api.eventBatches.getBatchStatus, { batchId });
 
   useEffect(() => {
     if (!batchStatus) return;
 
-    // Show initial loading toast
     if (batchStatus.status === "processing" && !toastIdRef.current) {
       toastIdRef.current = toast.loading(
         <div className="flex items-center gap-2">
@@ -40,13 +35,11 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
             {batchStatus.totalCount === 1 ? "event" : "events"}...
           </span>
         </div>,
-        {
-          duration: Infinity,
-        },
+        { duration: Infinity },
       );
+      return;
     }
 
-    // Update the same toast when completed/failed (or create a new one if no loading toast exists)
     if (
       (batchStatus.status === "completed" || batchStatus.status === "failed") &&
       !hasShownCompletionRef.current
@@ -56,10 +49,10 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
       const hasErrors = batchStatus.failureCount > 0;
 
       if (hasErrors) {
-        const successCount = batchStatus.successCount;
-        const totalCount = batchStatus.totalCount;
         toast.error(
-          `${successCount} out of ${totalCount} ${totalCount === 1 ? "event" : "events"} captured successfully`,
+          `${batchStatus.successCount} out of ${batchStatus.totalCount} ${
+            batchStatus.totalCount === 1 ? "event" : "events"
+          } captured successfully`,
           {
             id: toastIdRef.current ?? undefined,
             duration: 6000,
@@ -85,19 +78,47 @@ export function useBatchProgress({ batchId }: UseBatchProgressOptions): void {
         });
       }
 
-      // Clear the ref since the toast is now handled
       toastIdRef.current = null;
-    }
-  }, [batchStatus]);
 
-  // Cleanup: dismiss toast when component unmounts or batchId changes
+      cleanupTimeoutRef.current = setTimeout(
+        () => {
+          cleanupTimeoutRef.current = null;
+          removeBatchId(batchId);
+        },
+        hasErrors ? 6000 : 4000,
+      );
+    }
+  }, [batchStatus, batchId, router, removeBatchId]);
+
   useEffect(() => {
     return () => {
       if (toastIdRef.current) {
         toast.dismiss(toastIdRef.current);
         toastIdRef.current = null;
       }
-      hasShownCompletionRef.current = false;
+      if (cleanupTimeoutRef.current) {
+        clearTimeout(cleanupTimeoutRef.current);
+        cleanupTimeoutRef.current = null;
+        removeBatchId(batchId);
+      }
     };
-  }, [batchId]);
+  }, [batchId, removeBatchId]);
+
+  return null;
+}
+
+export function BatchStatusToastContainer() {
+  const batchIds = useBatchStore((state) => state.batchIds);
+
+  if (batchIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {batchIds.map((batchId) => (
+        <BatchStatusToast key={batchId} batchId={batchId} />
+      ))}
+    </>
+  );
 }

--- a/apps/web/components/DragAndDropProvider.tsx
+++ b/apps/web/components/DragAndDropProvider.tsx
@@ -7,7 +7,6 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useBatchProgress } from "~/hooks/useBatchProgress";
 import { useDragAndDropHandler } from "~/hooks/useDragAndDropHandler";
 import { isTargetPage } from "~/lib/pasteEventUtils";
 
@@ -22,19 +21,13 @@ export function DragAndDropProvider({ children }: DragAndDropProviderProps) {
   // Only enable the drag and drop handler on target pages and when user is authenticated
   const shouldEnable = isTargetPage(pathname) && !!currentUser;
 
-  const { isDragging, imageCount, currentBatchId, hasValidationError } =
-    useDragAndDropHandler({
-      enabled: shouldEnable,
-      onError: (error) => {
-        toast.error(`Failed to process images: ${error.message}`, {
-          duration: 6000, // Increased duration for error toasts
-        });
-      },
-    });
-
-  // Track batch progress with toast notifications
-  useBatchProgress({
-    batchId: currentBatchId,
+  const { isDragging, imageCount, hasValidationError } = useDragAndDropHandler({
+    enabled: shouldEnable,
+    onError: (error) => {
+      toast.error(`Failed to process images: ${error.message}`, {
+        duration: 6000, // Increased duration for error toasts
+      });
+    },
   });
 
   return (

--- a/apps/web/components/ImagePasteProvider.tsx
+++ b/apps/web/components/ImagePasteProvider.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useBatchProgress } from "~/hooks/useBatchProgress";
 import { useImagePasteHandler } from "~/hooks/useImagePasteHandler";
 import { isTargetPage } from "~/lib/pasteEventUtils";
 
@@ -21,18 +20,13 @@ export function ImagePasteProvider({ children }: ImagePasteProviderProps) {
   // Only enable the paste handler on target pages and when user is authenticated
   const shouldEnable = isTargetPage(pathname) && !!currentUser;
 
-  const { currentBatchId } = useImagePasteHandler({
+  useImagePasteHandler({
     enabled: shouldEnable,
     onError: (error) => {
       toast.error(`Failed to process images: ${error.message}`, {
         duration: 6000, // Increased duration for error toasts
       });
     },
-  });
-
-  // Track batch progress with toast notifications
-  useBatchProgress({
-    batchId: currentBatchId,
   });
 
   return <>{children}</>;

--- a/apps/web/hooks/useBatchStore.ts
+++ b/apps/web/hooks/useBatchStore.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { create } from "zustand";
+
+interface BatchStore {
+  batchIds: string[];
+  addBatchId: (batchId: string) => void;
+  removeBatchId: (batchId: string) => void;
+}
+
+export const useBatchStore = create<BatchStore>((set) => ({
+  batchIds: [],
+  addBatchId: (batchId) =>
+    set((state) => ({
+      batchIds: state.batchIds.includes(batchId)
+        ? state.batchIds
+        : [...state.batchIds, batchId],
+    })),
+  removeBatchId: (batchId) =>
+    set((state) => ({
+      batchIds: state.batchIds.filter((id) => id !== batchId),
+    })),
+}));

--- a/apps/web/hooks/useDragAndDropHandler.ts
+++ b/apps/web/hooks/useDragAndDropHandler.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
+import { useBatchStore } from "~/hooks/useBatchStore";
 import {
   generateBatchId,
   generateTempId,
@@ -36,7 +37,6 @@ interface UseDragAndDropHandlerReturn {
   error: string | null;
   lastProcessedImage: string | null;
   imageCount: number; // Number of images being dragged
-  currentBatchId: string | null; // Current batch being processed
   hasValidationError: boolean; // True if dragging too many images
 }
 
@@ -56,7 +56,6 @@ export function useDragAndDropHandler(
     null,
   );
   const [imageCount, setImageCount] = useState(0);
-  const [currentBatchId, setCurrentBatchId] = useState<string | null>(null);
   const [hasValidationError, setHasValidationError] = useState(false);
 
   // Counter to track drag enter/leave for nested elements
@@ -66,6 +65,7 @@ export function useDragAndDropHandler(
   const isProcessingRef = useRef(false);
 
   const createEventBatch = useMutation(api.ai.createEventBatch);
+  const addBatchId = useBatchStore((state) => state.addBatchId);
 
   // Handle drag enter
   const handleDragEnter = useCallback(
@@ -254,8 +254,7 @@ export function useDragAndDropHandler(
         });
 
         if (result.batchId) {
-          // Store the batchId for progress tracking
-          setCurrentBatchId(result.batchId);
+          addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId
           // The backend processes them asynchronously
@@ -287,6 +286,7 @@ export function useDragAndDropHandler(
       currentUser,
       timezone,
       createEventBatch,
+      addBatchId,
       onSuccess,
       onError,
       router,
@@ -350,7 +350,6 @@ export function useDragAndDropHandler(
     error,
     lastProcessedImage,
     imageCount,
-    currentBatchId,
     hasValidationError,
   };
 }

--- a/apps/web/hooks/useImagePasteHandler.ts
+++ b/apps/web/hooks/useImagePasteHandler.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { TimezoneContext } from "~/context/TimezoneContext";
+import { useBatchStore } from "~/hooks/useBatchStore";
 import {
   generateBatchId,
   generateTempId,
@@ -33,7 +34,6 @@ interface UseImagePasteHandlerReturn {
   isProcessing: boolean;
   error: string | null;
   lastProcessedImage: string | null;
-  currentBatchId: string | null;
 }
 
 export function useImagePasteHandler(
@@ -50,12 +50,12 @@ export function useImagePasteHandler(
   const [lastProcessedImage, setLastProcessedImage] = useState<string | null>(
     null,
   );
-  const [currentBatchId, setCurrentBatchId] = useState<string | null>(null);
 
   // Synchronous ref lock to prevent duplicate event creation on rapid paste
   const isProcessingRef = useRef(false);
 
   const createEventBatch = useMutation(api.ai.createEventBatch);
+  const addBatchId = useBatchStore((state) => state.addBatchId);
 
   // Helper function to check if paste event should be handled
   const shouldHandlePasteEventInternal = useCallback(
@@ -182,8 +182,7 @@ export function useImagePasteHandler(
         });
 
         if (result.batchId) {
-          // Store the batchId for progress tracking
-          setCurrentBatchId(result.batchId);
+          addBatchId(result.batchId);
 
           // For multi-image batches, we don't get a single workflowId
           // The backend processes them asynchronously
@@ -215,6 +214,7 @@ export function useImagePasteHandler(
       currentUser,
       timezone,
       createEventBatch,
+      addBatchId,
       onSuccess,
       onError,
       router,
@@ -249,6 +249,5 @@ export function useImagePasteHandler(
     isProcessing,
     error,
     lastProcessedImage,
-    currentBatchId,
   };
 }


### PR DESCRIPTION
## Summary
Refactored the batch upload progress tracking system from a hook-based approach to a component-based architecture using Zustand for state management. This change centralizes toast notifications and improves the handling of multiple concurrent batch uploads.

## Key Changes

- **Created `useBatchStore` hook**: New Zustand store to manage active batch IDs globally, replacing local state management in individual handlers
- **Converted `useBatchProgress` hook to `BatchStatusToast` component**: Changed from a hook that required manual integration to a self-contained component that renders nothing but manages its own toast lifecycle
- **Added `BatchStatusToastContainer` component**: New container component that renders `BatchStatusToast` components for all active batches, enabling support for multiple concurrent uploads
- **Centralized toast providers**: Moved `Toaster` and status toast containers to the root `providers.tsx` instead of individual layout files, ensuring consistent availability across all routes
- **Simplified handler hooks**: Removed `currentBatchId` return values from `useDragAndDropHandler` and `useImagePasteHandler`, replacing local state management with calls to `useBatchStore.addBatchId()`
- **Improved cleanup logic**: Added timeout-based cleanup in `BatchStatusToast` to automatically remove batch IDs from the store after toast notifications complete

## Implementation Details

- The `BatchStatusToast` component now handles its own lifecycle, including cleanup via timeout after success/error states
- Multiple batch uploads can now be tracked simultaneously, each with its own toast notification
- The store prevents duplicate batch IDs from being added
- Toast providers are now globally available rather than layout-specific, improving consistency

https://claude.ai/code/session_01Djd5H9kma94YUegB6Lhprn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors batch upload progress tracking from a hook-based approach to a Zustand-backed component architecture. `BatchStatusToast` now self-manages its toast lifecycle, `BatchStatusToastContainer` supports concurrent uploads, and `Toaster`/status containers are hoisted to `providers.tsx` so toast state survives client-side navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues; all remaining findings are P2 style suggestions.

The core refactor is correct: the Zustand store deduplicates batch IDs, cleanup via timeout matches toast duration, the unmount cleanup effect handles the pending-timeout case correctly, and centralising the Toaster in providers.tsx fixes the cross-navigation regression. Only P2 concerns remain (separate store vs single-store convention; no hard timeout for stuck batches).

apps/web/hooks/useBatchStore.ts and apps/web/components/BatchStatusToast.tsx warrant a second glance for the Zustand single-store convention and the missing stuck-batch guard.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/hooks/useBatchStore.ts | New Zustand store for active batch IDs with deduplication; deviates from single-store convention and action-selector pattern from project guidelines. |
| apps/web/components/BatchStatusToast.tsx | Self-contained component that manages toast lifecycle and batch subscription; cleanup logic is correct but no cap on how long a "processing" batch can block resources. |
| apps/web/app/providers.tsx | Toaster, WorkflowStatusToastContainer, and BatchStatusToastContainer centralised here so toasts persist across navigation — the intended fix. |
| apps/web/hooks/useDragAndDropHandler.ts | Calls addBatchId via store after createEventBatch succeeds; currentBatchId local state removed cleanly. |
| apps/web/hooks/useImagePasteHandler.ts | Same refactor as useDragAndDropHandler — local batch ID state removed, store used for registration. |
| apps/web/app/(base)/layout.tsx | Toaster removed from layout; providers.tsx now owns it globally. |
| apps/web/app/(marketing)/layout.tsx | Toaster removed; no other meaningful changes. |
| apps/web/app/(minimal)/layout.tsx | Unchanged layout structure; providers now supply Toaster globally. |
| apps/web/components/DragAndDropProvider.tsx | currentBatchId usage removed; drag-overlay UI unchanged. |
| apps/web/components/ImagePasteProvider.tsx | Thin provider unchanged; hook now handles batch registration via store internally. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Handler as useDragAndDropHandler / useImagePasteHandler
    participant Store as useBatchStore
    participant Container as BatchStatusToastContainer
    participant Toast as BatchStatusToast
    participant Convex

    User->>Handler: Drop / Paste images
    Handler->>Convex: createEventBatch(batchId, images)
    Convex-->>Handler: { batchId }
    Handler->>Store: addBatchId(batchId)
    Store-->>Container: batchIds updated
    Container->>Toast: render BatchStatusToast
    Toast->>Convex: useQuery(getBatchStatus, batchId)
    Convex-->>Toast: status = processing
    Toast->>Toast: toast.loading(duration: Infinity)
    Convex-->>Toast: status = completed or failed
    Toast->>Toast: toast.success/error
    Toast->>Toast: setTimeout → removeBatchId(batchId)
    Store-->>Container: batchIds updated (removed)
    Container->>Toast: unmount
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/components/BatchStatusToast.tsx
Line: 29-39

Comment:
**No timeout guard for perpetually-processing batches**

If the backend never transitions a batch from `"processing"` to `"completed"` or `"failed"` (e.g. a silent backend failure), the loading toast is shown with `duration: Infinity` and the `BatchStatusToast` component — along with its Convex subscription — stays alive forever. There's no watchdog timeout to clean up after a maximum wait period.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/hooks/useBatchStore.ts
Line: 11-23

Comment:
**Separate Zustand store vs. single-store guideline**

The Zustand style guide (`.cursor/rules/zustand.mdc`) recommends keeping a single store rather than creating multiple stores. `useBatchStore` is a standalone store separate from the existing store. Additionally, the guide recommends calling actions via auto-generated selectors (`useStore.use.addBatchId()`), but callers use the inline-selector pattern `useBatchStore((s) => s.addBatchId)` throughout the PR. Both are minor, but worth aligning with the established convention.

**Context Used:** Guidelines for optimal Zustand store usage, coveri... ([source](https://app.greptile.com/review/custom-context?memory=23b1dfae-2cae-4fc2-99a7-521f20cec72d))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): restore capture status toast a..."](https://github.com/jaronheard/soonlist-turbo/commit/036fd17d0e7d44ce2624724fda80c7f69388e0b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29054380)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Guidelines for optimal Zustand store usage, coveri... ([source](https://app.greptile.com/review/custom-context?memory=23b1dfae-2cae-4fc2-99a7-521f20cec72d))

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored batch upload status tracking to a global `zustand` store and centralized toasts. Status toasts now persist across navigation and support multiple concurrent uploads.

- **Refactors**
  - Added `useBatchStore` (`zustand`) for global batch ID tracking.
  - Replaced `useBatchProgress` with `BatchStatusToast` and `BatchStatusToastContainer`.
  - Moved `Toaster` (`@soonlist/ui/sonner`) and `WorkflowStatusToastContainer` to `providers.tsx`.
  - Updated drag-and-drop and paste handlers to call `useBatchStore.addBatchId()` with timeout-based cleanup.

<sup>Written for commit 036fd17d0e7d44ce2624724fda80c7f69388e0b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

