### PR TITLE
fix(expo): keep share sheet open on first-time share-setup flow

### DIFF
--- a/apps/expo/src/app/share-setup.tsx
+++ b/apps/expo/src/app/share-setup.tsx
@@ -130,7 +130,6 @@ export default function ShareSetupScreen() {
         publicEmail: links.publicEmail ?? null,
         publicPhone: links.publicPhone ?? null,
       });
-      router.back();
       if (username) {
         const url = `${Config.apiBaseUrl}/${username}`;
         try {
@@ -139,6 +138,7 @@ export default function ShareSetupScreen() {
           logError("Error sharing list", shareError);
         }
       }
+      router.back();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {


### PR DESCRIPTION
## Summary

- On the first-time "Your Soonlist is ready to share" screen, tapping **Share** dismissed the formSheet modal *before* presenting the native share sheet. iOS cancelled the share-sheet presentation as the parent modal animated away, so the user never got a chance to pick a share target.
- Fix: `await Share.share(...)` first, then call `router.back()` to dismiss the modal after the share sheet is closed.

## Why

`router.back()` triggers the formSheet's dismissal animation immediately. When `Share.share()` fires on the next line, iOS tries to present `UIActivityViewController` from a view that's already dismissing, which collapses the share sheet along with its presenter.

## Test plan

- [ ] Run Expo app on iOS and trigger the first-share flow (user where `hasSharedListBefore` is falsy).
- [ ] Tap **Share** on the "Your Soonlist is ready to share" screen.
- [ ] Verify the native share sheet stays presented until the user picks a target or dismisses it.
- [ ] Verify the share-setup modal dismisses *after* the share sheet is closed.
- [ ] Verify returning users (who skip setup) still get the share sheet directly via `useShareMyList.openNativeShare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the iOS share sheet open during the first-time “Your Soonlist is ready to share” flow. We now await `Share.share()` before dismissing the modal so users can complete sharing.

- **Bug Fixes**
  - Run `router.back()` after `Share.share()` completes to avoid iOS cancelling `UIActivityViewController` during modal dismissal.

<sup>Written for commit acc3d2e688f276acb7a29c00a814dad355893b80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

