### PR TITLE
feat(onboarding): redesign paywall with emoji feature rows

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -83,7 +83,9 @@ export default function CommunitySupportedScreen() {
                   <Text className="text-3xl">{emoji}</Text>
                 </View>
                 <View className="min-w-0 flex-1 pt-0.5">
-                  <Text className="text-lg font-semibold text-white">{title}</Text>
+                  <Text className="text-lg font-semibold text-white">
+                    {title}
+                  </Text>
                   <Text className="mt-1 text-base leading-snug text-white/70">
                     {description}
                   </Text>

--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import * as StoreReview from "expo-store-review";
 
-import { Check } from "~/components/icons";
 import { QuestionContainer } from "~/components/QuestionContainer";
 import { useOnboarding } from "~/hooks/useOnboarding";
 import {
@@ -13,10 +12,26 @@ import {
 } from "~/store";
 import { hapticLight } from "~/utils/feedback";
 
-const BULLETS = [
-  "Save events and share lists, free",
-  "No ads. No algorithm. No data sold.",
-  "Support for extras, not access",
+const FEATURE_ROWS: {
+  emoji: string;
+  title: string;
+  description: string;
+}[] = [
+  {
+    emoji: "📅",
+    title: "Save events and share lists",
+    description: "Free to use and share.",
+  },
+  {
+    emoji: "🛡️",
+    title: "No ads. No algorithm. No data sold.",
+    description: "We value your attention.",
+  },
+  {
+    emoji: "💝",
+    title: "Support for extras, not access",
+    description: "Optional extras fund the app.",
+  },
 ];
 
 const JARON_INSTAGRAM_URL = "https://www.instagram.com/jaronheard/";
@@ -55,20 +70,27 @@ export default function CommunitySupportedScreen() {
   return (
     <QuestionContainer
       question="Soonlist is free."
-      subtitle="Free because community access matters. You can support the app and unlock extras, but the essentials stay free for everyone."
+      subtitle="Free because community access matters."
       currentStep={currentStep}
       totalSteps={totalSteps}
     >
       <View className="flex-1 justify-between">
-        <View className="mt-4">
-          {BULLETS.map((text) => (
-            <View key={text} className="mb-5 flex-row items-start">
-              <View className="mr-3 mt-1 h-6 w-6 items-center justify-center rounded-full bg-white">
-                <Check size={16} color="#5A32FB" strokeWidth={3} />
+        <View className="flex-1 justify-center">
+          <View className="gap-6">
+            {FEATURE_ROWS.map(({ emoji, title, description }) => (
+              <View key={title} className="flex-row items-start gap-4">
+                <View className="h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-white">
+                  <Text className="text-3xl">{emoji}</Text>
+                </View>
+                <View className="min-w-0 flex-1 pt-0.5">
+                  <Text className="text-lg font-semibold text-white">{title}</Text>
+                  <Text className="mt-1 text-base leading-snug text-white/70">
+                    {description}
+                  </Text>
+                </View>
               </View>
-              <Text className="flex-1 text-lg text-white">{text}</Text>
-            </View>
-          ))}
+            ))}
+          </View>
         </View>
 
         <View>


### PR DESCRIPTION
## Summary
- Replace check-bullet list on paywall screen with emoji tiles, feature titles, and supporting descriptions
- Tighten subtitle copy to keep the key framing ("Free because community access matters") without the longer follow-up
- Center feature rows vertically and drop the now-unused `Check` icon import

## Test plan
- [ ] Run the onboarding flow on iOS and verify the paywall screen renders the three feature rows with emoji tiles
- [ ] Confirm spacing/alignment looks correct on small and large device sizes
- [ ] Confirm CTAs and Jaron attribution still work as expected

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the onboarding paywall to use emoji feature rows with titles and short descriptions, replacing the check-bullet list. Tightened the subtitle and centered content for a cleaner, more readable layout.

- **Refactors**
  - Replaced `BULLETS` with `FEATURE_ROWS` (emoji, title, description) and updated render logic; applied Prettier formatting to the paywall title.
  - Centered feature rows vertically and adjusted spacing.
  - Shortened subtitle to “Free because community access matters.”
  - Removed unused `Check` icon import.

<sup>Written for commit 2592ee99caa3f3446e3acde360637bd447618e50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the check-bullet list on the paywall screen with three emoji tile feature rows, each with a title and supporting description, tightens the subtitle copy, vertically centers the feature section, and removes the unused `Check` icon import. The change is purely presentational with no logic modifications.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure UI redesign with no logic changes and no issues found.

All changes are cosmetic: a new static data array, updated JSX layout, and a copy tweak. No business logic, navigation, or state management was altered. No P0/P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx | Paywall screen redesigned with emoji tile feature rows; removes Check icon import, tightens subtitle copy, and centers feature list vertically using flex layout. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(onboarding): redesign paywall with ..."](https://github.com/jaronheard/soonlist-turbo/commit/07629b6fd37effc86e2b4386557dd2e7e287cbbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29096105)</sub>

<!-- /greptile_comment -->