### PR TITLE
Improve followed lists UI with owner attribution and better layout

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -5,8 +5,8 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Platform, Share, Text, TouchableOpacity, View } from "react-native";
-import { Redirect } from "expo-router";
+import { Platform, Text, TouchableOpacity, View } from "react-native";
+import { Redirect, useRouter } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
 import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
@@ -28,7 +28,6 @@ import UserEventsList from "~/components/UserEventsList";
 import { useStableFeedListBodyLoading } from "~/hooks/useStableFeedListBodyLoading";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useAppStore, useStableTimestamp } from "~/store";
-import { logError } from "~/utils/errorLogging";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type Segment = "upcoming" | "past";
@@ -80,6 +79,7 @@ function SegmentedControlFallback({
 
 function FollowingFeedContent() {
   const { user } = useUser();
+  const router = useRouter();
   const [selectedSegment, setSelectedSegment] = useState<Segment>("upcoming");
   const [isModalVisible, setIsModalVisible] = useState(false);
   const stableTimestamp = useStableTimestamp();
@@ -216,23 +216,6 @@ function FollowingFeedContent() {
   const singleFollowedList =
     followedListCount === 1 ? followedLists?.[0] : null;
 
-  const handleShareList = useCallback(
-    async (listName: string, listSlug?: string) => {
-      const shareUrl = listSlug
-        ? `https://soonlist.com/list/${listSlug}`
-        : "https://soonlist.com";
-      try {
-        await Share.share({
-          message: `Check out ${listName} on Soonlist`,
-          url: shareUrl,
-        });
-      } catch (error) {
-        logError("Error sharing list", error);
-      }
-    },
-    [],
-  );
-
   const HeaderComponent = useCallback(() => {
     return (
       <View className="px-3 pb-2" style={{ marginTop: -4 }}>
@@ -245,11 +228,8 @@ function FollowingFeedContent() {
         {followedListCount > 0 && (
           <TouchableOpacity
             onPress={() => {
-              if (singleFollowedList) {
-                void handleShareList(
-                  singleFollowedList.name,
-                  singleFollowedList.slug ?? undefined,
-                );
+              if (singleFollowedList?.slug) {
+                router.push(`/list/${singleFollowedList.slug}`);
               } else {
                 setIsModalVisible(true);
               }
@@ -300,7 +280,7 @@ function FollowingFeedContent() {
     handleSegmentChange,
     followedListCount,
     singleFollowedList,
-    handleShareList,
+    router,
   ]);
 
   // Second branch avoids a one-frame flash before the latch effect commits.

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -15,7 +15,7 @@ import { useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { ChevronRight, List, ShareIcon } from "~/components/icons";
+import { List, ShareIcon } from "~/components/icons";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
@@ -119,38 +119,44 @@ export function FollowedListsModal({
               paddingTop: 16,
               paddingBottom: insets.bottom + 16,
             }}
-            ListHeaderComponent={
-              <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-2">
-                Lists
-              </Text>
-            }
+            ItemSeparatorComponent={() => (
+              <View className="h-px bg-neutral-3" />
+            )}
             renderItem={({ item: list }) => {
+              const ownerName = list.ownerDisplayName ?? list.ownerUsername;
               return (
-                <View className="flex-row items-center py-3">
+                <View className="flex-row items-center gap-3 py-4">
                   <TouchableOpacity
-                    className="flex-1 flex-row items-center"
+                    className="min-w-0 flex-1 flex-row items-center gap-4"
                     onPress={() => handleListPress(list)}
                     activeOpacity={0.7}
                   >
-                    <View className="h-10 w-10 items-center justify-center rounded-xl bg-interactive-2">
-                      <List size={20} color="#5A32FB" />
+                    <View className="h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-interactive-2">
+                      <List size={24} color="#5A32FB" />
                     </View>
-                    <View className="ml-3 flex-1">
+                    <View className="min-w-0 flex-1">
                       <Text
-                        className="text-base font-semibold text-neutral-1"
+                        className="text-lg font-bold text-neutral-1"
                         numberOfLines={1}
                       >
                         {list.name}
                       </Text>
+                      {ownerName ? (
+                        <Text
+                          className="mt-0.5 text-sm text-neutral-2"
+                          numberOfLines={1}
+                        >
+                          by {ownerName}
+                        </Text>
+                      ) : null}
                     </View>
-                    <ChevronRight size={16} color="#DCE0E8" />
                   </TouchableOpacity>
 
                   <TouchableOpacity
                     onPress={() =>
                       void handleShareList(list.name, list.slug ?? undefined)
                     }
-                    className="ml-2 rounded-full p-2"
+                    className="rounded-full p-2"
                     activeOpacity={0.7}
                     accessibilityLabel={`Share ${list.name}`}
                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -158,14 +164,12 @@ export function FollowedListsModal({
                     <ShareIcon size={18} color="#5A32FB" />
                   </TouchableOpacity>
 
-                  <View className="ml-1">
-                    <SubscribeButton
-                      isSubscribed={true}
-                      onPress={() => handleUnfollow(list.id)}
-                      size="sm"
-                      accessibilityLabel={`Unsubscribe from ${list.name}`}
-                    />
-                  </View>
+                  <SubscribeButton
+                    isSubscribed={true}
+                    onPress={() => handleUnfollow(list.id)}
+                    size="sm"
+                    accessibilityLabel={`Unsubscribe from ${list.name}`}
+                  />
                 </View>
               );
             }}

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -482,14 +482,23 @@ export const unfollowList = mutation({
 });
 
 /**
- * Get all lists a user follows
+ * Get all lists a user follows.
+ *
+ * Enriched with `ownerDisplayName` / `ownerUsername` so the mobile
+ * Subscribed Lists UI can show "by {owner}" attribution without an extra
+ * per-row query. Both are optional so optimistic updates elsewhere that
+ * push bare `Doc<"lists">` entries into this query's cache continue to
+ * type-check — the server response fills them back in.
  */
 export const getFollowedLists = query({
   args: {},
   handler: async (ctx) => {
     const userId = await getUserId(ctx);
     if (!userId) {
-      return [];
+      return [] as (Doc<"lists"> & {
+        ownerDisplayName?: string;
+        ownerUsername?: string;
+      })[];
     }
 
     const follows = await ctx.db
@@ -513,7 +522,19 @@ export const getFollowedLists = query({
           return null;
         }
 
-        return list;
+        const owner = await ctx.db
+          .query("users")
+          .withIndex("by_custom_id", (q) => q.eq("id", list.userId))
+          .first();
+
+        return {
+          ...list,
+          ownerDisplayName: owner?.displayName,
+          ownerUsername: owner?.username,
+        } as Doc<"lists"> & {
+          ownerDisplayName?: string;
+          ownerUsername?: string;
+        };
       }),
     );
 


### PR DESCRIPTION
## Summary
Enhanced the followed lists modal and navigation to display list owner information and improved the visual layout with better spacing and typography. Also refactored list sharing logic to navigate directly to list pages instead of using native share.

## Key Changes

- **FollowedListsModal.tsx**
  - Removed unused `ChevronRight` icon import
  - Added `ItemSeparatorComponent` to display dividers between list items
  - Increased icon size from 20 to 24 and container from 10x10 to 12x12
  - Enhanced typography: list name now uses `text-lg font-bold` instead of `text-base font-semibold`
  - Added owner attribution display showing "by {ownerName}" below list title
  - Improved spacing with `gap-3` and `gap-4` utilities
  - Removed `ChevronRight` icon from list items
  - Simplified `SubscribeButton` wrapper by removing unnecessary `View` container
  - Updated padding and margins for better visual hierarchy

- **following/index.tsx**
  - Removed unused `Share` import from react-native
  - Added `useRouter` hook from expo-router
  - Removed `handleShareList` function and `logError` import
  - Changed list action from sharing to navigation: now navigates to `/list/{slug}` instead of triggering native share
  - Updated header component to use router navigation for single followed list

- **lists.ts (Convex backend)**
  - Enhanced `getFollowedLists` query to include owner information
  - Added `ownerDisplayName` and `ownerUsername` fields to query response
  - Performs per-list owner lookup to enrich results with user display name and username
  - Updated JSDoc to document the enrichment behavior and explain optional fields for cache compatibility

## Implementation Details
The owner information is fetched server-side in the Convex query to avoid N+1 queries on the client. The fields are marked optional to maintain compatibility with optimistic updates that may push bare list documents into the query cache before the server response fills in the owner details.

https://claude.ai/code/session_01CTCf5it81mv7vQmasRbeD3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the Followed Lists modal with owner attribution and a cleaner layout, and fixed the single-list header to open the list page instead of sharing. Backend now enriches followed lists with owner info to avoid extra queries.

- **New Features**
  - Show "by {owner}" under each list, using data from `convex` `getFollowedLists` (adds optional `ownerDisplayName` / `ownerUsername`).
  - Layout updates: larger icon (24 in 12x12), bold title, better spacing, and item dividers.

- **Bug Fixes**
  - Tapping a single subscribed list in the Following tab now navigates to `/list/{slug}` via `expo-router` instead of triggering native share.

<sup>Written for commit 41d84839a169b41af89992f9f9a73e650b765a33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the followed-lists UI with owner attribution ("by {ownerName}"), better spacing/typography, and changes the single-list header tap to navigate directly to `/list/{slug}` instead of opening the modal. The Convex `getFollowedLists` query is enriched server-side with `ownerDisplayName`/`ownerUsername`; both fields are optional to stay compatible with optimistic-update cache entries that push bare list docs before the server response fills them in.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic bugs or data-integrity issues; remaining findings are P2 style suggestions.

All three files are clean: slug/null guards are properly applied before route construction, the optimistic update correctly filters the enriched list array, and the server-side owner enrichment is scoped and safe. The only open items are a minor type annotation width in FollowedListsModal and a cosmetically redundant DB read that Convex deduplicates anyway — neither blocks merge.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/following/index.tsx | Removed Share/logError imports, added router navigation for single-list header tap; slug guard is correctly applied before route construction. |
| apps/expo/src/components/FollowedListsModal.tsx | Adds owner attribution display, ItemSeparator, larger icons, and improved layout; handleListPress type annotation is slightly narrower than the enriched items passed to it (P2 style). |
| packages/backend/convex/lists.ts | getFollowedLists enriched with ownerDisplayName/ownerUsername via per-list user lookup; optional fields preserve optimistic-update cache compatibility; minor redundant DB read in canUserViewList (Convex deduplicates within a transaction). |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/backend/convex/lists.ts`, line 520-523 ([link](https://github.com/jaronheard/soonlist-turbo/blob/41d84839a169b41af89992f9f9a73e650b765a33/packages/backend/convex/lists.ts#L520-L523)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant list lookup in `getFollowedLists`**

   `canUserViewList` internally calls `checkListAccess`, which re-queries `lists` by `by_custom_id` for the same `follow.listId` — a document already fetched two lines above. Convex deduplicates reads within a transaction so there's no extra round-trip cost, but the check can be short-circuited using the already-fetched doc to keep the intent clear:

   Alternatively, pass the already-fetched `list` to a shared helper so the second query is skipped entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/lists.ts
   Line: 520-523

   Comment:
   **Redundant list lookup in `getFollowedLists`**

   `canUserViewList` internally calls `checkListAccess`, which re-queries `lists` by `by_custom_id` for the same `follow.listId` — a document already fetched two lines above. Convex deduplicates reads within a transaction so there's no extra round-trip cost, but the check can be short-circuited using the already-fetched doc to keep the intent clear:

   Alternatively, pass the already-fetched `list` to a shared helper so the second query is skipped entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/expo/src/components/FollowedListsModal.tsx`, line 73-81 ([link](https://github.com/jaronheard/soonlist-turbo/blob/41d84839a169b41af89992f9f9a73e650b765a33/apps/expo/src/components/FollowedListsModal.tsx#L73-L81)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Parameter type narrows away the enriched fields**

   `handleListPress` is typed as `(list: Doc<"lists">)` but is always called with the enriched `Doc<"lists"> & { ownerDisplayName?: string; ownerUsername?: string }` items from `followedLists`. The narrower type works at runtime, but annotating the exact type makes it easier for future callers to know that the enriched fields are available:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/src/components/FollowedListsModal.tsx
   Line: 73-81

   Comment:
   **Parameter type narrows away the enriched fields**

   `handleListPress` is typed as `(list: Doc<"lists">)` but is always called with the enriched `Doc<"lists"> & { ownerDisplayName?: string; ownerUsername?: string }` items from `followedLists`. The narrower type works at runtime, but annotating the exact type makes it easier for future callers to know that the enriched fields are available:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/lists.ts
Line: 520-523

Comment:
**Redundant list lookup in `getFollowedLists`**

`canUserViewList` internally calls `checkListAccess`, which re-queries `lists` by `by_custom_id` for the same `follow.listId` — a document already fetched two lines above. Convex deduplicates reads within a transaction so there's no extra round-trip cost, but the check can be short-circuited using the already-fetched doc to keep the intent clear:

Alternatively, pass the already-fetched `list` to a shared helper so the second query is skipped entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/FollowedListsModal.tsx
Line: 73-81

Comment:
**Parameter type narrows away the enriched fields**

`handleListPress` is typed as `(list: Doc<"lists">)` but is always called with the enriched `Doc<"lists"> & { ownerDisplayName?: string; ownerUsername?: string }` items from `followedLists`. The narrower type works at runtime, but annotating the exact type makes it easier for future callers to know that the enriched fields are available:

```suggestion
  const handleListPress = useCallback(
    (list: Doc<"lists"> & { ownerDisplayName?: string; ownerUsername?: string }) => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): single subscribed list opens ..."](https://github.com/jaronheard/soonlist-turbo/commit/41d84839a169b41af89992f9f9a73e650b765a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29188035)</sub>

<!-- /greptile_comment -->