### PR TITLE
fix(lists): include feedBackfilledAt in getBySlug validator

### DIFF
--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -734,6 +734,7 @@ export const getBySlug = query({
         slug: v.optional(v.string()),
         created_at: v.string(),
         updatedAt: v.union(v.string(), v.null()),
+        feedBackfilledAt: v.optional(v.string()),
         owner: listOwnerValidator,
         contributorCount: v.number(),
         followerCount: v.number(),


### PR DESCRIPTION
## Summary
- Hotfix: `lists.getBySlug` return validator was missing `feedBackfilledAt`, causing `ReturnsValidationError` in prod once the `backfillListFeeds` migration stamped the field onto existing lists (e.g. `pdx-discover`)
- `feedBackfilledAt` is optional in the schema (added in #1021) but the query spreads `...list` into its return, so the validator must allow it

## Test plan
- [ ] Open `/list/pdx-discover` on web and Expo — no more server error
- [ ] `pnpm --filter @soonlist/backend typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a production ReturnsValidationError in `lists.getBySlug` by including the optional `feedBackfilledAt` field in the return validator. This aligns the validator with the list schema and supports lists updated by the `backfillListFeeds` migration.

<sup>Written for commit 97f639873250b8af0b2e23e2a3944c8cee43df4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix adds the missing `feedBackfilledAt: v.optional(v.string())` field to the `getBySlug` return validator in `lists.ts`, resolving a `ReturnsValidationError` that fired in production after the `backfillListFeeds` migration stamped the field onto existing list documents. The fix correctly mirrors the optional field declaration already present in `schema.ts`, and other query validators that return list data (`getOgData`) project a narrower subset and are not affected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line validator fix that restores production parity with the schema definition.

The change is minimal, correct, and directly addresses the root cause. The field is already `v.optional` in the schema, so adding it as optional in the validator introduces no breaking change. No other query validators are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/lists.ts | Adds `feedBackfilledAt: v.optional(v.string())` to the `getBySlug` return validator, correctly matching the schema definition and fixing the production `ReturnsValidationError`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["backfillListFeeds migration\nstamps feedBackfilledAt onto lists"] --> B["lists DB doc\nnow has feedBackfilledAt field"]
    B --> C["getBySlug query\nreturns ...list spread"]
    C --> D{"Return validator\ncheck"}
    D -- "Before fix\n(field absent in validator)" --> E["❌ ReturnsValidationError\nin production"]
    D -- "After fix\n(feedBackfilledAt: v.optional)" --> F["✅ Validation passes\npage loads normally"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(lists): include feedBackfilledAt in ..."](https://github.com/jaronheard/soonlist-turbo/commit/97f639873250b8af0b2e23e2a3944c8cee43df4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29083336)</sub>

<!-- /greptile_comment -->