### PR TITLE
Expo polish: public profiles, onboarding, feed loading, and attribution

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/01-try-it.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/01-try-it.tsx
@@ -182,14 +182,14 @@ export default function TryItScreen() {
     <QuestionContainer
       question={
         phase === "result"
-          ? "That's it!"
+          ? "Captured!"
           : phase === "parsing"
             ? "Capturing..."
             : "Capture any event"
       }
       subtitle={
         phase === "result"
-          ? "Screenshots become organized events, automatically"
+          ? "Screenshots become events you can share and add to calendar."
           : phase === "parsing"
             ? undefined
             : "Screenshots, pictures of flyers, and links"

--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Pressable, Text, View } from "react-native";
+import { Linking, Pressable, Text, View } from "react-native";
 import * as StoreReview from "expo-store-review";
 
 import { Check } from "~/components/icons";
@@ -14,10 +14,16 @@ import {
 import { hapticLight } from "~/utils/feedback";
 
 const BULLETS = [
-  "Free to save events & share lists",
-  "Built for real life, not algorithms",
-  "Community supported — optional supporter perks",
+  "Save events and share lists, free",
+  "No ads. No algorithm. No data sold.",
+  "Support for extras, not access",
 ];
+
+const JARON_INSTAGRAM_URL = "https://www.instagram.com/jaronherad/";
+
+function openJaronInstagram() {
+  void Linking.openURL(JARON_INSTAGRAM_URL);
+}
 
 export default function CommunitySupportedScreen() {
   const pendingFollowUsername = usePendingFollowUsername();
@@ -48,8 +54,8 @@ export default function CommunitySupportedScreen() {
 
   return (
     <QuestionContainer
-      question="Free to use. Community supported."
-      subtitle="Soonlist is an invitation to real life — not a feed."
+      question="Soonlist is free."
+      subtitle="Free because community access matters. You can support the app and unlock extras, but the essentials stay free for everyone."
       currentStep={currentStep}
       totalSteps={totalSteps}
     >
@@ -67,8 +73,19 @@ export default function CommunitySupportedScreen() {
 
         <View>
           <Text className="mb-4 text-center text-sm text-white/70">
-            No ads. No algorithms. All features are free — supporter perks come
-            later.
+            💖 Built in Portland by{" "}
+            <Text
+              accessibilityRole="link"
+              accessibilityLabel="Jaron on Instagram"
+              className="text-sm text-white underline"
+              onPress={() => {
+                void hapticLight();
+                openJaronInstagram();
+              }}
+            >
+              Jaron
+            </Text>
+            {" "}& friends
           </Text>
           <Pressable
             onPress={handleContinue}

--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -19,7 +19,7 @@ const BULLETS = [
   "Support for extras, not access",
 ];
 
-const JARON_INSTAGRAM_URL = "https://www.instagram.com/jaronherad/";
+const JARON_INSTAGRAM_URL = "https://www.instagram.com/jaronheard/";
 
 function openJaronInstagram() {
   void Linking.openURL(JARON_INSTAGRAM_URL);

--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -84,8 +84,8 @@ export default function CommunitySupportedScreen() {
               }}
             >
               Jaron
-            </Text>
-            {" "}& friends
+            </Text>{" "}
+            & friends
           </Text>
           <Pressable
             onPress={handleContinue}

--- a/apps/expo/src/app/(onboarding)/onboarding/05-sign-in.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/05-sign-in.tsx
@@ -41,6 +41,7 @@ export default function OnboardingSignInScreen() {
       imageSlot={<OrbitStage />}
       dark
       progress={{ current: currentStep, total: totalSteps }}
+      onboardingFooterAlign
     />
   );
 }

--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -62,8 +62,9 @@ function DiscoverContent() {
     }
   }, [status, loadMore]);
 
-  const savedEventIds = new Set(
-    savedEventIdsQuery?.map((event) => event.id) ?? [],
+  const savedEventIds = useMemo(
+    () => new Set(savedEventIdsQuery?.map((event) => event.id) ?? []),
+    [savedEventIdsQuery],
   );
 
   // Add missing properties that UserEventsList expects and filter out ended events

--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -1,4 +1,3 @@
-import type { FunctionReturnType } from "convex/server";
 import React, { useCallback, useMemo } from "react";
 import { Redirect } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";

--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -1,6 +1,5 @@
 import type { FunctionReturnType } from "convex/server";
 import React, { useCallback, useMemo } from "react";
-import { Text, TouchableOpacity, useWindowDimensions } from "react-native";
 import { Redirect } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 import {
@@ -13,58 +12,11 @@ import {
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import DiscoverShareBanner from "~/components/DiscoverShareBanner";
-import { ShareIcon } from "~/components/icons";
 import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
-import SaveButton from "~/components/SaveButton";
 import UserEventsList from "~/components/UserEventsList";
-import { useEventActions } from "~/hooks/useEventActions";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
 import { getPlanStatusFromUser } from "~/utils/plan";
-
-type DiscoverEvent = NonNullable<FunctionReturnType<typeof api.events.get>>;
-
-function SaveOrShareActionButton({
-  event,
-  savedEventIds,
-  currentUser,
-}: {
-  event: DiscoverEvent;
-  savedEventIds: Set<string>;
-  currentUser: { id: string } | null | undefined;
-}) {
-  const { fontScale } = useWindowDimensions();
-  const iconSize = 16 * fontScale;
-  const isSaved = savedEventIds.has(event.id);
-  const { handleShare } = useEventActions({
-    event,
-    isSaved,
-    source: "discover_list",
-  });
-
-  // Only show save/share button for authenticated users
-  if (!currentUser) {
-    return null;
-  }
-
-  const isOwnEvent = event.userId === currentUser.id;
-
-  return isOwnEvent ? (
-    <TouchableOpacity
-      className="-mb-0.5 -ml-2.5 flex-row items-center gap-2 bg-interactive-2 px-4 py-2.5"
-      style={{ borderRadius: 16 }}
-      onPress={handleShare}
-      accessibilityLabel="Share"
-      accessibilityRole="button"
-      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-    >
-      <ShareIcon size={iconSize * 1.1} color="#5A32FB" />
-      <Text className="text-base font-bold text-interactive-1">Share</Text>
-    </TouchableOpacity>
-  ) : (
-    <SaveButton eventId={event.id} isSaved={isSaved} source="discover_list" />
-  );
-}
 
 function DiscoverContent() {
   const { user } = useUser();
@@ -94,7 +46,7 @@ function DiscoverContent() {
     },
   );
 
-  // Memoize saved events query args to prevent unnecessary re-renders
+  // Memoize saved events query args to avoid unnecessary re-renders
   const savedEventsQueryArgs = useMemo(() => {
     if (!canAccessDiscover || !user?.username) return "skip";
     return { userName: user.username };
@@ -147,17 +99,10 @@ function DiscoverContent() {
       onEndReached={handleLoadMore}
       isFetchingNextPage={status === "LoadingMore"}
       listBodyLoading={status === "LoadingFirstPage"}
-      ActionButton={({ event }) => (
-        <SaveOrShareActionButton
-          event={event}
-          savedEventIds={savedEventIds}
-          currentUser={user}
-        />
-      )}
       showCreator="always"
-      isDiscoverFeed={true}
       primaryAction="save"
       savedEventIds={savedEventIds}
+      source="discover_list"
       HeaderComponent={DiscoverShareBanner}
     />
   );

--- a/apps/expo/src/app/(tabs)/discover.tsx
+++ b/apps/expo/src/app/(tabs)/discover.tsx
@@ -1,11 +1,6 @@
 import type { FunctionReturnType } from "convex/server";
 import React, { useCallback, useMemo } from "react";
-import {
-  Text,
-  TouchableOpacity,
-  useWindowDimensions,
-  View,
-} from "react-native";
+import { Text, TouchableOpacity, useWindowDimensions } from "react-native";
 import { Redirect } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 import {
@@ -19,7 +14,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import DiscoverShareBanner from "~/components/DiscoverShareBanner";
 import { ShareIcon } from "~/components/icons";
-import LoadingSpinner from "~/components/LoadingSpinner";
+import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
 import SaveButton from "~/components/SaveButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useEventActions } from "~/hooks/useEventActions";
@@ -151,7 +146,7 @@ function DiscoverContent() {
       events={enrichedEvents}
       onEndReached={handleLoadMore}
       isFetchingNextPage={status === "LoadingMore"}
-      isLoadingFirstPage={status === "LoadingFirstPage"}
+      listBodyLoading={status === "LoadingFirstPage"}
       ActionButton={({ event }) => (
         <SaveOrShareActionButton
           event={event}
@@ -174,10 +169,7 @@ export default function Page() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-interactive-3">
-          <View className="h-[100px]" />
-          <LoadingSpinner />
-        </View>
+        <MatchAuthLoadingSurface />
       </AuthLoading>
 
       <Unauthenticated>

--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -22,12 +22,14 @@ import { usePostHog } from "posthog-react-native";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import LoadingSpinner from "~/components/LoadingSpinner";
+import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
 import UserEventsList from "~/components/UserEventsList";
 import { useShareListPrompt } from "~/hooks/useShareListPrompt";
 import { useShareMyList } from "~/hooks/useShareMyList";
+import { useStableFeedListBodyLoading } from "~/hooks/useStableFeedListBodyLoading";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
+import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type Segment = "upcoming" | "past";
 
@@ -117,6 +119,9 @@ function MyFeedContent() {
     initialNumItems: 50,
   });
 
+  const { listBodyLoading, markSegmentSwitchPending } =
+    useStableFeedListBodyLoading(status);
+
   // Memoize saved events query args to prevent unnecessary re-renders
   const savedEventsQueryArgs = useMemo(() => {
     if (!user?.username) return "skip";
@@ -134,8 +139,9 @@ function MyFeedContent() {
     }
   }, [status, loadMore]);
 
-  const savedEventIds = new Set(
-    savedEventIdsQuery?.map((event) => event.id) ?? [],
+  const savedEventIds = useMemo(
+    () => new Set(savedEventIdsQuery?.map((event) => event.id) ?? []),
+    [savedEventIdsQuery],
   );
 
   // Transform grouped events into the format UserEventsList expects
@@ -165,16 +171,14 @@ function MyFeedContent() {
       }),
     }));
 
-    // Client-side safety filter: hide events that have ended (upcoming only)
-    if (selectedSegment === "upcoming") {
-      const currentTime = new Date(stableTimestamp).getTime();
-      return events.filter((item) => {
-        const eventEndTime = new Date(item.event.endDateTime).getTime();
-        return eventEndTime >= currentTime;
-      });
-    }
-
-    return events;
+    const stableMs = new Date(stableTimestamp).getTime();
+    return events.filter((item) =>
+      eventMatchesFeedSegment(
+        item.event.endDateTime,
+        selectedSegment,
+        stableMs,
+      ),
+    );
   }, [groupedEvents, stableTimestamp, selectedSegment]);
 
   const upcomingCount =
@@ -224,9 +228,13 @@ function MyFeedContent() {
     }
   }, [enrichedEvents.length, selectedSegment, setMyListBadgeCount]);
 
-  const handleSegmentChange = useCallback((segment: Segment) => {
-    setSelectedSegment(segment);
-  }, []);
+  const handleSegmentChange = useCallback(
+    (segment: Segment) => {
+      markSegmentSwitchPending();
+      setSelectedSegment(segment);
+    },
+    [markSegmentSwitchPending],
+  );
 
   const HeaderComponent = useCallback(() => {
     return (
@@ -291,7 +299,7 @@ function MyFeedContent() {
       groupedEvents={enrichedEvents}
       onEndReached={handleLoadMore}
       isFetchingNextPage={status === "LoadingMore"}
-      isLoadingFirstPage={false}
+      listBodyLoading={listBodyLoading}
       showCreator="savedFromOthers"
       showSourceStickers
       savedEventIds={savedEventIds}
@@ -309,10 +317,7 @@ function MyFeed() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-interactive-3">
-          <View className="h-[100px]" />
-          <LoadingSpinner />
-        </View>
+        <MatchAuthLoadingSurface />
       </AuthLoading>
 
       <Unauthenticated>

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -240,7 +240,7 @@ function FollowingFeedContent() {
           className="mb-1 text-base font-medium text-neutral-2"
           style={{ paddingLeft: 6 }}
         >
-          Events from lists I subscribe to
+          Events from Soonlists I subscribe to
         </Text>
         {followedListCount > 0 && (
           <TouchableOpacity

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -22,12 +22,14 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { DefaultEmptyState } from "~/components/DefaultEmptyState";
 import { FollowedListsModal } from "~/components/FollowedListsModal";
-import LoadingSpinner from "~/components/LoadingSpinner";
+import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
 import { ReferralEmptyState } from "~/components/ReferralEmptyState";
 import UserEventsList from "~/components/UserEventsList";
+import { useStableFeedListBodyLoading } from "~/hooks/useStableFeedListBodyLoading";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
+import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type Segment = "upcoming" | "past";
 
@@ -124,15 +126,13 @@ function FollowingFeedContent() {
       // Reset to the default segment so the onboarding confirmation count and
       // the subsequent feed view both reflect upcoming events, not whatever
       // segment the user had picked under their prior subscriptions.
+      // No markSegmentSwitchPending: unfollow-all clears followings, so the
+      // paginated feed query is skipped — not a segment refetch race.
       setSelectedSegment("upcoming");
     }
   }, [followedLists, hasFollowings, emptyStateMode]);
   const handleExitEmptyState = useCallback(() => {
     setEmptyStateMode("dismissed");
-  }, []);
-
-  const handleSegmentChange = useCallback((segment: Segment) => {
-    setSelectedSegment(segment);
   }, []);
 
   // Memoize query args
@@ -154,6 +154,20 @@ function FollowingFeedContent() {
     },
   );
 
+  const { listBodyLoading, markSegmentSwitchPending } =
+    useStableFeedListBodyLoading(status, {
+      enabled: hasFollowings,
+      extraLoading: followedLists === undefined,
+    });
+
+  const handleSegmentChange = useCallback(
+    (segment: Segment) => {
+      markSegmentSwitchPending();
+      setSelectedSegment(segment);
+    },
+    [markSegmentSwitchPending],
+  );
+
   // Memoize saved events query args
   const savedEventsQueryArgs = useMemo(() => {
     if (!user?.username) return "skip";
@@ -171,20 +185,17 @@ function FollowingFeedContent() {
     }
   }, [status, loadMore]);
 
-  const savedEventIds = new Set(
-    savedEventIdsQuery?.map((event) => event.id) ?? [],
+  const savedEventIds = useMemo(
+    () => new Set(savedEventIdsQuery?.map((event) => event.id) ?? []),
+    [savedEventIdsQuery],
   );
 
-  // Filter events client-side
   const enrichedEvents = useMemo(() => {
-    const currentTime = new Date(stableTimestamp).getTime();
+    const stableMs = new Date(stableTimestamp).getTime();
     return events
-      .filter((event) => {
-        const eventEndTime = new Date(event.endDateTime).getTime();
-        return selectedSegment === "upcoming"
-          ? eventEndTime >= currentTime
-          : eventEndTime < currentTime;
-      })
+      .filter((event) =>
+        eventMatchesFeedSegment(event.endDateTime, selectedSegment, stableMs),
+      )
       .map((event) => ({
         ...event,
         comments: [],
@@ -329,7 +340,7 @@ function FollowingFeedContent() {
         events={enrichedEvents}
         onEndReached={handleLoadMore}
         isFetchingNextPage={status === "LoadingMore"}
-        isLoadingFirstPage={followedLists === undefined}
+        listBodyLoading={listBodyLoading}
         showCreator="always"
         primaryAction="save"
         showSourceStickers
@@ -348,10 +359,7 @@ function FollowingFeed() {
   return (
     <>
       <AuthLoading>
-        <View className="flex-1 bg-interactive-3">
-          <View className="h-[100px]" />
-          <LoadingSpinner />
-        </View>
+        <MatchAuthLoadingSurface />
       </AuthLoading>
 
       <Unauthenticated>

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -18,22 +18,16 @@ import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import {
-  Globe,
-  Instagram,
-  Mail,
-  Phone,
-  User,
-} from "~/components/icons";
+import { Globe, Instagram, Mail, Phone, User } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
-import { useLoadMoreHandler } from "~/hooks/useUpcomingFeed";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
+import { useLoadMoreHandler } from "~/hooks/useUpcomingFeed";
 import { useStableTimestamp } from "~/store";
-import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
+import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type ProfileSegment = "upcoming" | "past";
 
@@ -190,9 +184,7 @@ function ProfileHeroAndSoonlist({
     Boolean(websiteTrimmed);
 
   const lastUpdatedLine =
-    lastUpdatedAt === undefined
-      ? "…"
-      : formatLastUpdated(lastUpdatedAt);
+    lastUpdatedAt === undefined ? "…" : formatLastUpdated(lastUpdatedAt);
 
   return (
     <View className="px-4 pb-2 pt-2">
@@ -312,9 +304,7 @@ function ProfileHeroAndSoonlist({
               }}
               modifiers={[pickerStyle("segmented")]}
             >
-              <SwiftUIText modifiers={[tag("upcoming")]}>
-                Upcoming
-              </SwiftUIText>
+              <SwiftUIText modifiers={[tag("upcoming")]}>Upcoming</SwiftUIText>
               <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
             </Picker>
           </Host>
@@ -331,8 +321,7 @@ function ProfileHeroAndSoonlist({
 
 export default function UserProfilePage() {
   const params = useLocalSearchParams<{ username: string }>();
-  const username =
-    typeof params.username === "string" ? params.username : "";
+  const username = typeof params.username === "string" ? params.username : "";
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const [selectedSegment, setSelectedSegment] =
@@ -482,12 +471,7 @@ export default function UserProfilePage() {
         onSegmentChange={setSelectedSegment}
       />
     );
-  }, [
-    targetUser,
-    listTitle,
-    lastUpdatedAt,
-    selectedSegment,
-  ]);
+  }, [targetUser, listTitle, lastUpdatedAt, selectedSegment]);
 
   if (isUserLoading) {
     return (

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,11 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import {
-  ActivityIndicator,
-  Text,
-  TouchableOpacity,
-  useWindowDimensions,
-  View,
-} from "react-native";
+import { ActivityIndicator, Text, View } from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
@@ -13,13 +7,10 @@ import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import type { Event } from "~/components/UserEventsList";
-import { ShareIcon, User } from "~/components/icons";
-import SaveButton from "~/components/SaveButton";
+import { User } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
-import { useEventActions } from "~/hooks/useEventActions";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import {
   useLoadMoreHandler,
@@ -44,52 +35,6 @@ function profileLocationFromUser(user: {
     }
   }
   return null;
-}
-
-function ProfileSaveShareActionButton({
-  event,
-  savedEventIds,
-  currentUser,
-  isAuthenticated,
-}: {
-  event: Event;
-  savedEventIds: Set<string>;
-  currentUser: { id: string } | null | undefined;
-  isAuthenticated: boolean;
-}) {
-  const { fontScale } = useWindowDimensions();
-  const iconSize = 16 * fontScale;
-  const isSaved = savedEventIds.has(event.id);
-  const { handleShare } = useEventActions({
-    event,
-    isSaved,
-    source: "user_profile",
-  });
-
-  if (!isAuthenticated || !currentUser) {
-    return null;
-  }
-  const isOwnEvent = event.userId === currentUser.id;
-
-  if (isOwnEvent) {
-    return (
-      <TouchableOpacity
-        className="-mb-0.5 -ml-2.5 flex-row items-center gap-2 bg-interactive-2 px-4 py-2.5"
-        style={{ borderRadius: 16 }}
-        onPress={handleShare}
-        accessibilityLabel="Share"
-        accessibilityRole="button"
-        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-      >
-        <ShareIcon size={iconSize * 1.1} color="#5A32FB" />
-        <Text className="text-base font-bold text-interactive-1">Share</Text>
-      </TouchableOpacity>
-    );
-  }
-
-  return (
-    <SaveButton eventId={event.id} isSaved={isSaved} source="user_profile" />
-  );
 }
 
 export default function UserProfilePage() {
@@ -293,17 +238,9 @@ export default function UserProfilePage() {
           isFetchingNextPage={status === "LoadingMore"}
           listBodyLoading={status === "LoadingFirstPage"}
           showCreator="never"
-          isDiscoverFeed={false}
           primaryAction={isOwnProfile ? "addToCalendar" : "save"}
-          ActionButton={({ event }) => (
-            <ProfileSaveShareActionButton
-              event={event}
-              savedEventIds={savedEventIds}
-              currentUser={currentUser}
-              isAuthenticated={isAuthenticated}
-            />
-          )}
           savedEventIds={savedEventIds}
+          source="user_profile"
           HeaderComponent={renderListHeader}
         />
       </View>

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -149,6 +149,26 @@ type ProfileUser = NonNullable<
   FunctionReturnType<typeof api.users.getByUsername>
 >;
 
+type PublicFeedCountPart = { count: number; capped: boolean };
+
+/** Matches `PUBLIC_FEED_COUNT_CAP` in `packages/backend/convex/feeds.ts`. */
+const PUBLIC_FEED_COUNT_CAP = 50;
+
+function formatPublicFeedCount(part: PublicFeedCountPart): string {
+  return part.capped ? `${PUBLIC_FEED_COUNT_CAP}+` : String(part.count);
+}
+
+/** Exact sum when known; round "50+" if either segment hits the cap. */
+function publicFeedAllTimeLabel(
+  upcoming: PublicFeedCountPart,
+  past: PublicFeedCountPart,
+): string {
+  if (!upcoming.capped && !past.capped) {
+    return String(upcoming.count + past.count);
+  }
+  return `${PUBLIC_FEED_COUNT_CAP}+`;
+}
+
 function ProfileHeroAndSoonlist({
   user,
   listTitle,
@@ -158,14 +178,18 @@ function ProfileHeroAndSoonlist({
 }: {
   user: ProfileUser;
   listTitle: string;
-  feedCounts: { upcoming: number; past: number } | undefined;
+  feedCounts:
+    | { upcoming: PublicFeedCountPart; past: PublicFeedCountPart }
+    | undefined;
   selectedSegment: ProfileSegment;
   onSegmentChange: (s: ProfileSegment) => void;
 }) {
   const locationLine = profileLocationFromUser(user);
   const memberLine = formatMemberSince(user.created_at);
-  const totalPublic =
-    feedCounts !== undefined ? feedCounts.upcoming + feedCounts.past : null;
+  const totalPublicLabel =
+    feedCounts !== undefined
+      ? publicFeedAllTimeLabel(feedCounts.upcoming, feedCounts.past)
+      : null;
 
   const displayName =
     user.displayName?.trim() || `@${user.username}`;
@@ -270,8 +294,10 @@ function ProfileHeroAndSoonlist({
         <Text className="mt-1 text-sm text-neutral-2">
           {feedCounts !== undefined ? (
             <>
-              {feedCounts.upcoming} upcoming
-              {totalPublic !== null ? ` · ${totalPublic} events all-time` : ""}
+              {formatPublicFeedCount(feedCounts.upcoming)} upcoming
+              {totalPublicLabel !== null
+                ? ` · ${totalPublicLabel} events all-time`
+                : ""}
             </>
           ) : (
             "…"

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -205,8 +205,7 @@ export default function UserProfilePage() {
       <Stack.Screen
         options={{
           title: screenTitle,
-          headerLargeTitle: true,
-          headerLargeTitleStyle: { color: "#5A32FB" },
+          headerLargeTitle: false,
           headerTransparent: true,
           headerBlurEffect: "none",
           headerShadowVisible: false,

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -291,7 +291,7 @@ export default function UserProfilePage() {
           events={filteredEvents}
           onEndReached={handleLoadMore}
           isFetchingNextPage={status === "LoadingMore"}
-          isLoadingFirstPage={status === "LoadingFirstPage"}
+          listBodyLoading={status === "LoadingFirstPage"}
           showCreator="never"
           isDiscoverFeed={false}
           primaryAction={isOwnProfile ? "addToCalendar" : "save"}

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,5 +1,13 @@
-import React, { useCallback, useMemo } from "react";
-import { ActivityIndicator, Text, View } from "react-native";
+import type { FunctionReturnType } from "convex/server";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
@@ -11,13 +19,14 @@ import { User } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
+import { useLoadMoreHandler } from "~/hooks/useUpcomingFeed";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
-import {
-  useLoadMoreHandler,
-  useUpcomingEventsFilter,
-} from "~/hooks/useUpcomingFeed";
+import { useStableTimestamp } from "~/store";
+import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
+
+type ProfileSegment = "upcoming" | "past";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -37,10 +46,255 @@ function profileLocationFromUser(user: {
   return null;
 }
 
+function formatMemberSince(createdAtIso: string): string {
+  const d = new Date(createdAtIso);
+  if (Number.isNaN(d.getTime())) return "";
+  const now = new Date();
+  const days = (now.getTime() - d.getTime()) / 86_400_000;
+  if (days <= 30) {
+    return "New member";
+  }
+  return `Since ${d.toLocaleDateString(undefined, { month: "long", year: "numeric" })}`;
+}
+
+function websiteHref(raw: string): string {
+  const t = raw.trim();
+  if (t.startsWith("http://") || t.startsWith("https://")) {
+    return t;
+  }
+  return `https://${t}`;
+}
+
+function instaHref(raw: string): string {
+  const t = raw.trim();
+  if (t.startsWith("http://") || t.startsWith("https://")) {
+    return t;
+  }
+  const handle = t.replace(/^@/, "");
+  return `https://instagram.com/${handle}`;
+}
+
+function ProfileSegmentToggle({
+  selected,
+  onChange,
+}: {
+  selected: ProfileSegment;
+  onChange: (s: ProfileSegment) => void;
+}) {
+  return (
+    <View className="mt-3 flex-row rounded-lg bg-neutral-4/40 p-1">
+      <TouchableOpacity
+        className={`flex-1 items-center rounded-md py-2 ${
+          selected === "upcoming" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => onChange("upcoming")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: selected === "upcoming" }}
+        accessibilityLabel="Upcoming events"
+      >
+        <Text
+          className={
+            selected === "upcoming"
+              ? "font-semibold text-neutral-1"
+              : "text-neutral-2"
+          }
+        >
+          Upcoming
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        className={`flex-1 items-center rounded-md py-2 ${
+          selected === "past" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => onChange("past")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: selected === "past" }}
+        accessibilityLabel="Past events"
+      >
+        <Text
+          className={
+            selected === "past"
+              ? "font-semibold text-neutral-1"
+              : "text-neutral-2"
+          }
+        >
+          Past
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function ProfileLinkRow({
+  label,
+  onPress,
+}: {
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="link"
+      className="mt-1 active:opacity-70"
+    >
+      <Text className="text-sm font-medium text-interactive-1" numberOfLines={2}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+type ProfileUser = NonNullable<
+  FunctionReturnType<typeof api.users.getByUsername>
+>;
+
+function ProfileHeroAndSoonlist({
+  user,
+  listTitle,
+  feedCounts,
+  selectedSegment,
+  onSegmentChange,
+}: {
+  user: ProfileUser;
+  listTitle: string;
+  feedCounts: { upcoming: number; past: number } | undefined;
+  selectedSegment: ProfileSegment;
+  onSegmentChange: (s: ProfileSegment) => void;
+}) {
+  const locationLine = profileLocationFromUser(user);
+  const memberLine = formatMemberSince(user.created_at);
+  const totalPublic =
+    feedCounts !== undefined ? feedCounts.upcoming + feedCounts.past : null;
+
+  const displayName =
+    user.displayName?.trim() || `@${user.username}`;
+
+  return (
+    <View className="px-4 pb-2 pt-2">
+      <View className="flex-row gap-4">
+        <UserProfileFlair username={user.username} size="lg">
+          {user.userImage ? (
+            <Image
+              source={{ uri: user.userImage }}
+              style={{ width: 80, height: 80, borderRadius: 40 }}
+              contentFit="cover"
+              cachePolicy="disk"
+            />
+          ) : (
+            <View className="h-20 w-20 items-center justify-center rounded-full bg-neutral-4">
+              <User size={40} color="#627496" />
+            </View>
+          )}
+        </UserProfileFlair>
+
+        <View className="min-w-0 flex-1">
+          <Text
+            className="text-xl font-bold text-neutral-1"
+            numberOfLines={2}
+          >
+            {displayName}
+          </Text>
+          <Text className="text-sm text-neutral-2">@{user.username}</Text>
+
+          {user.bio?.trim() ? (
+            <Text className="mt-2 text-sm leading-5 text-neutral-1">
+              {user.bio.trim()}
+            </Text>
+          ) : null}
+
+          {locationLine ? (
+            <Text
+              className="mt-2 text-sm text-neutral-2"
+              numberOfLines={2}
+            >
+              {locationLine}
+            </Text>
+          ) : null}
+
+          {memberLine ? (
+            <Text className="mt-1 text-sm text-neutral-2">{memberLine}</Text>
+          ) : null}
+
+          {user.publicEmail?.trim() ? (
+            <ProfileLinkRow
+              label={user.publicEmail.trim()}
+              onPress={() => {
+                void Linking.openURL(
+                  `mailto:${encodeURIComponent(user.publicEmail!.trim())}`,
+                );
+              }}
+            />
+          ) : null}
+
+          {user.publicPhone?.trim() ? (
+            <ProfileLinkRow
+              label={user.publicPhone.trim()}
+              onPress={() => {
+                const n = user.publicPhone!.replace(/[^\d+]/g, "");
+                void Linking.openURL(`tel:${n}`);
+              }}
+            />
+          ) : null}
+
+          {user.publicInsta?.trim() ? (
+            <ProfileLinkRow
+              label={`Instagram: @${user.publicInsta.trim().replace(/^@/, "")}`}
+              onPress={() => {
+                void Linking.openURL(instaHref(user.publicInsta!));
+              }}
+            />
+          ) : null}
+
+          {user.publicWebsite?.trim() ? (
+            <ProfileLinkRow
+              label={user.publicWebsite.trim()}
+              onPress={() => {
+                void Linking.openURL(websiteHref(user.publicWebsite!));
+              }}
+            />
+          ) : null}
+        </View>
+      </View>
+
+      <View className="mt-5 border-t border-neutral-4/80 pt-4">
+        <Text className="text-xs font-semibold uppercase tracking-wide text-neutral-2">
+          Soonlist
+        </Text>
+        <Text
+          className="mt-1 text-lg font-bold text-interactive-1"
+          numberOfLines={2}
+        >
+          {listTitle}
+        </Text>
+        <Text className="mt-1 text-sm text-neutral-2">
+          {feedCounts !== undefined ? (
+            <>
+              {feedCounts.upcoming} upcoming
+              {totalPublic !== null ? ` · ${totalPublic} events all-time` : ""}
+            </>
+          ) : (
+            "…"
+          )}
+        </Text>
+        <ProfileSegmentToggle
+          selected={selectedSegment}
+          onChange={onSegmentChange}
+        />
+      </View>
+    </View>
+  );
+}
+
 export default function UserProfilePage() {
-  const { username } = useLocalSearchParams<{ username: string }>();
+  const params = useLocalSearchParams<{ username: string }>();
+  const username =
+    typeof params.username === "string" ? params.username : "";
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
+  const [selectedSegment, setSelectedSegment] =
+    useState<ProfileSegment>("upcoming");
+  const stableTimestamp = useStableTimestamp();
 
   const targetUser = useQuery(
     api.users.getByUsername,
@@ -52,6 +306,11 @@ export default function UserProfilePage() {
   const personalList = useQuery(
     api.lists.getPersonalListForUser,
     targetUser?.id ? { userId: targetUser.id } : "skip",
+  );
+
+  const feedCounts = useQuery(
+    api.feeds.getPublicUserFeedCounts,
+    targetUser ? { username } : "skip",
   );
 
   const followListMutation = useMutation(
@@ -89,22 +348,31 @@ export default function UserProfilePage() {
     savedEventIdsQuery?.map((event) => event.id) ?? [],
   );
 
+  const feedQueryArgs = useMemo(
+    () =>
+      username
+        ? {
+            username,
+            filter: selectedSegment,
+          }
+        : "skip",
+    [username, selectedSegment],
+  );
+
   const {
     results: events,
     status,
     loadMore,
-  } = useStablePaginatedQuery(
-    api.feeds.getPublicUserFeed,
-    username
-      ? {
-          username: username,
-          filter: "upcoming" as const,
-        }
-      : "skip",
-    { initialNumItems: 50 },
-  );
+  } = useStablePaginatedQuery(api.feeds.getPublicUserFeed, feedQueryArgs, {
+    initialNumItems: 50,
+  });
 
-  const filteredEvents = useUpcomingEventsFilter(events);
+  const displayEvents = useMemo(() => {
+    const stableMs = new Date(stableTimestamp).getTime();
+    return events.filter((e) =>
+      eventMatchesFeedSegment(e.endDateTime, selectedSegment, stableMs),
+    );
+  }, [events, selectedSegment, stableTimestamp]);
 
   const handleLoadMore = useLoadMoreHandler(status, loadMore);
 
@@ -128,6 +396,14 @@ export default function UserProfilePage() {
     ? followingIds.has(personalList.id)
     : false;
 
+  const listTitle = useMemo(() => {
+    if (!targetUser) return "";
+    const fromList = personalList?.name?.trim();
+    const fromUser = targetUser.publicListName?.trim();
+    const fallback = `${targetUser.displayName?.trim() || targetUser.username}'s Soonlist`;
+    return fromList || fromUser || fallback;
+  }, [targetUser, personalList]);
+
   const handleFollowListPress = useCallback(() => {
     if (!personalList) return;
     if (!isAuthenticated) {
@@ -150,21 +426,25 @@ export default function UserProfilePage() {
     router,
   ]);
 
-  const listHeader = useMemo(() => {
+  const renderListHeader = useCallback(() => {
     if (!targetUser) {
-      return <></>;
+      return null;
     }
-    const upcomingCount = filteredEvents.length;
-
     return (
-      <ProfileIdentityHeader
+      <ProfileHeroAndSoonlist
         user={targetUser}
-        upcomingEventCount={upcomingCount}
+        listTitle={listTitle}
+        feedCounts={feedCounts}
+        selectedSegment={selectedSegment}
+        onSegmentChange={setSelectedSegment}
       />
     );
-  }, [targetUser, filteredEvents.length]);
-
-  const renderListHeader = useCallback(() => listHeader, [listHeader]);
+  }, [
+    targetUser,
+    listTitle,
+    feedCounts,
+    selectedSegment,
+  ]);
 
   if (isUserLoading) {
     return (
@@ -232,7 +512,7 @@ export default function UserProfilePage() {
       />
       <View className="flex-1 bg-interactive-3">
         <UserEventsList
-          events={filteredEvents}
+          events={displayEvents}
           onEndReached={handleLoadMore}
           isFetchingNextPage={status === "LoadingMore"}
           listBodyLoading={status === "LoadingFirstPage"}
@@ -244,58 +524,6 @@ export default function UserProfilePage() {
         />
       </View>
     </>
-  );
-}
-
-interface ProfileIdentityHeaderProps {
-  user: {
-    id: string;
-    username: string;
-    displayName?: string | null;
-    userImage?: string | null;
-    publicMetadata?: unknown;
-  };
-  upcomingEventCount: number;
-}
-
-/** Profile header: avatar stacked above identity text block. */
-function ProfileIdentityHeader({
-  user,
-  upcomingEventCount,
-}: ProfileIdentityHeaderProps) {
-  const locationLine = profileLocationFromUser(user);
-
-  return (
-    <View className="items-start gap-3 px-4 pb-4 pt-2">
-      <UserProfileFlair username={user.username} size="lg">
-        {user.userImage ? (
-          <Image
-            source={{ uri: user.userImage }}
-            style={{ width: 80, height: 80, borderRadius: 40 }}
-            contentFit="cover"
-            cachePolicy="disk"
-          />
-        ) : (
-          <View className="h-20 w-20 items-center justify-center rounded-full bg-neutral-4">
-            <User size={40} color="#627496" />
-          </View>
-        )}
-      </UserProfileFlair>
-      <View className="w-full">
-        <Text className="text-xl font-bold text-neutral-1">
-          @{user.username}
-        </Text>
-        <Text className="text-sm text-neutral-2">
-          {upcomingEventCount}{" "}
-          {upcomingEventCount === 1 ? "upcoming event" : "upcoming events"}
-        </Text>
-        {locationLine ? (
-          <Text className="text-sm text-neutral-2" numberOfLines={1}>
-            {locationLine}
-          </Text>
-        ) : null}
-      </View>
-    </View>
   );
 }
 

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Linking,
+  Platform,
   Pressable,
   Text,
   TouchableOpacity,
@@ -10,12 +11,20 @@ import {
 } from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
+import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { User } from "~/components/icons";
+import {
+  Globe,
+  Instagram,
+  Mail,
+  Phone,
+  User,
+} from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
@@ -28,24 +37,6 @@ import { toast } from "~/utils/feedback";
 
 type ProfileSegment = "upcoming" | "past";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function profileLocationFromUser(user: {
-  publicMetadata?: unknown;
-}): string | null {
-  const meta = user.publicMetadata;
-  if (!isRecord(meta)) return null;
-  for (const key of ["location", "city", "hometown"] as const) {
-    const v = meta[key];
-    if (typeof v === "string" && v.trim().length > 0) {
-      return v.trim();
-    }
-  }
-  return null;
-}
-
 function formatMemberSince(createdAtIso: string): string {
   const d = new Date(createdAtIso);
   if (Number.isNaN(d.getTime())) return "";
@@ -54,7 +45,7 @@ function formatMemberSince(createdAtIso: string): string {
   if (days <= 30) {
     return "New member";
   }
-  return `Since ${d.toLocaleDateString(undefined, { month: "long", year: "numeric" })}`;
+  return `Joined ${d.toLocaleDateString(undefined, { month: "long", year: "numeric" })}`;
 }
 
 function websiteHref(raw: string): string {
@@ -74,48 +65,42 @@ function instaHref(raw: string): string {
   return `https://instagram.com/${handle}`;
 }
 
-function ProfileSegmentToggle({
-  selected,
-  onChange,
+function SegmentedControlFallback({
+  selectedSegment,
+  onSegmentChange,
 }: {
-  selected: ProfileSegment;
-  onChange: (s: ProfileSegment) => void;
+  selectedSegment: ProfileSegment;
+  onSegmentChange: (segment: ProfileSegment) => void;
 }) {
   return (
-    <View className="mt-3 flex-row rounded-lg bg-neutral-4/40 p-1">
+    <View className="flex-row rounded-lg bg-gray-100 p-1">
       <TouchableOpacity
-        className={`flex-1 items-center rounded-md py-2 ${
-          selected === "upcoming" ? "bg-white shadow-sm" : ""
+        className={`items-center rounded-md px-4 py-2 ${
+          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
         }`}
-        onPress={() => onChange("upcoming")}
-        accessibilityRole="button"
-        accessibilityState={{ selected: selected === "upcoming" }}
-        accessibilityLabel="Upcoming events"
+        onPress={() => onSegmentChange("upcoming")}
       >
         <Text
           className={
-            selected === "upcoming"
-              ? "font-semibold text-neutral-1"
-              : "text-neutral-2"
+            selectedSegment === "upcoming"
+              ? "font-semibold text-gray-900"
+              : "text-gray-500"
           }
         >
           Upcoming
         </Text>
       </TouchableOpacity>
       <TouchableOpacity
-        className={`flex-1 items-center rounded-md py-2 ${
-          selected === "past" ? "bg-white shadow-sm" : ""
+        className={`items-center rounded-md px-4 py-2 ${
+          selectedSegment === "past" ? "bg-white shadow-sm" : ""
         }`}
-        onPress={() => onChange("past")}
-        accessibilityRole="button"
-        accessibilityState={{ selected: selected === "past" }}
-        accessibilityLabel="Past events"
+        onPress={() => onSegmentChange("past")}
       >
         <Text
           className={
-            selected === "past"
-              ? "font-semibold text-neutral-1"
-              : "text-neutral-2"
+            selectedSegment === "past"
+              ? "font-semibold text-gray-900"
+              : "text-gray-500"
           }
         >
           Past
@@ -125,22 +110,27 @@ function ProfileSegmentToggle({
   );
 }
 
-function ProfileLinkRow({
-  label,
+const PROFILE_CONTACT_ICON_SIZE = 16;
+const PROFILE_CONTACT_ICON_COLOR = "#5A32FB";
+
+function ProfileContactIconButton({
+  accessibilityLabel,
   onPress,
+  children,
 }: {
-  label: string;
+  accessibilityLabel: string;
   onPress: () => void;
+  children: React.ReactNode;
 }) {
   return (
     <Pressable
       onPress={onPress}
-      accessibilityRole="link"
-      className="mt-1 active:opacity-70"
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+      className="h-8 w-8 items-center justify-center rounded-full bg-neutral-4/70 active:opacity-70"
     >
-      <Text className="text-sm font-medium text-interactive-1" numberOfLines={2}>
-        {label}
-      </Text>
+      {children}
     </Pressable>
   );
 }
@@ -149,164 +139,191 @@ type ProfileUser = NonNullable<
   FunctionReturnType<typeof api.users.getByUsername>
 >;
 
-type PublicFeedCountPart = { count: number; capped: boolean };
-
-/** Matches `PUBLIC_FEED_COUNT_CAP` in `packages/backend/convex/feeds.ts`. */
-const PUBLIC_FEED_COUNT_CAP = 50;
-
-function formatPublicFeedCount(part: PublicFeedCountPart): string {
-  return part.capped ? `${PUBLIC_FEED_COUNT_CAP}+` : String(part.count);
-}
-
-/** Exact sum when known; round "50+" if either segment hits the cap. */
-function publicFeedAllTimeLabel(
-  upcoming: PublicFeedCountPart,
-  past: PublicFeedCountPart,
-): string {
-  if (!upcoming.capped && !past.capped) {
-    return String(upcoming.count + past.count);
+function formatLastUpdated(addedAtMs: number | null | undefined): string {
+  if (addedAtMs === null || addedAtMs === undefined) return "";
+  const now = Date.now();
+  const diffMs = Math.max(0, now - addedAtMs);
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "Last updated just now";
+  if (minutes < 60) {
+    return `Last updated ${minutes} minute${minutes === 1 ? "" : "s"} ago`;
   }
-  return `${PUBLIC_FEED_COUNT_CAP}+`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Last updated ${hours} hour${hours === 1 ? "" : "s"} ago`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `Last updated ${days} day${days === 1 ? "" : "s"} ago`;
+  }
+  const d = new Date(addedAtMs);
+  return `Last updated ${d.toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  })}`;
 }
 
 function ProfileHeroAndSoonlist({
   user,
   listTitle,
-  feedCounts,
+  lastUpdatedAt,
   selectedSegment,
   onSegmentChange,
 }: {
   user: ProfileUser;
   listTitle: string;
-  feedCounts:
-    | { upcoming: PublicFeedCountPart; past: PublicFeedCountPart }
-    | undefined;
+  lastUpdatedAt: number | null | undefined;
   selectedSegment: ProfileSegment;
   onSegmentChange: (s: ProfileSegment) => void;
 }) {
-  const locationLine = profileLocationFromUser(user);
   const memberLine = formatMemberSince(user.created_at);
-  const totalPublicLabel =
-    feedCounts !== undefined
-      ? publicFeedAllTimeLabel(feedCounts.upcoming, feedCounts.past)
-      : null;
 
-  const displayName =
-    user.displayName?.trim() || `@${user.username}`;
+  const emailTrimmed = user.publicEmail?.trim() ?? "";
+  const phoneTrimmed = user.publicPhone?.trim() ?? "";
+  const instaTrimmed = user.publicInsta?.trim() ?? "";
+  const instaHandle = instaTrimmed.replace(/^@/, "");
+  const websiteTrimmed = user.publicWebsite?.trim() ?? "";
+  const hasContact =
+    Boolean(emailTrimmed) ||
+    Boolean(phoneTrimmed) ||
+    Boolean(instaTrimmed) ||
+    Boolean(websiteTrimmed);
+
+  const lastUpdatedLine =
+    lastUpdatedAt === undefined
+      ? "…"
+      : formatLastUpdated(lastUpdatedAt);
 
   return (
     <View className="px-4 pb-2 pt-2">
-      <View className="flex-row gap-4">
-        <UserProfileFlair username={user.username} size="lg">
+      <Text
+        className="text-3xl font-bold leading-tight text-interactive-1"
+        numberOfLines={2}
+      >
+        {listTitle}
+      </Text>
+
+      {/* Byline: avatar + @username + joined + contact icons */}
+      <View className="mt-3 flex-row items-center gap-3">
+        <UserProfileFlair username={user.username} size="sm">
           {user.userImage ? (
             <Image
               source={{ uri: user.userImage }}
-              style={{ width: 80, height: 80, borderRadius: 40 }}
+              style={{ width: 36, height: 36, borderRadius: 18 }}
               contentFit="cover"
               cachePolicy="disk"
             />
           ) : (
-            <View className="h-20 w-20 items-center justify-center rounded-full bg-neutral-4">
-              <User size={40} color="#627496" />
+            <View className="h-9 w-9 items-center justify-center rounded-full bg-neutral-4">
+              <User size={20} color="#627496" />
             </View>
           )}
         </UserProfileFlair>
 
         <View className="min-w-0 flex-1">
           <Text
-            className="text-xl font-bold text-neutral-1"
-            numberOfLines={2}
+            className="text-sm font-semibold text-neutral-1"
+            numberOfLines={1}
+            accessibilityLabel={
+              user.displayName?.trim()
+                ? `${user.displayName.trim()}, @${user.username}`
+                : `@${user.username}`
+            }
           >
-            {displayName}
+            @{user.username}
           </Text>
-          <Text className="text-sm text-neutral-2">@{user.username}</Text>
-
-          {user.bio?.trim() ? (
-            <Text className="mt-2 text-sm leading-5 text-neutral-1">
-              {user.bio.trim()}
-            </Text>
-          ) : null}
-
-          {locationLine ? (
-            <Text
-              className="mt-2 text-sm text-neutral-2"
-              numberOfLines={2}
-            >
-              {locationLine}
-            </Text>
-          ) : null}
-
           {memberLine ? (
-            <Text className="mt-1 text-sm text-neutral-2">{memberLine}</Text>
-          ) : null}
-
-          {user.publicEmail?.trim() ? (
-            <ProfileLinkRow
-              label={user.publicEmail.trim()}
-              onPress={() => {
-                void Linking.openURL(
-                  `mailto:${encodeURIComponent(user.publicEmail!.trim())}`,
-                );
-              }}
-            />
-          ) : null}
-
-          {user.publicPhone?.trim() ? (
-            <ProfileLinkRow
-              label={user.publicPhone.trim()}
-              onPress={() => {
-                const n = user.publicPhone!.replace(/[^\d+]/g, "");
-                void Linking.openURL(`tel:${n}`);
-              }}
-            />
-          ) : null}
-
-          {user.publicInsta?.trim() ? (
-            <ProfileLinkRow
-              label={`Instagram: @${user.publicInsta.trim().replace(/^@/, "")}`}
-              onPress={() => {
-                void Linking.openURL(instaHref(user.publicInsta!));
-              }}
-            />
-          ) : null}
-
-          {user.publicWebsite?.trim() ? (
-            <ProfileLinkRow
-              label={user.publicWebsite.trim()}
-              onPress={() => {
-                void Linking.openURL(websiteHref(user.publicWebsite!));
-              }}
-            />
+            <Text className="text-xs text-neutral-2" numberOfLines={1}>
+              {memberLine}
+            </Text>
           ) : null}
         </View>
+
+        {hasContact ? (
+          <View className="flex-row items-center gap-1.5">
+            {emailTrimmed ? (
+              <ProfileContactIconButton
+                accessibilityLabel={`Email ${emailTrimmed}`}
+                onPress={() => {
+                  void Linking.openURL(
+                    `mailto:${encodeURIComponent(emailTrimmed)}`,
+                  );
+                }}
+              >
+                <Mail
+                  size={PROFILE_CONTACT_ICON_SIZE}
+                  color={PROFILE_CONTACT_ICON_COLOR}
+                />
+              </ProfileContactIconButton>
+            ) : null}
+            {phoneTrimmed ? (
+              <ProfileContactIconButton
+                accessibilityLabel={`Call ${phoneTrimmed}`}
+                onPress={() => {
+                  const n = phoneTrimmed.replace(/[^\d+]/g, "");
+                  void Linking.openURL(`tel:${n}`);
+                }}
+              >
+                <Phone
+                  size={PROFILE_CONTACT_ICON_SIZE}
+                  color={PROFILE_CONTACT_ICON_COLOR}
+                />
+              </ProfileContactIconButton>
+            ) : null}
+            {instaTrimmed ? (
+              <ProfileContactIconButton
+                accessibilityLabel={`Instagram @${instaHandle}`}
+                onPress={() => {
+                  void Linking.openURL(instaHref(instaTrimmed));
+                }}
+              >
+                <Instagram
+                  size={PROFILE_CONTACT_ICON_SIZE}
+                  color={PROFILE_CONTACT_ICON_COLOR}
+                />
+              </ProfileContactIconButton>
+            ) : null}
+            {websiteTrimmed ? (
+              <ProfileContactIconButton
+                accessibilityLabel={`Website ${websiteTrimmed}`}
+                onPress={() => {
+                  void Linking.openURL(websiteHref(websiteTrimmed));
+                }}
+              >
+                <Globe
+                  size={PROFILE_CONTACT_ICON_SIZE}
+                  color={PROFILE_CONTACT_ICON_COLOR}
+                />
+              </ProfileContactIconButton>
+            ) : null}
+          </View>
+        ) : null}
       </View>
 
-      <View className="mt-5 border-t border-neutral-4/80 pt-4">
-        <Text className="text-xs font-semibold uppercase tracking-wide text-neutral-2">
-          Soonlist
-        </Text>
-        <Text
-          className="mt-1 text-lg font-bold text-interactive-1"
-          numberOfLines={2}
-        >
-          {listTitle}
-        </Text>
-        <Text className="mt-1 text-sm text-neutral-2">
-          {feedCounts !== undefined ? (
-            <>
-              {formatPublicFeedCount(feedCounts.upcoming)} upcoming
-              {totalPublicLabel !== null
-                ? ` · ${totalPublicLabel} events all-time`
-                : ""}
-            </>
-          ) : (
-            "…"
-          )}
-        </Text>
-        <ProfileSegmentToggle
-          selected={selectedSegment}
-          onChange={onSegmentChange}
-        />
+      <Text className="mt-2 text-sm text-neutral-2">{lastUpdatedLine}</Text>
+
+      <View className="mt-3" style={{ width: 260 }}>
+        {Platform.OS === "ios" ? (
+          <Host matchContents>
+            <Picker
+              selection={selectedSegment}
+              onSelectionChange={(value) => {
+                onSegmentChange(value as ProfileSegment);
+              }}
+              modifiers={[pickerStyle("segmented")]}
+            >
+              <SwiftUIText modifiers={[tag("upcoming")]}>
+                Upcoming
+              </SwiftUIText>
+              <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
+            </Picker>
+          </Host>
+        ) : (
+          <SegmentedControlFallback
+            selectedSegment={selectedSegment}
+            onSegmentChange={onSegmentChange}
+          />
+        )}
       </View>
     </View>
   );
@@ -334,8 +351,8 @@ export default function UserProfilePage() {
     targetUser?.id ? { userId: targetUser.id } : "skip",
   );
 
-  const feedCounts = useQuery(
-    api.feeds.getPublicUserFeedCounts,
+  const lastUpdatedAt = useQuery(
+    api.feeds.getPublicUserFeedLastUpdated,
     targetUser ? { username } : "skip",
   );
 
@@ -460,7 +477,7 @@ export default function UserProfilePage() {
       <ProfileHeroAndSoonlist
         user={targetUser}
         listTitle={listTitle}
-        feedCounts={feedCounts}
+        lastUpdatedAt={lastUpdatedAt}
         selectedSegment={selectedSegment}
         onSegmentChange={setSelectedSegment}
       />
@@ -468,7 +485,7 @@ export default function UserProfilePage() {
   }, [
     targetUser,
     listTitle,
-    feedCounts,
+    lastUpdatedAt,
     selectedSegment,
   ]);
 

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -376,8 +376,9 @@ export default function UserProfilePage() {
       : "skip",
   );
 
-  const savedEventIds = new Set(
-    savedEventIdsQuery?.map((event) => event.id) ?? [],
+  const savedEventIds = useMemo(
+    () => new Set(savedEventIdsQuery?.map((event) => event.id) ?? []),
+    [savedEventIdsQuery],
   );
 
   const feedQueryArgs = useMemo(

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -273,7 +273,7 @@ const InitialLayout = () => {
           presentation: "formSheet",
           title: "",
           headerShown: false,
-          sheetAllowedDetents: [0.5],
+          sheetAllowedDetents: [0.4, 0.8],
           sheetGrabberVisible: true,
           sheetCornerRadius: 24,
         }}

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -423,8 +423,7 @@ function EventDetail({ id }: { id: string }) {
           </View>
 
           {/* Meta rows (venue + visibility) */}
-          {(eventData.location ||
-            (showDiscover && isCurrentUserEvent)) && (
+          {(eventData.location || (showDiscover && isCurrentUserEvent)) && (
             <View className="mt-4 flex flex-col gap-2">
               {/* Location link */}
               {eventData.location && (

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -32,6 +32,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { getTimezoneAbbreviation } from "@soonlist/cal";
 
 import { EventMenu } from "~/components/EventMenu";
+import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
 import { HeaderLogo } from "~/components/HeaderLogo";
 import {
   CalendarPlus,
@@ -44,7 +45,6 @@ import {
   ShareIcon,
 } from "~/components/icons";
 import LoadingSpinner from "~/components/LoadingSpinner";
-import { UserAvatar } from "~/components/UserAvatar";
 import { useEventActions, useEventSaveActions } from "~/hooks/useEventActions";
 import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import {
@@ -422,8 +422,9 @@ function EventDetail({ id }: { id: string }) {
             </Text>
           </View>
 
-          {/* Meta rows (venue + visibility/author) */}
-          {(eventData.location || showDiscover) && (
+          {/* Meta rows (venue + visibility) */}
+          {(eventData.location ||
+            (showDiscover && isCurrentUserEvent)) && (
             <View className="mt-4 flex flex-col gap-2">
               {/* Location link */}
               {eventData.location && (
@@ -444,47 +445,21 @@ function EventDetail({ id }: { id: string }) {
                 </Link>
               )}
 
-              {/* Visibility or user info */}
-              {showDiscover && (
-                <>
-                  {isCurrentUserEvent ? (
-                    <View className="flex-row items-center gap-2">
-                      {event.visibility === "public" ? (
-                        <Globe2 size={16} color="#627496" />
-                      ) : (
-                        <EyeOff size={16} color="#627496" />
-                      )}
-                      <Text className="text-sm text-neutral-2">
-                        {event.visibility === "public"
-                          ? "Discoverable"
-                          : "Not discoverable"}
-                      </Text>
-                    </View>
+              {/* Visibility (owner-only info). Attribution now lives in the
+                  "From these Soonlists" section below. */}
+              {showDiscover && isCurrentUserEvent && (
+                <View className="flex-row items-center gap-2">
+                  {event.visibility === "public" ? (
+                    <Globe2 size={16} color="#627496" />
                   ) : (
-                    <Pressable
-                      onPress={() =>
-                        event.user?.username &&
-                        router.push(`/${event.user.username}`)
-                      }
-                      className="-my-2 flex-row items-center gap-2 py-2"
-                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                    >
-                      <UserAvatar
-                        user={{
-                          id: event.user?.id ?? "",
-                          username: event.user?.username ?? "",
-                          userImage: event.user?.userImage,
-                        }}
-                        size={20}
-                      />
-                      <Text className="text-sm text-neutral-2">
-                        {event.user?.displayName ||
-                          event.user?.username ||
-                          "unknown"}
-                      </Text>
-                    </Pressable>
+                    <EyeOff size={16} color="#627496" />
                   )}
-                </>
+                  <Text className="text-sm text-neutral-2">
+                    {event.visibility === "public"
+                      ? "Discoverable"
+                      : "Not discoverable"}
+                  </Text>
+                </View>
               )}
             </View>
           )}
@@ -616,6 +591,35 @@ function EventDetail({ id }: { id: string }) {
                 );
               })()}
             </>
+          )}
+
+          {/* From these Soonlists — unified attribution of people + lists.
+              Lives after the event content and source attribution so the
+              reading order is: what it is → what it's about → where it
+              came from → who has it. */}
+          {showDiscover && event.user && (
+            <View className="mb-4">
+              <FromTheseSoonlists
+                creator={{
+                  id: event.user.id,
+                  username: event.user.username,
+                  displayName: event.user.displayName,
+                  userImage: event.user.userImage,
+                }}
+                savers={event.eventFollows
+                  .map((f) => f.user)
+                  .filter((u): u is NonNullable<typeof u> => !!u)
+                  .map((u) => ({
+                    id: u.id,
+                    username: u.username,
+                    displayName: u.displayName,
+                    userImage: u.userImage,
+                  }))}
+                lists={event.lists}
+                currentUserId={currentUser?.id}
+                variant="compact"
+              />
+            </View>
           )}
 
           {/* Hidden probe to detect image dimensions without layout shift */}

--- a/apps/expo/src/app/share-setup.tsx
+++ b/apps/expo/src/app/share-setup.tsx
@@ -90,7 +90,7 @@ export default function ShareSetupScreen() {
   // Animate between medium (preview) and large (edit) detents.
   useEffect(() => {
     navigation.setOptions({
-      sheetAllowedDetents: isEditing ? [1.0] : [0.5],
+      sheetAllowedDetents: isEditing ? [0.8] : [0.4, 0.8],
     });
   }, [isEditing, navigation]);
 
@@ -180,7 +180,7 @@ export default function ShareSetupScreen() {
         flex: 1,
         flexDirection: "column",
         backgroundColor: "white",
-        paddingTop: insets.top,
+        paddingTop: Platform.OS === "ios" ? 8 : insets.top,
       }}
     >
       {isEditing ? (

--- a/apps/expo/src/components/AppleSignInButton.tsx
+++ b/apps/expo/src/components/AppleSignInButton.tsx
@@ -12,7 +12,7 @@ export const AppleSignInButton: React.FC<AppleSignInButtonProps> = ({
   onPress,
 }) => (
   <Pressable
-    className="rounded-full bg-black py-3 active:scale-[0.98] active:bg-neutral-800"
+    className="w-full rounded-full bg-black py-4 active:scale-[0.98] active:bg-neutral-800"
     onPress={() => {
       void hapticMedium();
       onPress();

--- a/apps/expo/src/components/DefaultEmptyState.tsx
+++ b/apps/expo/src/components/DefaultEmptyState.tsx
@@ -55,25 +55,29 @@ export function DefaultEmptyState({
             className="mb-1 text-base font-medium text-neutral-2"
             style={{ paddingLeft: 6 }}
           >
-            Events from lists I subscribe to
+            Events from Soonlists I subscribe to
           </Text>
         </View>
 
         <View className="px-6 pt-6">
-          {/* Shared-first primary block */}
-          <View className="mb-6 rounded-2xl border border-neutral-3 bg-white p-4">
-            <Text className="mb-3 text-base font-semibold text-neutral-1">
-              Someone shared a list with you?
+          {/* Shared-first primary block — soft surface so it doesn’t read as a stark white slab */}
+          <View
+            className="mb-6 rounded-2xl border border-neutral-3/70 p-3"
+            style={{ backgroundColor: "rgba(255,255,255,0.72)" }}
+          >
+            <Text className="mb-2 text-sm font-medium text-neutral-2">
+              Someone shared their Soonlist with you?
             </Text>
             <TouchableOpacity
               onPress={() => setIsModalVisible(true)}
               activeOpacity={0.85}
               accessibilityRole="button"
-              accessibilityLabel="Enter their username"
-              className="w-full rounded-full bg-interactive-1 py-3"
+              accessibilityLabel="Find by username"
+              className="w-full self-center rounded-full bg-interactive-1 px-6 py-2"
+              style={{ maxWidth: 320 }}
             >
-              <Text className="text-center text-base font-semibold text-white">
-                Enter their username
+              <Text className="text-center text-sm font-semibold text-white">
+                Find by username
               </Text>
             </TouchableOpacity>
           </View>
@@ -82,8 +86,8 @@ export function DefaultEmptyState({
           {featuredLists.length > 0 ? (
             <View className="mb-4 flex-row items-center gap-3">
               <View className="h-px flex-1 bg-neutral-3" />
-              <Text className="text-sm text-neutral-2">
-                Or start with one of these
+              <Text className="text-center text-sm text-neutral-2">
+                Or start with these from Portland
               </Text>
               <View className="h-px flex-1 bg-neutral-3" />
             </View>

--- a/apps/expo/src/components/EmailSignInButton.tsx
+++ b/apps/expo/src/components/EmailSignInButton.tsx
@@ -11,7 +11,7 @@ interface EmailSignInButtonProps {
 export function EmailSignInButton({ onPress }: EmailSignInButtonProps) {
   return (
     <Pressable
-      className="rounded-full border border-[#DCE0E8] bg-[#DCE0E8] py-3 active:scale-[0.98] active:bg-[#CDD1D9]"
+      className="w-full rounded-full border border-[#DCE0E8] bg-[#DCE0E8] py-4 active:scale-[0.98] active:bg-[#CDD1D9]"
       onPress={() => {
         void hapticMedium();
         onPress();

--- a/apps/expo/src/components/FromTheseSoonlists.tsx
+++ b/apps/expo/src/components/FromTheseSoonlists.tsx
@@ -46,9 +46,7 @@ export function FromTheseSoonlists({
   // `queryFeed`/`queryGroupedFeed`, which filter `event.lists` through
   // `getViewableListIds`). Here we only strip system/personal lists, which
   // are an implementation detail and not meaningful attribution.
-  const visibleLists = lists.filter(
-    (list) => !list.isSystemList && !!list.slug,
-  );
+  const visibleLists = lists.filter((list) => !list.isSystemList);
 
   const handleUserPress = (user: UserForDisplay) => {
     onNavigate?.();
@@ -141,34 +139,53 @@ export function FromTheseSoonlists({
 
   visibleLists.forEach((list) => {
     const iconSize = isCompact ? 32 : 44;
-    rows.push(
-      <TouchableOpacity
-        key={`list-${list.id}`}
-        onPress={() => handleListPress(list)}
-        className={`flex-row items-center ${rowPaddingY}`}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={`Open list ${list.name}`}
+    const icon = (
+      <View
+        className="items-center justify-center rounded-full bg-interactive-3"
+        style={{ width: iconSize, height: iconSize }}
       >
-        <View
-          className="items-center justify-center rounded-full bg-interactive-3"
-          style={{ width: iconSize, height: iconSize }}
-        >
-          <ListIcon size={isCompact ? 16 : 20} color="#5A32FB" />
-        </View>
-        <View className="ml-3 flex-1">
-          <Text
-            className={`${
-              isCompact ? "text-sm" : "text-base"
-            } font-semibold text-neutral-1`}
-            numberOfLines={1}
-          >
-            {list.name}
-          </Text>
-        </View>
-        <ChevronRight size={16} color={chevronColor} />
-      </TouchableOpacity>,
+        <ListIcon size={isCompact ? 16 : 20} color="#5A32FB" />
+      </View>
     );
+    const label = (
+      <View className="ml-3 flex-1">
+        <Text
+          className={`${
+            isCompact ? "text-sm" : "text-base"
+          } font-semibold text-neutral-1`}
+          numberOfLines={1}
+        >
+          {list.name}
+        </Text>
+      </View>
+    );
+
+    if (list.slug) {
+      rows.push(
+        <TouchableOpacity
+          key={`list-${list.id}`}
+          onPress={() => handleListPress(list)}
+          className={`flex-row items-center ${rowPaddingY}`}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={`Open list ${list.name}`}
+        >
+          {icon}
+          {label}
+          <ChevronRight size={16} color={chevronColor} />
+        </TouchableOpacity>,
+      );
+    } else {
+      rows.push(
+        <View
+          key={`list-${list.id}`}
+          className={`flex-row items-center ${rowPaddingY}`}
+        >
+          {icon}
+          {label}
+        </View>,
+      );
+    }
   });
 
   if (rows.length === 0) return null;

--- a/apps/expo/src/components/FromTheseSoonlists.tsx
+++ b/apps/expo/src/components/FromTheseSoonlists.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import { router } from "expo-router";
+
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
+
+import type { UserForDisplay } from "~/types/user";
+import { ChevronRight, List as ListIcon } from "~/components/icons";
+import { UserAvatar } from "~/components/UserAvatar";
+import { navigateToUser } from "~/utils/navigateToUser";
+
+interface FromTheseSoonlistsProps {
+  creator: UserForDisplay;
+  savers: UserForDisplay[];
+  lists: Doc<"lists">[];
+  currentUserId?: string;
+  /** Called before navigating, e.g. to dismiss an enclosing modal. */
+  onNavigate?: () => void;
+  /**
+   * - "card": padded card with label + dividers (used in the modal body).
+   * - "compact": tighter, borderless, tinted card for inline use.
+   */
+  variant?: "card" | "compact";
+  /** Whether to show the "From these Soonlists" section label. */
+  showLabel?: boolean;
+}
+
+export function FromTheseSoonlists({
+  creator,
+  savers,
+  lists,
+  currentUserId,
+  onNavigate,
+  variant = "card",
+  showLabel = true,
+}: FromTheseSoonlistsProps) {
+  // People: creator first, then savers, deduped.
+  const people: UserForDisplay[] = [creator];
+  for (const saver of savers) {
+    if (!people.some((u) => u.id === saver.id)) {
+      people.push(saver);
+    }
+  }
+
+  // Private-list access is enforced on the SERVER (see feeds.ts
+  // `queryFeed`/`queryGroupedFeed`, which filter `event.lists` through
+  // `getViewableListIds`). Here we only strip system/personal lists, which
+  // are an implementation detail and not meaningful attribution.
+  const visibleLists = lists.filter((list) => !list.isSystemList);
+
+  const handleUserPress = (user: UserForDisplay) => {
+    onNavigate?.();
+    navigateToUser(user, currentUserId);
+  };
+
+  const handleListPress = (list: Doc<"lists">) => {
+    if (!list.slug) return;
+    onNavigate?.();
+    router.push(`/list/${list.slug}`);
+  };
+
+  const isCompact = variant === "compact";
+
+  // Degenerate case (compact only): just the creator, no other savers and no
+  // lists. The full card is over-chrome for "one person captured this" — drop
+  // to a one-liner in the same visual language (avatar + "captured" concept).
+  const isSingleCreator =
+    isCompact && people.length === 1 && visibleLists.length === 0;
+
+  if (isSingleCreator) {
+    return (
+      <TouchableOpacity
+        onPress={() => handleUserPress(creator)}
+        className="flex-row items-center"
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${
+          creator.displayName || creator.username || "user"
+        }'s Soonlist`}
+      >
+        <UserAvatar user={creator} size={24} />
+        <Text className="ml-2 text-sm text-neutral-2" numberOfLines={1}>
+          Captured by{" "}
+          <Text className="font-semibold text-neutral-1">
+            {creator.displayName || creator.username}
+          </Text>
+        </Text>
+      </TouchableOpacity>
+    );
+  }
+
+  const avatarSize = isCompact ? 32 : 44;
+  const rowPaddingY = isCompact ? "py-2" : "py-2.5";
+  const containerPadding = isCompact ? "px-3 pb-2 pt-2" : "px-4 pb-3 pt-3";
+  const labelMargin = isCompact ? "mb-1" : "mb-2";
+  // Both variants share the same visual language: tinted card, no dividers
+  // between rows, muted-brand chevron. Rows are grouped by the tint + row
+  // padding, not by lines. The card variant is simply the compact design
+  // scaled up.
+  const chevronColor = "#8F7AD6";
+
+  const rows: React.ReactNode[] = [];
+
+  people.forEach((user) => {
+    const isCreator = user.id === creator.id;
+    rows.push(
+      <TouchableOpacity
+        key={`user-${user.id}`}
+        onPress={() => handleUserPress(user)}
+        className={`flex-row items-center ${rowPaddingY}`}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${
+          user.displayName || user.username || "user"
+        }'s Soonlist`}
+      >
+        <UserAvatar user={user} size={avatarSize} />
+        <View className="ml-3 flex-1 flex-row items-center">
+          <Text
+            className={`shrink ${
+              isCompact ? "text-sm" : "text-base"
+            } font-semibold text-neutral-1`}
+            numberOfLines={1}
+          >
+            {user.displayName || user.username}
+          </Text>
+          {isCreator ? (
+            <View className="ml-2 shrink-0 rounded-full bg-accent-yellow px-2 py-0.5">
+              <Text className="text-[11px] font-semibold text-neutral-1">
+                captured
+              </Text>
+            </View>
+          ) : null}
+        </View>
+        <ChevronRight size={16} color={chevronColor} />
+      </TouchableOpacity>,
+    );
+  });
+
+  visibleLists.forEach((list) => {
+    const iconSize = isCompact ? 32 : 44;
+    rows.push(
+      <TouchableOpacity
+        key={`list-${list.id}`}
+        onPress={() => handleListPress(list)}
+        className={`flex-row items-center ${rowPaddingY}`}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={`Open list ${list.name}`}
+      >
+        <View
+          className="items-center justify-center rounded-full bg-interactive-3"
+          style={{ width: iconSize, height: iconSize }}
+        >
+          <ListIcon size={isCompact ? 16 : 20} color="#5A32FB" />
+        </View>
+        <View className="ml-3 flex-1">
+          <Text
+            className={`${
+              isCompact ? "text-sm" : "text-base"
+            } font-semibold text-neutral-1`}
+            numberOfLines={1}
+          >
+            {list.name}
+          </Text>
+        </View>
+        <ChevronRight size={16} color={chevronColor} />
+      </TouchableOpacity>,
+    );
+  });
+
+  if (rows.length === 0) return null;
+
+  // Both variants share the same tinted, borderless card. The card variant
+  // is simply the compact design scaled up for use in the modal / +N more
+  // detail view.
+  const containerClass = `rounded-2xl bg-interactive-3/60 ${containerPadding}`;
+
+  return (
+    <View className={containerClass}>
+      {showLabel ? (
+        <Text
+          className={`${labelMargin} ${
+            isCompact ? "text-xs" : "text-sm"
+          } text-neutral-2`}
+        >
+          From these Soonlists:
+        </Text>
+      ) : null}
+      {rows}
+    </View>
+  );
+}

--- a/apps/expo/src/components/FromTheseSoonlists.tsx
+++ b/apps/expo/src/components/FromTheseSoonlists.tsx
@@ -46,7 +46,9 @@ export function FromTheseSoonlists({
   // `queryFeed`/`queryGroupedFeed`, which filter `event.lists` through
   // `getViewableListIds`). Here we only strip system/personal lists, which
   // are an implementation detail and not meaningful attribution.
-  const visibleLists = lists.filter((list) => !list.isSystemList);
+  const visibleLists = lists.filter(
+    (list) => !list.isSystemList && !!list.slug,
+  );
 
   const handleUserPress = (user: UserForDisplay) => {
     onNavigate?.();

--- a/apps/expo/src/components/GoogleSignInButton.tsx
+++ b/apps/expo/src/components/GoogleSignInButton.tsx
@@ -14,7 +14,7 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
 }) => {
   return (
     <Pressable
-      className="rounded-full border border-gray-300 bg-white py-3 active:scale-[0.98] active:bg-neutral-100"
+      className="w-full rounded-full border border-gray-300 bg-white py-4 active:scale-[0.98] active:bg-neutral-100"
       onPress={() => {
         void hapticMedium();
         onPress();

--- a/apps/expo/src/components/MatchAuthLoadingSurface.tsx
+++ b/apps/expo/src/components/MatchAuthLoadingSurface.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { View } from "react-native";
+
+import LoadingSpinner from "./LoadingSpinner";
+
+/**
+ * Same static layout as {@link AuthLoading} on tab screens: large-title offset,
+ * then centered {@link LoadingSpinner} on bg-interactive-3.
+ */
+export function MatchAuthLoadingSurface() {
+  return (
+    <View className="flex-1 bg-interactive-3">
+      <View className="h-[100px]" />
+      <LoadingSpinner />
+    </View>
+  );
+}

--- a/apps/expo/src/components/ProfileMenu.tsx
+++ b/apps/expo/src/components/ProfileMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Share, View } from "react-native";
+import { View } from "react-native";
 import { Image as ExpoImage } from "expo-image";
 import { router } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
@@ -7,7 +7,7 @@ import Intercom from "@intercom/intercom-react-native";
 import { useConvexAuth } from "convex/react";
 import * as DropdownMenu from "zeego/dropdown-menu";
 
-import { LogOut, MessageSquare, ShareIcon, User } from "~/components/icons";
+import { LogOut, MessageSquare, User } from "~/components/icons";
 import { useSignOut } from "~/hooks/useSignOut";
 import { toast } from "~/utils/feedback";
 import { logError } from "../utils/errorLogging";
@@ -43,15 +43,6 @@ export function ProfileMenu() {
     } catch (error) {
       logError("Error presenting Intercom", error);
     }
-  };
-
-  const handleShareApp = async () => {
-    const url =
-      "https://apps.apple.com/us/app/soonlist-save-events-instantly/id6670222216";
-    await Share.share({
-      message: "Check out Soonlist on the App Store!",
-      url: url,
-    });
   };
 
   const profileImage = (
@@ -92,13 +83,6 @@ export function ProfileMenu() {
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Content>
-        <DropdownMenu.Item key="share-app" onSelect={handleShareApp}>
-          <DropdownMenu.ItemIcon ios={{ name: "square.and.arrow.up" }}>
-            <ShareIcon />
-          </DropdownMenu.ItemIcon>
-          <DropdownMenu.ItemTitle>Share App</DropdownMenu.ItemTitle>
-        </DropdownMenu.Item>
-
         <DropdownMenu.Item key="profile" onSelect={handleEditProfile}>
           <DropdownMenu.ItemIcon ios={{ name: "person.circle" }}>
             <User />

--- a/apps/expo/src/components/ReferralEmptyState.tsx
+++ b/apps/expo/src/components/ReferralEmptyState.tsx
@@ -241,7 +241,7 @@ export function ReferralEmptyState({
             className="mb-1 text-base font-medium text-neutral-2"
             style={{ paddingLeft: 6 }}
           >
-            Events from lists I subscribe to
+            Events from Soonlists I subscribe to
           </Text>
         </View>
 

--- a/apps/expo/src/components/SavedByModal.tsx
+++ b/apps/expo/src/components/SavedByModal.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import { Modal, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { router } from "expo-router";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 
 import type { UserForDisplay } from "~/types/user";
-import { ChevronRight, List } from "~/components/icons";
-import { UserAvatar } from "~/components/UserAvatar";
-import { navigateToUser } from "~/utils/navigateToUser";
+import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
+import { X } from "~/components/icons";
 
 interface SavedByModalProps {
   visible: boolean;
@@ -29,39 +27,6 @@ export function SavedByModal({
 }: SavedByModalProps) {
   const insets = useSafeAreaInsets();
 
-  // Deduplicated users: creator first, then savers
-  const allUsers: UserForDisplay[] = [creator];
-  for (const saver of savers) {
-    if (!allUsers.some((u) => u.id === saver.id)) {
-      allUsers.push(saver);
-    }
-  }
-
-  // Show every non-system list this event belongs to — including the source
-  // list that's shown inline on the card. This is a complete "Saved by" view,
-  // and the "+N" card badge intentionally counts *additional* lists beyond
-  // the source, so the modal length is N+1 by design.
-  //
-  // Private-list access is enforced on the SERVER (see feeds.ts
-  // `queryFeed`/`queryGroupedFeed`, which filter `event.lists` through
-  // `getViewableListIds`). Do NOT re-add a blanket `visibility !== "private"`
-  // filter here: the server already guarantees we only receive lists the
-  // viewer can see, and adding that filter would incorrectly hide private
-  // lists the viewer is the owner/member of.
-  const visibleLists = lists.filter((list) => !list.isSystemList);
-
-  const handleUserPress = (user: UserForDisplay) => {
-    onClose();
-    navigateToUser(user, currentUserId);
-  };
-
-  const handleListPress = (list: Doc<"lists">) => {
-    onClose();
-    if (list.slug) {
-      router.push(`/list/${list.slug}`);
-    }
-  };
-
   return (
     <Modal
       visible={visible}
@@ -70,67 +35,40 @@ export function SavedByModal({
       onRequestClose={onClose}
     >
       <View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
-        {/* Header */}
-        <View className="border-b border-neutral-3 px-4 py-3">
-          <Text className="text-lg font-bold text-neutral-1">Saved by</Text>
+        {/* Header — matches the "From these Soonlists" teaching sentence,
+            paired with a tinted close chip that ties to the card tint
+            below. */}
+        <View className="flex-row items-center justify-between px-4 py-3">
+          <Text className="text-lg font-bold text-neutral-1">
+            From these Soonlists:
+          </Text>
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            className="h-8 w-8 items-center justify-center rounded-full bg-interactive-3"
+          >
+            <X size={16} color="#5A32FB" />
+          </TouchableOpacity>
         </View>
 
         {/* Scrollable content */}
         <ScrollView
-          contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+          contentContainerStyle={{
+            paddingHorizontal: 16,
+            paddingBottom: insets.bottom + 16,
+          }}
         >
-          {/* People section */}
-          <View className="px-4 pt-4">
-            <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-2">
-              People
-            </Text>
-            {allUsers.map((user) => (
-              <TouchableOpacity
-                key={user.id}
-                onPress={() => handleUserPress(user)}
-                className="flex-row items-center py-3"
-                activeOpacity={0.7}
-              >
-                <UserAvatar user={user} size={40} />
-                <View className="ml-3 flex-1">
-                  <Text className="text-base font-semibold text-neutral-1">
-                    {user.displayName || user.username}
-                  </Text>
-                  <Text className="text-sm text-neutral-2">
-                    {user.id === creator.id ? "Captured this event" : "Saved"}
-                  </Text>
-                </View>
-                <ChevronRight size={16} color="#DCE0E8" />
-              </TouchableOpacity>
-            ))}
-          </View>
-
-          {/* Lists section */}
-          {visibleLists.length > 0 && (
-            <View className="px-4 pt-4">
-              <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-2">
-                Lists
-              </Text>
-              {visibleLists.map((list) => (
-                <TouchableOpacity
-                  key={list.id}
-                  onPress={() => handleListPress(list)}
-                  className="flex-row items-center py-3"
-                  activeOpacity={0.7}
-                >
-                  <View className="h-10 w-10 items-center justify-center rounded-xl bg-interactive-2">
-                    <List size={20} color="#5A32FB" />
-                  </View>
-                  <View className="ml-3 flex-1">
-                    <Text className="text-base font-semibold text-neutral-1">
-                      {list.name}
-                    </Text>
-                  </View>
-                  <ChevronRight size={16} color="#DCE0E8" />
-                </TouchableOpacity>
-              ))}
-            </View>
-          )}
+          <FromTheseSoonlists
+            creator={creator}
+            savers={savers}
+            lists={lists}
+            currentUserId={currentUserId}
+            onNavigate={onClose}
+            variant="card"
+            showLabel={false}
+          />
         </ScrollView>
       </View>
     </Modal>

--- a/apps/expo/src/components/SignInWithOAuth.tsx
+++ b/apps/expo/src/components/SignInWithOAuth.tsx
@@ -23,6 +23,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { X } from "~/components/icons";
 import { useGuestUser } from "~/hooks/useGuestUser";
 import { useAppStore } from "~/store";
+import { cn } from "~/utils/cn";
 import { useWarmUpBrowser } from "../hooks/useWarmUpBrowser";
 import { AF_EVENTS, trackAFEvent } from "../utils/appsflyerEvents";
 import { logError } from "../utils/errorLogging";
@@ -52,6 +53,12 @@ interface SignInWithOAuthProps {
   dark?: boolean;
   /** Shows an onboarding progress bar at the top. Pass the step out of total. */
   progress?: { current: number; total: number };
+  /**
+   * Match `QuestionContainer` / paywall footer: same horizontal inset, no extra
+   * bottom padding, progress bar spacing, and primary CTA (Apple) last so it
+   * aligns with the prior screen’s Continue button.
+   */
+  onboardingFooterAlign?: boolean;
 }
 
 const SignInWithOAuth = ({
@@ -63,6 +70,7 @@ const SignInWithOAuth = ({
   imageSlot,
   dark,
   progress,
+  onboardingFooterAlign,
 }: SignInWithOAuthProps) => {
   useWarmUpBrowser();
   const posthog = usePostHog();
@@ -339,21 +347,37 @@ const SignInWithOAuth = ({
       className={`flex-1 ${dark ? "bg-interactive-1" : "bg-interactive-3"}`}
     >
       <Stack.Screen options={{ headerShown: false }} />
-      {progress && (
-        <View className="pt-2">
+      {progress &&
+        (onboardingFooterAlign ? (
           <ProgressBar
             currentStep={progress.current}
             totalSteps={progress.total}
             backgroundColor="bg-neutral-3"
             foregroundColor="bg-neutral-1"
           />
-        </View>
-      )}
+        ) : (
+          <View className="pt-2">
+            <ProgressBar
+              currentStep={progress.current}
+              totalSteps={progress.total}
+              backgroundColor="bg-neutral-3"
+              foregroundColor="bg-neutral-1"
+            />
+          </View>
+        ))}
       {banner}
       <View
-        className={`flex-1 px-4 pb-8 ${
-          banner ? "pt-0" : progress ? "pt-10" : "pt-24"
-        }`}
+        className={cn(
+          "flex-1",
+          onboardingFooterAlign ? "px-6 pb-0" : "px-4 pb-8",
+          banner
+            ? "pt-0"
+            : progress
+              ? onboardingFooterAlign
+                ? "pt-8"
+                : "pt-10"
+              : "pt-24",
+        )}
       >
         <View className="flex-1">
           <View className="shrink-0">
@@ -406,24 +430,53 @@ const SignInWithOAuth = ({
             </View>
           )}
 
-          <View className="relative mt-4 w-full shrink-0">
-            <AppleSignInButton
-              onPress={() => void handleOAuthFlow("oauth_apple")}
-            />
-            <View className="h-3" />
-            <Pressable
-              onPress={toggleOtherOptions}
-              className="relative flex-row items-center justify-center rounded-full border border-gray-300 bg-white px-6 py-3 active:scale-[0.98] active:bg-neutral-100"
-            >
-              <Text className="text-base font-medium text-gray-700">
-                More ways to sign up
-              </Text>
-              {showOtherOptions && (
-                <View className="absolute right-6">
-                  <X size={20} color="#374151" />
-                </View>
-              )}
-            </Pressable>
+          <View
+            className={cn(
+              "relative w-full shrink-0",
+              !onboardingFooterAlign && "mt-4",
+            )}
+          >
+            {onboardingFooterAlign ? (
+              <>
+                <Pressable
+                  onPress={toggleOtherOptions}
+                  className="relative w-full flex-row items-center justify-center rounded-full border border-gray-300 bg-white px-6 py-4 active:scale-[0.98] active:bg-neutral-100"
+                >
+                  <Text className="text-base font-medium text-gray-700">
+                    More ways to sign up
+                  </Text>
+                  {showOtherOptions && (
+                    <View className="absolute right-6">
+                      <X size={20} color="#374151" />
+                    </View>
+                  )}
+                </Pressable>
+                <View className="h-3" />
+                <AppleSignInButton
+                  onPress={() => void handleOAuthFlow("oauth_apple")}
+                />
+              </>
+            ) : (
+              <>
+                <AppleSignInButton
+                  onPress={() => void handleOAuthFlow("oauth_apple")}
+                />
+                <View className="h-3" />
+                <Pressable
+                  onPress={toggleOtherOptions}
+                  className="relative w-full flex-row items-center justify-center rounded-full border border-gray-300 bg-white px-6 py-4 active:scale-[0.98] active:bg-neutral-100"
+                >
+                  <Text className="text-base font-medium text-gray-700">
+                    More ways to sign up
+                  </Text>
+                  {showOtherOptions && (
+                    <View className="absolute right-6">
+                      <X size={20} color="#374151" />
+                    </View>
+                  )}
+                </Pressable>
+              </>
+            )}
             {showOtherOptions && (
               <AnimatedView
                 entering={FadeIn.duration(400)}

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -441,6 +441,18 @@ export function UserEventListItem(props: UserEventListItemProps) {
                     >
                       <CalendarPlus size={iconSize * 1.1} color="#5A32FB" />
                     </TouchableOpacity>
+                  ) : isOwner ? (
+                    <TouchableOpacity
+                      className="rounded-full p-2.5"
+                      onPress={() => {
+                        router.navigate(`/event/${id}/edit`);
+                      }}
+                      accessibilityLabel="Edit"
+                      accessibilityRole="button"
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    >
+                      <PenSquare size={iconSize * 1.1} color="#5A32FB" />
+                    </TouchableOpacity>
                   ) : (
                     <SaveButton
                       eventId={id}

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -50,6 +50,7 @@ import { getEventEmoji } from "~/utils/eventEmoji";
 import { collapseSimilarEvents } from "~/utils/similarEvents";
 import { EventMenu } from "./EventMenu";
 import { EventStats } from "./EventStats";
+import { MatchAuthLoadingSurface } from "./MatchAuthLoadingSurface";
 import SaveButton from "./SaveButton";
 
 type ShowCreatorOption = "always" | "otherUsers" | "never" | "savedFromOthers";
@@ -929,7 +930,12 @@ interface UserEventsListProps {
   showCreator: ShowCreatorOption;
   onEndReached: () => void;
   isFetchingNextPage: boolean;
-  isLoadingFirstPage?: boolean;
+  /**
+   * Purple spinner: list body when `HeaderComponent`/`stats` exist, otherwise
+   * full-screen loading (MatchAuthLoadingSurface). Use for initial load / segment
+   * refetch so titles and toggles stay on the FlatList.
+   */
+  listBodyLoading?: boolean;
   showSourceStickers?: boolean;
   demoMode?: boolean;
   stats?: EventStatsData;
@@ -952,7 +958,7 @@ export default function UserEventsList(props: UserEventsListProps) {
     showCreator,
     onEndReached,
     isFetchingNextPage,
-    isLoadingFirstPage = false,
+    listBodyLoading = false,
     showSourceStickers = false,
     demoMode,
     stats,
@@ -1001,20 +1007,8 @@ export default function UserEventsList(props: UserEventsListProps) {
     );
   };
 
-  if (isLoadingFirstPage) {
-    return (
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={{ flex: 1, backgroundColor: "#F4F1FF" }}
-        contentContainerStyle={{
-          flexGrow: 1,
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <ActivityIndicator size="large" color="#5A32FB" />
-      </ScrollView>
-    );
+  if (listBodyLoading && !HeaderComponent && !stats) {
+    return <MatchAuthLoadingSurface />;
   }
 
   if (collapsedEvents.length === 0) {
@@ -1025,6 +1019,25 @@ export default function UserEventsList(props: UserEventsListProps) {
       return renderEmptyState();
     }
   }
+
+  const renderListEmpty = () => {
+    if (listBodyLoading) {
+      return (
+        <View
+          style={{
+            flexGrow: 1,
+            minHeight: 320,
+            justifyContent: "center",
+            alignItems: "center",
+            paddingBottom: 40,
+          }}
+        >
+          <ActivityIndicator size="large" color="#5A32FB" />
+        </View>
+      );
+    }
+    return renderEmptyState(true);
+  };
 
   const renderFooter = () => {
     if (collapsedEvents.length === 0) return null;
@@ -1069,7 +1082,7 @@ export default function UserEventsList(props: UserEventsListProps) {
       data={collapsedEvents}
       keyExtractor={(item) => item.event.id}
       ListHeaderComponent={renderHeader}
-      ListEmptyComponent={() => renderEmptyState(true)}
+      ListEmptyComponent={renderListEmpty}
       renderItem={({ item, index }) => {
         const eventData = item.event;
         // Use savedEventIds if provided, otherwise check eventFollows

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -85,7 +85,6 @@ interface UserEventListItemProps {
   similarEventsCount?: number;
   demoMode?: boolean;
   index: number;
-  isDiscoverFeed?: boolean;
   primaryAction?: "addToCalendar" | "save";
   source?: string;
   sourceListName?: string;
@@ -104,7 +103,6 @@ export function UserEventListItem(props: UserEventListItemProps) {
     similarEventsCount,
     demoMode,
     index,
-    isDiscoverFeed = false,
     primaryAction = "addToCalendar",
     source,
     sourceListName,
@@ -389,30 +387,29 @@ export function UserEventListItem(props: UserEventListItemProps) {
                 <>
                   <ActionButton event={event} />
 
-                  {!isDiscoverFeed &&
-                    (isOwner && primaryAction !== "addToCalendar" ? (
-                      <TouchableOpacity
-                        className="rounded-full p-2.5"
-                        onPress={() => {
-                          router.navigate(`/event/${id}/edit`);
-                        }}
-                        accessibilityLabel="Edit"
-                        accessibilityRole="button"
-                        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                      >
-                        <PenSquare size={iconSize * 1.1} color="#5A32FB" />
-                      </TouchableOpacity>
-                    ) : (
-                      <TouchableOpacity
-                        className="rounded-full p-2.5"
-                        onPress={handleShare}
-                        accessibilityLabel="Share"
-                        accessibilityRole="button"
-                        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                      >
-                        <ShareIcon size={iconSize * 1.1} color="#5A32FB" />
-                      </TouchableOpacity>
-                    ))}
+                  {isOwner && primaryAction !== "addToCalendar" ? (
+                    <TouchableOpacity
+                      className="rounded-full p-2.5"
+                      onPress={() => {
+                        router.navigate(`/event/${id}/edit`);
+                      }}
+                      accessibilityLabel="Edit"
+                      accessibilityRole="button"
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    >
+                      <PenSquare size={iconSize * 1.1} color="#5A32FB" />
+                    </TouchableOpacity>
+                  ) : (
+                    <TouchableOpacity
+                      className="rounded-full p-2.5"
+                      onPress={handleShare}
+                      accessibilityLabel="Share"
+                      accessibilityRole="button"
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    >
+                      <ShareIcon size={iconSize * 1.1} color="#5A32FB" />
+                    </TouchableOpacity>
+                  )}
 
                   <EventMenu
                     event={event}
@@ -939,7 +936,6 @@ interface UserEventsListProps {
   showSourceStickers?: boolean;
   demoMode?: boolean;
   stats?: EventStatsData;
-  isDiscoverFeed?: boolean;
   primaryAction?: "addToCalendar" | "save";
   savedEventIds?: Set<string>;
   HeaderComponent?: React.ComponentType<Record<string, never>>;
@@ -962,7 +958,6 @@ export default function UserEventsList(props: UserEventsListProps) {
     showSourceStickers = false,
     demoMode,
     stats,
-    isDiscoverFeed = false,
     primaryAction = "addToCalendar",
     savedEventIds,
     HeaderComponent,
@@ -1117,7 +1112,6 @@ export default function UserEventsList(props: UserEventsListProps) {
             }
             demoMode={demoMode}
             index={index}
-            isDiscoverFeed={isDiscoverFeed}
             primaryAction={primaryAction}
             source={source}
             sourceListName={sourceListName}

--- a/apps/expo/src/components/UsernameEntryModal.tsx
+++ b/apps/expo/src/components/UsernameEntryModal.tsx
@@ -157,7 +157,7 @@ export function UsernameEntryModal({
           ) : (
             <>
               <Text className="mb-6 text-center font-heading text-xl font-bold text-gray-700">
-                Enter their username
+                Find by username
               </Text>
 
               <View

--- a/apps/expo/src/hooks/useStableFeedListBodyLoading.ts
+++ b/apps/expo/src/hooks/useStableFeedListBodyLoading.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Convex paginated query status (live, not stabilized results). */
+export type StablePaginatedStatus =
+  | "LoadingFirstPage"
+  | "CanLoadMore"
+  | "Exhausted"
+  | "LoadingMore";
+
+function isFirstPageReady(status: StablePaginatedStatus): boolean {
+  return (
+    status === "CanLoadMore" ||
+    status === "Exhausted" ||
+    status === "LoadingMore"
+  );
+}
+
+/**
+ * Shared list-body loading flag for My Soonlist / My Scene: spinner below the
+ * header in {@link UserEventsList}, without replacing the whole screen.
+ *
+ * - Initial load: `LoadingFirstPage` before any page is ready.
+ * - Segment switch: user-driven refetch while `LoadingFirstPage` — including
+ *   if the user switches before the first page resolves (pending ref covers that).
+ *
+ * @param extraLoading — e.g. followed-lists query still undefined (My Scene).
+ * @param enabled — false resets refs (e.g. no followings); still allow `extraLoading`.
+ */
+export function useStableFeedListBodyLoading(
+  status: StablePaginatedStatus,
+  options: {
+    enabled?: boolean;
+    extraLoading?: boolean;
+  } = {},
+) {
+  const { enabled = true, extraLoading = false } = options;
+
+  const [hasReceivedFirstPage, setHasReceivedFirstPage] = useState(
+    () => enabled && isFirstPageReady(status),
+  );
+  const segmentSwitchPendingRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      segmentSwitchPendingRef.current = false;
+      setHasReceivedFirstPage(false);
+      return;
+    }
+    if (status !== "LoadingFirstPage") {
+      segmentSwitchPendingRef.current = false;
+    }
+    if (isFirstPageReady(status)) {
+      setHasReceivedFirstPage(true);
+    }
+  }, [enabled, status]);
+
+  const markSegmentSwitchPending = useCallback(() => {
+    segmentSwitchPendingRef.current = true;
+  }, []);
+
+  const listBodyLoading =
+    extraLoading ||
+    (enabled &&
+      status === "LoadingFirstPage" &&
+      (!hasReceivedFirstPage || segmentSwitchPendingRef.current));
+
+  return { listBodyLoading, markSegmentSwitchPending };
+}

--- a/apps/expo/src/hooks/useStableQuery.ts
+++ b/apps/expo/src/hooks/useStableQuery.ts
@@ -38,7 +38,9 @@ export const useStableQuery = ((name, ...args) => {
  *
  * Note: the returned `status` reflects the live status (including
  * "LoadingMore") so callers can render load-more spinners while pagination
- * is in flight. Only the `results` array is stabilized.
+ * is in flight. Only the `results` array is stabilized. When query args change
+ * (e.g. Upcoming/Past), results stay on the previous page until the new one
+ * loads — pair with segment-aware UI filtering (see `~/utils/feedSegment.ts`).
  *
  * See https://stack.convex.dev/help-my-app-is-overreacting for details.
  *

--- a/apps/expo/src/utils/feedSegment.ts
+++ b/apps/expo/src/utils/feedSegment.ts
@@ -1,0 +1,16 @@
+/**
+ * Upcoming vs Past for My Soonlist / My Scene tabs.
+ *
+ * `useStablePaginatedQuery` keeps the previous segment's rows while the new
+ * query loads; filter by end time so we don't show the wrong tab's events.
+ * `stableTimeMs` is from `useStableTimestamp` in the store (coarse "now").
+ * This does not affect Convex caching — only which stale rows we show per tab.
+ */
+export function eventMatchesFeedSegment(
+  endDateTime: string | Date,
+  segment: "upcoming" | "past",
+  stableTimeMs: number,
+): boolean {
+  const end = new Date(endDateTime).getTime();
+  return segment === "upcoming" ? end >= stableTimeMs : end < stableTimeMs;
+}

--- a/packages/backend/convex/events.ts
+++ b/packages/backend/convex/events.ts
@@ -9,6 +9,7 @@ import {
 } from "./_generated/server";
 import * as Events from "./model/events";
 import { enrichEventsAndFilterNulls } from "./model/events";
+import { getViewableListIds } from "./model/lists";
 
 // Validators for complex types
 const eventMetadataValidator = v.optional(
@@ -94,7 +95,21 @@ export const getSavedIdsForUser = query({
 export const get = query({
   args: { eventId: v.string() },
   handler: async (ctx, args) => {
-    return await Events.getEventById(ctx, args.eventId);
+    const event = await Events.getEventById(ctx, args.eventId);
+    if (!event) return null;
+
+    // Strip lists the viewer can't see so the event-detail attribution
+    // (FromTheseSoonlists / SavedByModal) doesn't leak private list
+    // names or slugs to non-members.
+    const identity = await ctx.auth.getUserIdentity();
+    const viewerId = identity?.subject ?? null;
+    const viewableListIds = await getViewableListIds(
+      ctx,
+      event.lists,
+      viewerId,
+    );
+    const lists = event.lists.filter((l) => viewableListIds.has(l.id));
+    return { ...event, lists };
   },
 });
 

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -433,15 +433,17 @@ export const getPublicUserFeed = query({
   },
 });
 
-/** Sample size for public feed counts (Convex: no `.paginate()` — use `.take()` only). */
-const PUBLIC_FEED_COUNT_CAP = 50;
-const PUBLIC_FEED_COUNT_TAKE = PUBLIC_FEED_COUNT_CAP + 1;
+/**
+ * Bound the scan for "last updated" — we only need the max `addedAt` across a
+ * recent window per bucket, not every historical feed entry.
+ */
+const PUBLIC_FEED_LAST_UPDATED_TAKE = 100;
 
-async function samplePublicUserFeedCount(
+async function sampleMaxAddedAt(
   ctx: QueryCtx,
   feedId: string,
   hasEnded: boolean,
-): Promise<{ count: number; capped: boolean }> {
+): Promise<number> {
   const rows = await ctx.db
     .query("userFeeds")
     .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
@@ -450,26 +452,17 @@ async function samplePublicUserFeedCount(
         .eq("eventVisibility", "public")
         .eq("hasEnded", hasEnded),
     )
-    .order("asc")
-    .take(PUBLIC_FEED_COUNT_TAKE);
-
-  const capped = rows.length === PUBLIC_FEED_COUNT_TAKE;
-  const count = capped ? PUBLIC_FEED_COUNT_CAP : rows.length;
-  return { count, capped };
+    .take(PUBLIC_FEED_LAST_UPDATED_TAKE);
+  let max = 0;
+  for (const row of rows) {
+    if (row.addedAt > max) max = row.addedAt;
+  }
+  return max;
 }
 
-export const getPublicUserFeedCounts = query({
+export const getPublicUserFeedLastUpdated = query({
   args: { username: v.string() },
-  returns: v.object({
-    upcoming: v.object({
-      count: v.number(),
-      capped: v.boolean(),
-    }),
-    past: v.object({
-      count: v.number(),
-      capped: v.boolean(),
-    }),
-  }),
+  returns: v.union(v.number(), v.null()),
   handler: async (ctx, { username }) => {
     const user = await ctx.db
       .query("users")
@@ -481,12 +474,12 @@ export const getPublicUserFeedCounts = query({
     }
 
     const feedId = `user_${user.id}`;
-    const [upcoming, past] = await Promise.all([
-      samplePublicUserFeedCount(ctx, feedId, false),
-      samplePublicUserFeedCount(ctx, feedId, true),
+    const [upcomingMax, pastMax] = await Promise.all([
+      sampleMaxAddedAt(ctx, feedId, false),
+      sampleMaxAddedAt(ctx, feedId, true),
     ]);
-
-    return { upcoming, past };
+    const max = Math.max(upcomingMax, pastMax);
+    return max > 0 ? max : null;
   },
 });
 

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -444,6 +444,12 @@ async function sampleMaxAddedAt(
   feedId: string,
   hasEnded: boolean,
 ): Promise<number> {
+  // The index is ordered by startTime, not addedAt. We don't have a recency
+  // index on addedAt, so we sample the slice most likely to contain recent
+  // additions: near-term upcoming (asc) or most-recent past (desc). A new
+  // event added far from "now" in startTime can still be missed, but most
+  // recent activity clusters here so the "Last updated" label stays fresh.
+  const order = hasEnded ? "desc" : "asc";
   const rows = await ctx.db
     .query("userFeeds")
     .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
@@ -452,7 +458,7 @@ async function sampleMaxAddedAt(
         .eq("eventVisibility", "public")
         .eq("hasEnded", hasEnded),
     )
-    .order("desc")
+    .order(order)
     .take(PUBLIC_FEED_LAST_UPDATED_TAKE);
   let max = 0;
   for (const row of rows) {

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -452,6 +452,7 @@ async function sampleMaxAddedAt(
         .eq("eventVisibility", "public")
         .eq("hasEnded", hasEnded),
     )
+    .order("desc")
     .take(PUBLIC_FEED_LAST_UPDATED_TAKE);
   let max = 0;
   for (const row of rows) {

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -433,36 +433,42 @@ export const getPublicUserFeed = query({
   },
 });
 
-/** Total public feed entries for a user (matches `getPublicUserFeed` filters). */
-async function countPublicUserFeedEntries(
+/** Sample size for public feed counts (Convex: no `.paginate()` — use `.take()` only). */
+const PUBLIC_FEED_COUNT_CAP = 50;
+const PUBLIC_FEED_COUNT_TAKE = PUBLIC_FEED_COUNT_CAP + 1;
+
+async function samplePublicUserFeedCount(
   ctx: QueryCtx,
   feedId: string,
   hasEnded: boolean,
-): Promise<number> {
-  let total = 0;
-  let cursor: string | null = null;
-  for (let i = 0; i < 250; i++) {
-    const result = await ctx.db
-      .query("userFeeds")
-      .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
-        q
-          .eq("feedId", feedId)
-          .eq("eventVisibility", "public")
-          .eq("hasEnded", hasEnded),
-      )
-      .paginate({ numItems: 500, cursor });
-    total += result.page.length;
-    if (result.isDone) break;
-    cursor = result.continueCursor;
-  }
-  return total;
+): Promise<{ count: number; capped: boolean }> {
+  const rows = await ctx.db
+    .query("userFeeds")
+    .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
+      q
+        .eq("feedId", feedId)
+        .eq("eventVisibility", "public")
+        .eq("hasEnded", hasEnded),
+    )
+    .order("asc")
+    .take(PUBLIC_FEED_COUNT_TAKE);
+
+  const capped = rows.length === PUBLIC_FEED_COUNT_TAKE;
+  const count = capped ? PUBLIC_FEED_COUNT_CAP : rows.length;
+  return { count, capped };
 }
 
 export const getPublicUserFeedCounts = query({
   args: { username: v.string() },
   returns: v.object({
-    upcoming: v.number(),
-    past: v.number(),
+    upcoming: v.object({
+      count: v.number(),
+      capped: v.boolean(),
+    }),
+    past: v.object({
+      count: v.number(),
+      capped: v.boolean(),
+    }),
   }),
   handler: async (ctx, { username }) => {
     const user = await ctx.db
@@ -476,8 +482,8 @@ export const getPublicUserFeedCounts = query({
 
     const feedId = `user_${user.id}`;
     const [upcoming, past] = await Promise.all([
-      countPublicUserFeedEntries(ctx, feedId, false),
-      countPublicUserFeedEntries(ctx, feedId, true),
+      samplePublicUserFeedCount(ctx, feedId, false),
+      samplePublicUserFeedCount(ctx, feedId, true),
     ]);
 
     return { upcoming, past };

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -433,6 +433,57 @@ export const getPublicUserFeed = query({
   },
 });
 
+/** Total public feed entries for a user (matches `getPublicUserFeed` filters). */
+async function countPublicUserFeedEntries(
+  ctx: QueryCtx,
+  feedId: string,
+  hasEnded: boolean,
+): Promise<number> {
+  let total = 0;
+  let cursor: string | null = null;
+  for (let i = 0; i < 250; i++) {
+    const result = await ctx.db
+      .query("userFeeds")
+      .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
+        q
+          .eq("feedId", feedId)
+          .eq("eventVisibility", "public")
+          .eq("hasEnded", hasEnded),
+      )
+      .paginate({ numItems: 500, cursor });
+    total += result.page.length;
+    if (result.isDone) break;
+    cursor = result.continueCursor;
+  }
+  return total;
+}
+
+export const getPublicUserFeedCounts = query({
+  args: { username: v.string() },
+  returns: v.object({
+    upcoming: v.number(),
+    past: v.number(),
+  }),
+  handler: async (ctx, { username }) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_username", (q) => q.eq("username", username))
+      .unique();
+
+    if (!user) {
+      throw new ConvexError("User not found");
+    }
+
+    const feedId = `user_${user.id}`;
+    const [upcoming, past] = await Promise.all([
+      countPublicUserFeedEntries(ctx, feedId, false),
+      countPublicUserFeedEntries(ctx, feedId, true),
+    ]);
+
+    return { upcoming, past };
+  },
+});
+
 // Internal mutation to update hasEndedFlags for a batch of userFeeds entries
 export const updateHasEndedFlagsBatch = internalMutation({
   args: {


### PR DESCRIPTION
## Summary
- Redesign public profiles with a Soonlist-led header, compact byline, contact links, last-updated metadata, and an Upcoming/Past segment toggle backed by new Convex feed queries (counts capped at 50+, `getPublicUserFeedLastUpdated`)
- Unify "From these Soonlists" attribution across event detail and `SavedByModal` with a shared `FromTheseSoonlists` component; align profile/discover action rows with the Following icon row
- Tighten onboarding: refreshed try-it/paywall copy, tappable Jaron Instagram link, aligned sign-in footer with paywall Continue, and inline profile modal header
- Smoother feed loading: `MatchAuthLoadingSurface`, in-list spinners via `useStableFeedListBodyLoading`, segment-aware filtering through `eventMatchesFeedSegment`, memoized `savedEventIds`
- Misc fixes: share-setup sheet detents/top inset, remove Share App from profile menu, Soonlist wording across empty states

## Test plan
- [ ] Public profile (own + other user): header, byline, contact links, last-updated, Upcoming/Past toggle, 50+ cap rendering
- [ ] Event detail + SavedByModal: single-creator inline, multi-creator card, +N overflow
- [ ] Onboarding flow through paywall → sign-in on iOS; Jaron Instagram link opens
- [ ] Feed/Following/Discover: loading spinners, segment switches, saved-heart state
- [ ] Share-setup sheet detents (0.4/0.8, edit locks to 0.8) on iOS
- [ ] `pnpm lint:fix && pnpm check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Expo app with redesigned public profiles, unified attribution, smoother feed loading, and tighter onboarding. Adds a “Last updated” backend query for profiles with improved sampling to reflect recent activity and filters private lists server-side.

- New Features
  - Public profiles: Soonlist-first header, compact byline with contact icons, joined line, “Last updated,” and Upcoming/Past toggle (`getPublicUserFeedLastUpdated` with near-term upcoming asc and recent past desc sampling).
  - Unified attribution: new `FromTheseSoonlists` used on event detail and in `SavedByModal` (single-creator inline; multi as a tinted card). Slugless non-system lists are shown but not tappable.

- Polish & Fixes
  - Standardized action row on Discover/Profile (save/share/edit/menu); owners see Edit instead of Save.
  - Feed loading: in-list spinners via `MatchAuthLoadingSurface` + `useStableFeedListBodyLoading`; segment-aware filtering with `eventMatchesFeedSegment`; memoized saved IDs (feed/following/discover/profile).
  - Privacy/attribution: `events.get` strips unviewable lists so attribution doesn’t leak private list names/slugs; event detail shows visibility row only to owners; “Last updated” sampling refined as above.
  - Onboarding and UI: iOS share-setup detents 0.4/0.8 with reduced top inset; removed “Share App” from profile menu; “Soonlists” wording and softer “Find by username”; profile uses a standard nav bar; refreshed onboarding copy with a tappable Jaron Instagram link and aligned sign-in footer.

<sup>Written for commit bcf7eeaa15f03b34b727b00e430cacd54d8913a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a substantial Expo polish pass: redesigned public profiles with segment picker and "Last updated" metadata, a new `FromTheseSoonlists` attribution component shared between event detail and `SavedByModal`, smoother feed loading via `useStableFeedListBodyLoading` and `eventMatchesFeedSegment`, and refreshed onboarding copy.

- **`getPublicUserFeed` skips the list-visibility filter** that `queryFeed`/`queryGroupedFeed` apply via `getViewableListIds`. Private list names and slugs belonging to co-savers are sent in the API response to unauthenticated callers viewing a public profile.
- **`sampleMaxAddedAt` samples the 100 nearest-`startTime` rows** to compute `max(addedAt)`. For a user whose events span > 100 slots by start time, the most-recently-added (but far-future-dated) events fall outside the window, causing the "Last updated" label to show a stale time.

<h3>Confidence Score: 4/5</h3>

Hold for the privacy fix in `getPublicUserFeed` before merging.

One P1 security finding (private list metadata returned to unauthenticated callers) blocks a clean merge. The rest of the changes are well-executed.

`packages/backend/convex/feeds.ts` — `getPublicUserFeed` needs `getViewableListIds` filtering; `sampleMaxAddedAt` sampling direction.

<details open><summary><h3>Security Review</h3></summary>

- **Private list metadata exposure** (`packages/backend/convex/feeds.ts`, `getPublicUserFeed`): `event.lists` is returned to unauthenticated callers without filtering through `getViewableListIds`. An event saved to a public feed may also belong to private lists owned by other users; their `name` and `slug` are included in the wire response.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/feeds.ts | Adds `getPublicUserFeedLastUpdated` and `sampleMaxAddedAt`; `getPublicUserFeed` omits the `getViewableListIds` list-privacy filter that `queryFeed`/`queryGroupedFeed` apply, leaking private list metadata to unauthenticated callers. |
| apps/expo/src/app/[username]/index.tsx | Redesigns the public profile with header, byline, contact links, segment picker, and last-updated label. `savedEventIds` is not wrapped in `useMemo`, unlike the parallel fix applied in feed/following tabs. |
| apps/expo/src/components/FromTheseSoonlists.tsx | New shared attribution component with compact/card variants; clean design. |
| apps/expo/src/app/(tabs)/feed/index.tsx | Adds `MatchAuthLoadingSurface`, `useStableFeedListBodyLoading`, segment-aware filtering, and correctly memoized `savedEventIds`. |
| apps/expo/src/app/(tabs)/following/index.tsx | Same loading/segment improvements as feed tab; correctly handles the no-followings case. |
| apps/expo/src/hooks/useStableFeedListBodyLoading.ts | New hook driving in-list loading spinners; handles initial load and segment-switch pending state cleanly. |
| apps/expo/src/utils/feedSegment.ts | New utility for client-side segment-aware stale-row filtering; simple and correct. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Expo Client
    participant PUF as getPublicUserFeed
    participant PUFL as getPublicUserFeedLastUpdated
    participant queryFeed as queryFeed (private)
    participant DB as Convex DB

    Client->>PUF: username, filter, paginationOpts
    PUF->>DB: query userFeeds (by_feed_visibility_hasEnded_startTime)
    DB-->>PUF: feed entries
    PUF->>DB: getEventById per entry
    DB-->>PUF: events (with ALL lists, unfiltered ⚠️)
    PUF-->>Client: events (private list names leaked)

    Client->>PUFL: username
    PUFL->>DB: take(100) ordered by startTime
    DB-->>PUFL: first 100 rows by startTime
    PUFL-->>Client: max(addedAt) — may be stale ⚠️

    note over queryFeed,DB: getViewableListIds filters event.lists before returning ✅
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/backend/convex/feeds.ts`, line 393-433 ([link](https://github.com/jaronheard/soonlist-turbo/blob/8ecacd4f66ecdc2e6a7e817b7f323e247a9ea648/packages/backend/convex/feeds.ts#L393-L433)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Private list names/slugs leak to unauthenticated callers**

   `getPublicUserFeed` returns `event.lists` directly from `getEventById` without running it through `getViewableListIds`. An event saved by a public user may also belong to private lists owned by other users; those lists' `name` and `slug` fields are included in the API response and visible to any unauthenticated caller inspecting the wire payload.

   `queryFeed` and `queryGroupedFeed` both apply the filter explicitly, with a comment calling out exactly this risk:

   ```ts
   // Strip private-unviewable lists from `event.lists` before sending to the
   // client. The "Saved by" modal (SavedByModal) renders this array
   // directly, so any private list that leaks here leaks its name/slug to
   // viewers who can see the event but not the list.
   ```

   `getPublicUserFeed` needs the same guard before returning:

   ```ts
   const viewerId = await getUserId(ctx);
   const events = await Promise.all(
     feedResults.page.map(async (entry) => {
       const event = await getEventById(ctx, entry.eventId);
       if (!event) return null;
       const viewableListIds = await getViewableListIds(
         ctx,
         event.lists ?? [],
         viewerId,
       );
       return {
         ...event,
         lists: (event.lists ?? []).filter((l) => viewableListIds.has(l.id)),
       };
     }),
   );
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/feeds.ts
   Line: 393-433

   Comment:
   **Private list names/slugs leak to unauthenticated callers**

   `getPublicUserFeed` returns `event.lists` directly from `getEventById` without running it through `getViewableListIds`. An event saved by a public user may also belong to private lists owned by other users; those lists' `name` and `slug` fields are included in the API response and visible to any unauthenticated caller inspecting the wire payload.

   `queryFeed` and `queryGroupedFeed` both apply the filter explicitly, with a comment calling out exactly this risk:

   ```ts
   // Strip private-unviewable lists from `event.lists` before sending to the
   // client. The "Saved by" modal (SavedByModal) renders this array
   // directly, so any private list that leaks here leaks its name/slug to
   // viewers who can see the event but not the list.
   ```

   `getPublicUserFeed` needs the same guard before returning:

   ```ts
   const viewerId = await getUserId(ctx);
   const events = await Promise.all(
     feedResults.page.map(async (entry) => {
       const event = await getEventById(ctx, entry.eventId);
       if (!event) return null;
       const viewableListIds = await getViewableListIds(
         ctx,
         event.lists ?? [],
         viewerId,
       );
       return {
         ...event,
         lists: (event.lists ?? []).filter((l) => viewableListIds.has(l.id)),
       };
     }),
   );
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/feeds.ts
Line: 393-433

Comment:
**Private list names/slugs leak to unauthenticated callers**

`getPublicUserFeed` returns `event.lists` directly from `getEventById` without running it through `getViewableListIds`. An event saved by a public user may also belong to private lists owned by other users; those lists' `name` and `slug` fields are included in the API response and visible to any unauthenticated caller inspecting the wire payload.

`queryFeed` and `queryGroupedFeed` both apply the filter explicitly, with a comment calling out exactly this risk:

```ts
// Strip private-unviewable lists from `event.lists` before sending to the
// client. The "Saved by" modal (SavedByModal) renders this array
// directly, so any private list that leaks here leaks its name/slug to
// viewers who can see the event but not the list.
```

`getPublicUserFeed` needs the same guard before returning:

```ts
const viewerId = await getUserId(ctx);
const events = await Promise.all(
  feedResults.page.map(async (entry) => {
    const event = await getEventById(ctx, entry.eventId);
    if (!event) return null;
    const viewableListIds = await getViewableListIds(
      ctx,
      event.lists ?? [],
      viewerId,
    );
    return {
      ...event,
      lists: (event.lists ?? []).filter((l) => viewableListIds.has(l.id)),
    };
  }),
);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/feeds.ts
Line: 442-461

Comment:
**`sampleMaxAddedAt` scans earliest-startTime rows, not latest-addedAt rows**

The index `by_feed_visibility_hasEnded_startTime` orders rows by `startTime`. `.take(100)` therefore yields the 100 upcoming events with the nearest start times. A user who adds a new event far in the future (position 101+ by start time) will have that event's `addedAt` skipped entirely, so the "Last updated" label on the public profile shows a stale timestamp.

Consider reversing the scan direction (`.order("desc").take(100)`) to pick the events with the latest start times, which tend to be recently-added. Alternatively, if a dedicated `addedAt` index exists, use it; if not, a full-scan with a `reduce` on the server is also acceptable given the low frequency of this query.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/app/[username]/index.tsx
Line: 390-393

Comment:
**`savedEventIds` not memoized**

A new `Set` is allocated on every render here. The PR description calls out "memoized `savedEventIds`" as one of the smoother-feed-loading fixes, and `feed/index.tsx` (line 142–144) and `following/index.tsx` (line 188–190) both use `useMemo` for this. The same pattern is also missed in `discover.tsx` (line 66–68).

```suggestion
  const savedEventIds = useMemo(
    () => new Set(savedEventIdsQuery?.map((event) => event.id) ?? []),
    [savedEventIdsQuery],
  );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(expo): fix CI lint and prettier"](https://github.com/jaronheard/soonlist-turbo/commit/8ecacd4f66ecdc2e6a7e817b7f323e247a9ea648) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29080869)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->