### PR TITLE
Refactor hero sections and add list detail improvements

### DIFF
--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,24 +1,23 @@
 import type { FunctionReturnType } from "convex/server";
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  ActivityIndicator,
-  Linking,
-  Platform,
-  Pressable,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { ActivityIndicator, Linking, Share, Text, View } from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
-import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
+import type { SoonlistHeroSegment } from "~/components/SoonlistHero";
+import { FloatingShareButton } from "~/components/FloatingShareButton";
 import { Globe, Instagram, Mail, Phone, User } from "~/components/icons";
+import {
+  SOONLIST_HERO_CONTACT_ICON_COLOR,
+  SOONLIST_HERO_CONTACT_ICON_SIZE,
+  SoonlistHero,
+  SoonlistHeroBylineRow,
+  SoonlistHeroContactButton,
+} from "~/components/SoonlistHero";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { UserProfileFlair } from "~/components/UserProfileFlair";
@@ -29,7 +28,7 @@ import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
-type ProfileSegment = "upcoming" | "past";
+type ProfileSegment = SoonlistHeroSegment;
 
 function formatMemberSince(createdAtIso: string): string {
   const d = new Date(createdAtIso);
@@ -59,119 +58,12 @@ function instaHref(raw: string): string {
   return `https://instagram.com/${handle}`;
 }
 
-function SegmentedControlFallback({
-  selectedSegment,
-  onSegmentChange,
-}: {
-  selectedSegment: ProfileSegment;
-  onSegmentChange: (segment: ProfileSegment) => void;
-}) {
-  return (
-    <View className="flex-row rounded-lg bg-gray-100 p-1">
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("upcoming")}
-      >
-        <Text
-          className={
-            selectedSegment === "upcoming"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Upcoming
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "past" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("past")}
-      >
-        <Text
-          className={
-            selectedSegment === "past"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Past
-        </Text>
-      </TouchableOpacity>
-    </View>
-  );
-}
-
-const PROFILE_CONTACT_ICON_SIZE = 16;
-const PROFILE_CONTACT_ICON_COLOR = "#5A32FB";
-
-function ProfileContactIconButton({
-  accessibilityLabel,
-  onPress,
-  children,
-}: {
-  accessibilityLabel: string;
-  onPress: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      hitSlop={8}
-      className="h-8 w-8 items-center justify-center rounded-full bg-neutral-4/70 active:opacity-70"
-    >
-      {children}
-    </Pressable>
-  );
-}
-
 type ProfileUser = NonNullable<
   FunctionReturnType<typeof api.users.getByUsername>
 >;
 
-function formatLastUpdated(addedAtMs: number | null | undefined): string {
-  if (addedAtMs === null || addedAtMs === undefined) return "";
-  const now = Date.now();
-  const diffMs = Math.max(0, now - addedAtMs);
-  const minutes = Math.floor(diffMs / 60_000);
-  if (minutes < 1) return "Last updated just now";
-  if (minutes < 60) {
-    return `Last updated ${minutes} minute${minutes === 1 ? "" : "s"} ago`;
-  }
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `Last updated ${hours} hour${hours === 1 ? "" : "s"} ago`;
-  }
-  const days = Math.floor(hours / 24);
-  if (days < 30) {
-    return `Last updated ${days} day${days === 1 ? "" : "s"} ago`;
-  }
-  const d = new Date(addedAtMs);
-  return `Last updated ${d.toLocaleDateString(undefined, {
-    month: "long",
-    year: "numeric",
-  })}`;
-}
-
-function ProfileHeroAndSoonlist({
-  user,
-  listTitle,
-  lastUpdatedAt,
-  selectedSegment,
-  onSegmentChange,
-}: {
-  user: ProfileUser;
-  listTitle: string;
-  lastUpdatedAt: number | null | undefined;
-  selectedSegment: ProfileSegment;
-  onSegmentChange: (s: ProfileSegment) => void;
-}) {
+function ProfileBylineRow({ user }: { user: ProfileUser }) {
   const memberLine = formatMemberSince(user.created_at);
-
   const emailTrimmed = user.publicEmail?.trim() ?? "";
   const phoneTrimmed = user.publicPhone?.trim() ?? "";
   const instaTrimmed = user.publicInsta?.trim() ?? "";
@@ -183,20 +75,9 @@ function ProfileHeroAndSoonlist({
     Boolean(instaTrimmed) ||
     Boolean(websiteTrimmed);
 
-  const lastUpdatedLine =
-    lastUpdatedAt === undefined ? "…" : formatLastUpdated(lastUpdatedAt);
-
   return (
-    <View className="px-4 pb-2 pt-2">
-      <Text
-        className="text-3xl font-bold leading-tight text-interactive-1"
-        numberOfLines={2}
-      >
-        {listTitle}
-      </Text>
-
-      {/* Byline: avatar + @username + joined + contact icons */}
-      <View className="mt-3 flex-row items-center gap-3">
+    <SoonlistHeroBylineRow
+      avatar={
         <UserProfileFlair username={user.username} size="sm">
           {user.userImage ? (
             <Image
@@ -211,30 +92,19 @@ function ProfileHeroAndSoonlist({
             </View>
           )}
         </UserProfileFlair>
-
-        <View className="min-w-0 flex-1">
-          <Text
-            className="text-sm font-semibold text-neutral-1"
-            numberOfLines={1}
-            accessibilityLabel={
-              user.displayName?.trim()
-                ? `${user.displayName.trim()}, @${user.username}`
-                : `@${user.username}`
-            }
-          >
-            @{user.username}
-          </Text>
-          {memberLine ? (
-            <Text className="text-xs text-neutral-2" numberOfLines={1}>
-              {memberLine}
-            </Text>
-          ) : null}
-        </View>
-
-        {hasContact ? (
-          <View className="flex-row items-center gap-1.5">
+      }
+      primaryText={`@${user.username}`}
+      primaryAccessibilityLabel={
+        user.displayName.trim()
+          ? `${user.displayName.trim()}, @${user.username}`
+          : `@${user.username}`
+      }
+      secondaryText={memberLine || undefined}
+      contacts={
+        hasContact ? (
+          <>
             {emailTrimmed ? (
-              <ProfileContactIconButton
+              <SoonlistHeroContactButton
                 accessibilityLabel={`Email ${emailTrimmed}`}
                 onPress={() => {
                   void Linking.openURL(
@@ -243,13 +113,13 @@ function ProfileHeroAndSoonlist({
                 }}
               >
                 <Mail
-                  size={PROFILE_CONTACT_ICON_SIZE}
-                  color={PROFILE_CONTACT_ICON_COLOR}
+                  size={SOONLIST_HERO_CONTACT_ICON_SIZE}
+                  color={SOONLIST_HERO_CONTACT_ICON_COLOR}
                 />
-              </ProfileContactIconButton>
+              </SoonlistHeroContactButton>
             ) : null}
             {phoneTrimmed ? (
-              <ProfileContactIconButton
+              <SoonlistHeroContactButton
                 accessibilityLabel={`Call ${phoneTrimmed}`}
                 onPress={() => {
                   const n = phoneTrimmed.replace(/[^\d+]/g, "");
@@ -257,65 +127,41 @@ function ProfileHeroAndSoonlist({
                 }}
               >
                 <Phone
-                  size={PROFILE_CONTACT_ICON_SIZE}
-                  color={PROFILE_CONTACT_ICON_COLOR}
+                  size={SOONLIST_HERO_CONTACT_ICON_SIZE}
+                  color={SOONLIST_HERO_CONTACT_ICON_COLOR}
                 />
-              </ProfileContactIconButton>
+              </SoonlistHeroContactButton>
             ) : null}
             {instaTrimmed ? (
-              <ProfileContactIconButton
+              <SoonlistHeroContactButton
                 accessibilityLabel={`Instagram @${instaHandle}`}
                 onPress={() => {
                   void Linking.openURL(instaHref(instaTrimmed));
                 }}
               >
                 <Instagram
-                  size={PROFILE_CONTACT_ICON_SIZE}
-                  color={PROFILE_CONTACT_ICON_COLOR}
+                  size={SOONLIST_HERO_CONTACT_ICON_SIZE}
+                  color={SOONLIST_HERO_CONTACT_ICON_COLOR}
                 />
-              </ProfileContactIconButton>
+              </SoonlistHeroContactButton>
             ) : null}
             {websiteTrimmed ? (
-              <ProfileContactIconButton
+              <SoonlistHeroContactButton
                 accessibilityLabel={`Website ${websiteTrimmed}`}
                 onPress={() => {
                   void Linking.openURL(websiteHref(websiteTrimmed));
                 }}
               >
                 <Globe
-                  size={PROFILE_CONTACT_ICON_SIZE}
-                  color={PROFILE_CONTACT_ICON_COLOR}
+                  size={SOONLIST_HERO_CONTACT_ICON_SIZE}
+                  color={SOONLIST_HERO_CONTACT_ICON_COLOR}
                 />
-              </ProfileContactIconButton>
+              </SoonlistHeroContactButton>
             ) : null}
-          </View>
-        ) : null}
-      </View>
-
-      <Text className="mt-2 text-sm text-neutral-2">{lastUpdatedLine}</Text>
-
-      <View className="mt-3" style={{ width: 260 }}>
-        {Platform.OS === "ios" ? (
-          <Host matchContents>
-            <Picker
-              selection={selectedSegment}
-              onSelectionChange={(value) => {
-                onSegmentChange(value as ProfileSegment);
-              }}
-              modifiers={[pickerStyle("segmented")]}
-            >
-              <SwiftUIText modifiers={[tag("upcoming")]}>Upcoming</SwiftUIText>
-              <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
-            </Picker>
-          </Host>
-        ) : (
-          <SegmentedControlFallback
-            selectedSegment={selectedSegment}
-            onSegmentChange={onSegmentChange}
-          />
-        )}
-      </View>
-    </View>
+          </>
+        ) : null
+      }
+    />
   );
 }
 
@@ -459,14 +305,28 @@ export default function UserProfilePage() {
     router,
   ]);
 
+  const handleShareProfile = useCallback(async () => {
+    if (!targetUser) return;
+    try {
+      await Share.share({
+        message: `Check out ${
+          targetUser.displayName.trim() || targetUser.username
+        }'s Soonlist`,
+        url: `https://soonlist.com/${targetUser.username}`,
+      });
+    } catch (error) {
+      logError("Error sharing profile", error);
+    }
+  }, [targetUser]);
+
   const renderListHeader = useCallback(() => {
     if (!targetUser) {
       return null;
     }
     return (
-      <ProfileHeroAndSoonlist
-        user={targetUser}
-        listTitle={listTitle}
+      <SoonlistHero
+        title={listTitle}
+        subtitle={<ProfileBylineRow user={targetUser} />}
         lastUpdatedAt={lastUpdatedAt}
         selectedSegment={selectedSegment}
         onSegmentChange={setSelectedSegment}
@@ -549,6 +409,12 @@ export default function UserProfilePage() {
           savedEventIds={savedEventIds}
           source="user_profile"
           HeaderComponent={renderListHeader}
+        />
+        <FloatingShareButton
+          onPress={() => void handleShareProfile()}
+          accessibilityLabel={`Share ${
+            targetUser.displayName.trim() || targetUser.username
+          }'s Soonlist`}
         />
       </View>
     </>

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -1,6 +1,13 @@
 import type { FunctionReturnType } from "convex/server";
 import React, { useCallback, useMemo, useState } from "react";
-import { ActivityIndicator, Linking, Share, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Linking,
+  Platform,
+  Share,
+  Text,
+  View,
+} from "react-native";
 import { Image } from "expo-image";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
@@ -24,11 +31,10 @@ import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useLoadMoreHandler } from "~/hooks/useUpcomingFeed";
 import { useStableTimestamp } from "~/store";
+import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
-
-type ProfileSegment = SoonlistHeroSegment;
 
 function formatMemberSince(createdAtIso: string): string {
   const d = new Date(createdAtIso);
@@ -171,7 +177,7 @@ export default function UserProfilePage() {
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const [selectedSegment, setSelectedSegment] =
-    useState<ProfileSegment>("upcoming");
+    useState<SoonlistHeroSegment>("upcoming");
   const stableTimestamp = useStableTimestamp();
 
   const targetUser = useQuery(
@@ -307,13 +313,9 @@ export default function UserProfilePage() {
 
   const handleShareProfile = useCallback(async () => {
     if (!targetUser) return;
+    const url = `${Config.apiBaseUrl}/${targetUser.username}`;
     try {
-      await Share.share({
-        message: `Check out ${
-          targetUser.displayName.trim() || targetUser.username
-        }'s Soonlist`,
-        url: `https://soonlist.com/${targetUser.username}`,
-      });
+      await Share.share(Platform.OS === "ios" ? { url } : { message: url });
     } catch (error) {
       logError("Error sharing profile", error);
     }

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -31,8 +31,8 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 import { getTimezoneAbbreviation } from "@soonlist/cal";
 
-import { EventMenu } from "~/components/EventMenu";
 import { AttributionGrid } from "~/components/AttributionGrid";
+import { EventMenu } from "~/components/EventMenu";
 import { HeaderLogo } from "~/components/HeaderLogo";
 import {
   CalendarPlus,

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -32,7 +32,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { getTimezoneAbbreviation } from "@soonlist/cal";
 
 import { EventMenu } from "~/components/EventMenu";
-import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
+import { AttributionGrid } from "~/components/AttributionGrid";
 import { HeaderLogo } from "~/components/HeaderLogo";
 import {
   CalendarPlus,
@@ -592,13 +592,13 @@ function EventDetail({ id }: { id: string }) {
             </>
           )}
 
-          {/* From these Soonlists — unified attribution of people + lists.
+          {/* Attribution grid — unified attribution of people + lists.
               Lives after the event content and source attribution so the
               reading order is: what it is → what it's about → where it
               came from → who has it. */}
           {showDiscover && event.user && (
             <View className="mb-4">
-              <FromTheseSoonlists
+              <AttributionGrid
                 creator={{
                   id: event.user.id,
                   username: event.user.username,

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -1,17 +1,14 @@
-import React, { useCallback, useMemo } from "react";
-import {
-  ActivityIndicator,
-  Share,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import React, { useCallback, useMemo, useState } from "react";
+import { ActivityIndicator, Share, Text, View } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { List as ListIcon, ShareIcon } from "~/components/icons";
+import type { SoonlistHeroSegment } from "~/components/SoonlistHero";
+import { FloatingShareButton } from "~/components/FloatingShareButton";
+import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
+import { SoonlistHero } from "~/components/SoonlistHero";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
@@ -19,8 +16,10 @@ import {
   useLoadMoreHandler,
   useUpcomingEventsFilter,
 } from "~/hooks/useUpcomingFeed";
+import { useStableTimestamp } from "~/store";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
+import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 export default function ListDetailScreen() {
   const { slug } = useLocalSearchParams<{ slug: string }>();
@@ -28,25 +27,57 @@ export default function ListDetailScreen() {
   const router = useRouter();
   const { isAuthenticated } = useConvexAuth();
   const currentUser = useQuery(api.users.getCurrentUser);
+  const [selectedSegment, setSelectedSegment] =
+    useState<SoonlistHeroSegment>("upcoming");
+  const stableTimestamp = useStableTimestamp();
 
   const listResult = useQuery(
     api.lists.getBySlug,
     normalizedSlug ? { slug: normalizedSlug } : "skip",
   );
   const listData = listResult?.status === "ok" ? listResult.list : null;
+
+  const lastUpdatedAt = useQuery(
+    api.feeds.getPublicListFeedLastUpdated,
+    normalizedSlug ? { slug: normalizedSlug } : "skip",
+  );
+
+  const contributors = useQuery(
+    api.lists.getContributorsForList,
+    normalizedSlug ? { slug: normalizedSlug } : "skip",
+  );
+
+  const feedQueryArgs = useMemo(
+    () =>
+      normalizedSlug
+        ? { slug: normalizedSlug, filter: selectedSegment }
+        : "skip",
+    [normalizedSlug, selectedSegment],
+  );
+
   const {
     results: listEvents,
     status,
     loadMore,
-  } = useStablePaginatedQuery(
-    api.lists.getEventsForList,
-    normalizedSlug
-      ? { slug: normalizedSlug, filter: "upcoming" as const }
-      : "skip",
-    { initialNumItems: 50 },
+  } = useStablePaginatedQuery(api.lists.getEventsForList, feedQueryArgs, {
+    initialNumItems: 50,
+  });
+
+  // Upcoming uses the freshness-filter helper for parity with the profile
+  // screen; past just trusts the server filter and the segment guard below.
+  const upcomingEventsFiltered = useUpcomingEventsFilter(
+    selectedSegment === "upcoming" ? listEvents : [],
   );
 
-  const upcomingEvents = useUpcomingEventsFilter(listEvents);
+  const displayEvents = useMemo(() => {
+    if (selectedSegment === "upcoming") {
+      return upcomingEventsFiltered;
+    }
+    const stableMs = new Date(stableTimestamp).getTime();
+    return listEvents.filter((e) =>
+      eventMatchesFeedSegment(e.endDateTime, "past", stableMs),
+    );
+  }, [selectedSegment, listEvents, upcomingEventsFiltered, stableTimestamp]);
 
   const followListMutation = useMutation(
     api.lists.followList,
@@ -125,26 +156,59 @@ export default function ListDetailScreen() {
 
   const handleLoadMore = useLoadMoreHandler(status, loadMore);
 
-  const ListHeader = useCallback(
-    () => (
-      <View className="flex-row items-start gap-4 px-4 pb-2">
-        <View className="h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-interactive-2">
-          <ListIcon size={24} color="#5A32FB" />
-        </View>
-        <View className="min-w-0 flex-1 justify-center pt-0.5">
-          <Text className="text-lg font-bold text-neutral-1" numberOfLines={2}>
-            {listData?.name}
-          </Text>
-          {listData?.owner ? (
-            <Text className="mt-0.5 text-sm text-neutral-2" numberOfLines={1}>
-              by {listData.owner.displayName || listData.owner.username}
-            </Text>
-          ) : null}
-        </View>
-      </View>
-    ),
-    [listData?.name, listData?.owner],
-  );
+  const ownerByline = useMemo(() => {
+    if (!listData?.owner) return undefined;
+    const name =
+      listData.owner.displayName.trim() || listData.owner.username || "owner";
+    return `by ${name}`;
+  }, [listData?.owner]);
+
+  const renderListHeader = useCallback(() => {
+    if (!listData) return null;
+
+    const ownerForDisplay = listData.owner
+      ? {
+          id: listData.owner.id,
+          username: listData.owner.username,
+          displayName: listData.owner.displayName,
+          userImage: listData.owner.userImage,
+        }
+      : null;
+
+    return (
+      <SoonlistHero
+        title={listData.name}
+        subtitle={
+          ownerByline ? (
+            <Text className="text-sm text-neutral-2">{ownerByline}</Text>
+          ) : undefined
+        }
+        lastUpdatedAt={lastUpdatedAt}
+        selectedSegment={selectedSegment}
+        onSegmentChange={setSelectedSegment}
+        footer={
+          ownerForDisplay ? (
+            <FromTheseSoonlists
+              creator={ownerForDisplay}
+              savers={contributors ?? []}
+              lists={[]}
+              currentUserId={currentUser?.id}
+              variant="card"
+              showLabel={false}
+              creatorBadgeLabel="owner"
+            />
+          ) : null
+        }
+      />
+    );
+  }, [
+    listData,
+    ownerByline,
+    lastUpdatedAt,
+    selectedSegment,
+    contributors,
+    currentUser?.id,
+  ]);
 
   if (
     !normalizedSlug ||
@@ -197,7 +261,7 @@ export default function ListDetailScreen() {
     return null;
   }
 
-  const events = upcomingEvents.map((event) => ({
+  const events = displayEvents.map((event) => ({
     event,
     similarEvents: [],
     similarityGroupId: event.id,
@@ -209,53 +273,34 @@ export default function ListDetailScreen() {
       <Stack.Screen
         options={{
           title: "List Details",
-          unstable_headerRightItems:
-            isOwnList || !listData
-              ? undefined
-              : () => [
-                  {
-                    type: "custom",
-                    element: (
-                      <SubscribeButton
-                        isSubscribed={isFollowing}
-                        onPress={handleToggleFollow}
-                      />
-                    ),
-                    hidesSharedBackground: true,
-                  },
-                ],
+          unstable_headerRightItems: isOwnList
+            ? undefined
+            : () => [
+                {
+                  type: "custom",
+                  element: (
+                    <SubscribeButton
+                      isSubscribed={isFollowing}
+                      onPress={handleToggleFollow}
+                    />
+                  ),
+                  hidesSharedBackground: true,
+                },
+              ],
         }}
       />
-      <UserEventsList
-        groupedEvents={events}
-        showCreator="always"
-        onEndReached={handleLoadMore}
-        isFetchingNextPage={status === "LoadingMore"}
-        HeaderComponent={ListHeader}
-      />
-
-      {/* Floating Share button (primary action), matches event detail */}
-      <View
-        className="absolute bottom-8 flex-row items-center justify-center gap-4 self-center"
-        style={{
-          shadowColor: "#5A32FB",
-          shadowOffset: { width: 0, height: 3 },
-          shadowOpacity: 0.3,
-          shadowRadius: 6,
-          elevation: 8,
-        }}
-      >
-        <TouchableOpacity
+      <View className="flex-1 bg-interactive-3">
+        <UserEventsList
+          groupedEvents={events}
+          showCreator="always"
+          onEndReached={handleLoadMore}
+          isFetchingNextPage={status === "LoadingMore"}
+          HeaderComponent={renderListHeader}
+        />
+        <FloatingShareButton
           onPress={() => void handleShare()}
           accessibilityLabel="Share list"
-          accessibilityRole="button"
-          activeOpacity={0.8}
-        >
-          <View className="flex-row items-center gap-4 rounded-full bg-interactive-1 px-8 py-5">
-            <ShareIcon size={28} color="#FFFFFF" />
-            <Text className="text-xl font-bold text-white">Share</Text>
-          </View>
-        </TouchableOpacity>
+        />
       </View>
     </>
   );

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -6,8 +6,8 @@ import { useConvexAuth, useMutation, useQuery } from "convex/react";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import type { SoonlistHeroSegment } from "~/components/SoonlistHero";
-import { FloatingShareButton } from "~/components/FloatingShareButton";
 import { AttributionGrid } from "~/components/AttributionGrid";
+import { FloatingShareButton } from "~/components/FloatingShareButton";
 import { SoonlistHero } from "~/components/SoonlistHero";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
@@ -191,13 +191,7 @@ export default function ListDetailScreen() {
         onSegmentChange={setSelectedSegment}
       />
     );
-  }, [
-    listData,
-    lastUpdatedAt,
-    selectedSegment,
-    contributors,
-    currentUser?.id,
-  ]);
+  }, [listData, lastUpdatedAt, selectedSegment, contributors, currentUser?.id]);
 
   if (
     !normalizedSlug ||

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { ActivityIndicator, Share, Text, View } from "react-native";
+import { ActivityIndicator, Platform, Share, Text, View } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useConvexAuth, useMutation, useQuery } from "convex/react";
 
@@ -17,6 +17,7 @@ import {
   useUpcomingEventsFilter,
 } from "~/hooks/useUpcomingFeed";
 import { useStableTimestamp } from "~/store";
+import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
@@ -63,8 +64,6 @@ export default function ListDetailScreen() {
     initialNumItems: 50,
   });
 
-  // Upcoming uses the freshness-filter helper for parity with the profile
-  // screen; past just trusts the server filter and the segment guard below.
   const upcomingEventsFiltered = useUpcomingEventsFilter(
     selectedSegment === "upcoming" ? listEvents : [],
   );
@@ -144,11 +143,13 @@ export default function ListDetailScreen() {
 
   const handleShare = useCallback(async () => {
     if (!listData || !normalizedSlug) return;
+    const url = `${Config.apiBaseUrl}/list/${normalizedSlug}`;
     try {
-      await Share.share({
-        message: `Check out ${listData.name} on Soonlist`,
-        url: `https://soonlist.com/list/${normalizedSlug}`,
-      });
+      await Share.share(
+        Platform.OS === "ios"
+          ? { url }
+          : { message: `Check out ${listData.name} on Soonlist: ${url}` },
+      );
     } catch (error) {
       logError("Error sharing list", error);
     }

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -7,7 +7,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import type { SoonlistHeroSegment } from "~/components/SoonlistHero";
 import { FloatingShareButton } from "~/components/FloatingShareButton";
-import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
+import { AttributionGrid } from "~/components/AttributionGrid";
 import { SoonlistHero } from "~/components/SoonlistHero";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import UserEventsList from "~/components/UserEventsList";
@@ -156,13 +156,6 @@ export default function ListDetailScreen() {
 
   const handleLoadMore = useLoadMoreHandler(status, loadMore);
 
-  const ownerByline = useMemo(() => {
-    if (!listData?.owner) return undefined;
-    const name =
-      listData.owner.displayName.trim() || listData.owner.username || "owner";
-    return `by ${name}`;
-  }, [listData?.owner]);
-
   const renderListHeader = useCallback(() => {
     if (!listData) return null;
 
@@ -179,31 +172,26 @@ export default function ListDetailScreen() {
       <SoonlistHero
         title={listData.name}
         subtitle={
-          ownerByline ? (
-            <Text className="text-sm text-neutral-2">{ownerByline}</Text>
-          ) : undefined
-        }
-        lastUpdatedAt={lastUpdatedAt}
-        selectedSegment={selectedSegment}
-        onSegmentChange={setSelectedSegment}
-        footer={
           ownerForDisplay ? (
-            <FromTheseSoonlists
+            <AttributionGrid
               creator={ownerForDisplay}
               savers={contributors ?? []}
               lists={[]}
               currentUserId={currentUser?.id}
               variant="compact"
-              showLabel={false}
+              background="white"
+              label="List contributors:"
               creatorBadgeLabel="owner"
             />
           ) : null
         }
+        lastUpdatedAt={lastUpdatedAt}
+        selectedSegment={selectedSegment}
+        onSegmentChange={setSelectedSegment}
       />
     );
   }, [
     listData,
-    ownerByline,
     lastUpdatedAt,
     selectedSegment,
     contributors,

--- a/apps/expo/src/app/list/[slug].tsx
+++ b/apps/expo/src/app/list/[slug].tsx
@@ -193,7 +193,7 @@ export default function ListDetailScreen() {
               savers={contributors ?? []}
               lists={[]}
               currentUserId={currentUser?.id}
-              variant="card"
+              variant="compact"
               showLabel={false}
               creatorBadgeLabel="owner"
             />

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -112,10 +112,6 @@ export function AttributionGrid({
   const rowPaddingY = isCompact ? "py-2" : "py-2.5";
   const containerPadding = isCompact ? "px-3 pb-2 pt-2" : "px-4 pb-3 pt-3";
   const labelMargin = isCompact ? "mb-1" : "mb-2";
-  // Both variants share the same visual language: tinted card, no dividers
-  // between rows, muted-brand chevron. Rows are grouped by the tint + row
-  // padding, not by lines. The card variant is simply the compact design
-  // scaled up.
   const chevronColor = "#8F7AD6";
 
   const rows: React.ReactNode[] = [];
@@ -209,9 +205,6 @@ export function AttributionGrid({
 
   if (rows.length === 0) return null;
 
-  // Both variants share the same tinted, borderless card. The card variant
-  // is simply the compact design scaled up for use in the modal / +N more
-  // detail view.
   const bgClass = background === "white" ? "bg-white" : "bg-interactive-3/60";
   const containerClass = `rounded-2xl ${bgClass} ${containerPadding}`;
 

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -87,6 +87,7 @@ export function AttributionGrid({
     isCompact && people.length === 1 && visibleLists.length === 0;
 
   if (isSingleCreator) {
+    const prefix = creatorBadgeLabel === "owner" ? "Owned by" : "Captured by";
     return (
       <TouchableOpacity
         onPress={() => handleUserPress(creator)}
@@ -99,7 +100,7 @@ export function AttributionGrid({
       >
         <UserAvatar user={creator} size={24} />
         <Text className="ml-2 text-sm text-neutral-2" numberOfLines={1}>
-          Captured by{" "}
+          {prefix}{" "}
           <Text className="font-semibold text-neutral-1">
             {creator.displayName || creator.username}
           </Text>

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -9,7 +9,7 @@ import { ChevronRight, List as ListIcon } from "~/components/icons";
 import { UserAvatar } from "~/components/UserAvatar";
 import { navigateToUser } from "~/utils/navigateToUser";
 
-interface FromTheseSoonlistsProps {
+interface AttributionGridProps {
   creator: UserForDisplay;
   savers: UserForDisplay[];
   lists: Doc<"lists">[];
@@ -30,9 +30,18 @@ interface FromTheseSoonlistsProps {
    * "captured" (event-detail semantics). List detail uses "owner".
    */
   creatorBadgeLabel?: string;
+  /**
+   * Card background tone.
+   * - "tint" (default): muted-brand wash — used on event detail + modals
+   *   where the card sits on the app's white canvas and needs to feel
+   *   attached to the item it describes.
+   * - "white": crisp white — used in list detail, where the card itself
+   *   sits on the tinted hero background and needs contrast the other way.
+   */
+  background?: "tint" | "white";
 }
 
-export function FromTheseSoonlists({
+export function AttributionGrid({
   creator,
   savers,
   lists,
@@ -42,7 +51,8 @@ export function FromTheseSoonlists({
   showLabel = true,
   label = "From these Soonlists:",
   creatorBadgeLabel = "captured",
-}: FromTheseSoonlistsProps) {
+  background = "tint",
+}: AttributionGridProps) {
   // People: creator first, then savers, deduped.
   const people: UserForDisplay[] = [creator];
   for (const saver of savers) {
@@ -202,7 +212,8 @@ export function FromTheseSoonlists({
   // Both variants share the same tinted, borderless card. The card variant
   // is simply the compact design scaled up for use in the modal / +N more
   // detail view.
-  const containerClass = `rounded-2xl bg-interactive-3/60 ${containerPadding}`;
+  const bgClass = background === "white" ? "bg-white" : "bg-interactive-3/60";
+  const containerClass = `rounded-2xl ${bgClass} ${containerPadding}`;
 
   return (
     <View className={containerClass}>

--- a/apps/expo/src/components/FloatingShareButton.tsx
+++ b/apps/expo/src/components/FloatingShareButton.tsx
@@ -9,11 +9,6 @@ interface FloatingShareButtonProps {
   accessibilityLabel?: string;
 }
 
-/**
- * Shared bottom-anchored share CTA used by the list detail screen and user
- * profile. The parent must render this inside a relatively-positioned
- * container (e.g., sibling of the scrollable list under a `flex-1` parent).
- */
 export function FloatingShareButton({
   onPress,
   label = "Share",

--- a/apps/expo/src/components/FloatingShareButton.tsx
+++ b/apps/expo/src/components/FloatingShareButton.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+
+import { ShareIcon } from "~/components/icons";
+
+interface FloatingShareButtonProps {
+  onPress: () => void;
+  label?: string;
+  accessibilityLabel?: string;
+}
+
+/**
+ * Shared bottom-anchored share CTA used by the list detail screen and user
+ * profile. The parent must render this inside a relatively-positioned
+ * container (e.g., sibling of the scrollable list under a `flex-1` parent).
+ */
+export function FloatingShareButton({
+  onPress,
+  label = "Share",
+  accessibilityLabel,
+}: FloatingShareButtonProps) {
+  return (
+    <View
+      className="absolute bottom-8 flex-row items-center justify-center gap-4 self-center"
+      style={{
+        shadowColor: "#5A32FB",
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+        elevation: 8,
+      }}
+    >
+      <TouchableOpacity
+        onPress={onPress}
+        accessibilityLabel={accessibilityLabel ?? label}
+        accessibilityRole="button"
+        activeOpacity={0.8}
+      >
+        <View className="flex-row items-center gap-4 rounded-full bg-interactive-1 px-8 py-5">
+          <ShareIcon size={28} color="#FFFFFF" />
+          <Text className="text-xl font-bold text-white">{label}</Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from "react";
 import {
   ActivityIndicator,
+  FlatList,
   Modal,
   Platform,
-  ScrollView,
   Share,
   Text,
   TouchableOpacity,
@@ -114,15 +114,22 @@ export function FollowedListsModal({
             </Text>
           </View>
         ) : (
-          <ScrollView
+          <FlatList
+            data={followedLists}
+            keyExtractor={(list) => list.id}
             contentContainerStyle={{
               paddingHorizontal: 16,
               paddingBottom: insets.bottom + 16,
             }}
-          >
-            <View className="rounded-2xl bg-interactive-3/60 px-4 pb-3 pt-3">
-              {followedLists.map((list) => (
-                <View key={list.id} className="flex-row items-center py-2.5">
+            renderItem={({ item: list, index }) => {
+              const isFirst = index === 0;
+              const isLast = index === followedLists.length - 1;
+              return (
+                <View
+                  className={`flex-row items-center bg-interactive-3/60 px-4 py-2.5 ${
+                    isFirst ? "rounded-t-2xl pt-3" : ""
+                  } ${isLast ? "rounded-b-2xl pb-3" : ""}`}
+                >
                   <TouchableOpacity
                     className="min-w-0 flex-1 flex-row items-center"
                     onPress={() => handleListPress(list)}
@@ -164,9 +171,9 @@ export function FollowedListsModal({
                     />
                   </View>
                 </View>
-              ))}
-            </View>
-          </ScrollView>
+              );
+            }}
+          />
         )}
       </View>
     </Modal>

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -118,7 +118,7 @@ export function FollowedListsModal({
             }}
           >
             {/* Single tinted card wrapping all rows — matches the
-                FromTheseSoonlists "card" variant: borderless rows, circle
+                AttributionGrid "card" variant: borderless rows, circle
                 icons, no chevron when trailing actions are present. */}
             <View className="rounded-2xl bg-interactive-3/60 px-4 pb-3 pt-3">
               {followedLists.map((list) => (

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import {
   ActivityIndicator,
   Modal,
+  Platform,
   ScrollView,
   Share,
   Text,
@@ -18,6 +19,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { List, ShareIcon } from "~/components/icons";
 import { SheetHeader } from "~/components/SheetHeader";
 import { SubscribeButton } from "~/components/SubscribeButton";
+import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 
@@ -57,13 +59,14 @@ export function FollowedListsModal({
   const handleShareList = useCallback(
     async (listName: string, listSlug?: string) => {
       const shareUrl = listSlug
-        ? `https://soonlist.com/list/${listSlug}`
-        : "https://soonlist.com";
+        ? `${Config.apiBaseUrl}/list/${listSlug}`
+        : Config.apiBaseUrl;
       try {
-        await Share.share({
-          message: `Check out ${listName} on Soonlist`,
-          url: shareUrl,
-        });
+        await Share.share(
+          Platform.OS === "ios"
+            ? { url: shareUrl }
+            : { message: `Check out ${listName} on Soonlist: ${shareUrl}` },
+        );
       } catch (error) {
         logError("Error sharing list", error);
       }
@@ -117,9 +120,6 @@ export function FollowedListsModal({
               paddingBottom: insets.bottom + 16,
             }}
           >
-            {/* Single tinted card wrapping all rows — matches the
-                AttributionGrid "card" variant: borderless rows, circle
-                icons, no chevron when trailing actions are present. */}
             <View className="rounded-2xl bg-interactive-3/60 px-4 pb-3 pt-3">
               {followedLists.map((list) => (
                 <View key={list.id} className="flex-row items-center py-2.5">

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from "react";
 import {
   ActivityIndicator,
-  FlatList,
   Modal,
+  ScrollView,
   Share,
   Text,
   TouchableOpacity,
@@ -15,7 +15,8 @@ import { useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { ChevronRight, List, ShareIcon } from "~/components/icons";
+import { List, ShareIcon } from "~/components/icons";
+import { SheetHeader } from "~/components/SheetHeader";
 import { SubscribeButton } from "~/components/SubscribeButton";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
@@ -88,17 +89,16 @@ export function FollowedListsModal({
       onRequestClose={onClose}
     >
       <View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
-        {/* Header */}
-        <View className="flex-row items-center justify-between border-b border-neutral-3 px-4 py-3">
-          <Text className="text-lg font-bold text-neutral-1">
-            Subscribed lists
-          </Text>
-          <TouchableOpacity onPress={onClose} activeOpacity={0.7}>
-            <Text className="text-base font-semibold text-interactive-1">
-              Done
-            </Text>
-          </TouchableOpacity>
-        </View>
+        <SheetHeader
+          title="Subscribed lists"
+          trailing={
+            <TouchableOpacity onPress={onClose} activeOpacity={0.7}>
+              <Text className="text-base font-semibold text-interactive-1">
+                Done
+              </Text>
+            </TouchableOpacity>
+          }
+        />
 
         {followedLists === undefined ? (
           <View className="flex-1 items-center justify-center">
@@ -111,31 +111,29 @@ export function FollowedListsModal({
             </Text>
           </View>
         ) : (
-          <FlatList
-            data={followedLists}
-            keyExtractor={(list) => list.id}
+          <ScrollView
             contentContainerStyle={{
               paddingHorizontal: 16,
-              paddingTop: 16,
               paddingBottom: insets.bottom + 16,
             }}
-            ListHeaderComponent={
-              <Text className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-2">
-                Lists
-              </Text>
-            }
-            renderItem={({ item: list }) => {
-              return (
-                <View className="flex-row items-center py-3">
+          >
+            {/* Single tinted card wrapping all rows — matches the
+                FromTheseSoonlists "card" variant: borderless rows, circle
+                icons, no chevron when trailing actions are present. */}
+            <View className="rounded-2xl bg-interactive-3/60 px-4 pb-3 pt-3">
+              {followedLists.map((list) => (
+                <View key={list.id} className="flex-row items-center py-2.5">
                   <TouchableOpacity
-                    className="flex-1 flex-row items-center"
+                    className="min-w-0 flex-1 flex-row items-center"
                     onPress={() => handleListPress(list)}
                     activeOpacity={0.7}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open list ${list.name}`}
                   >
-                    <View className="h-10 w-10 items-center justify-center rounded-xl bg-interactive-2">
+                    <View className="h-11 w-11 shrink-0 items-center justify-center rounded-full bg-interactive-3">
                       <List size={20} color="#5A32FB" />
                     </View>
-                    <View className="ml-3 flex-1">
+                    <View className="ml-3 min-w-0 flex-1">
                       <Text
                         className="text-base font-semibold text-neutral-1"
                         numberOfLines={1}
@@ -143,7 +141,6 @@ export function FollowedListsModal({
                         {list.name}
                       </Text>
                     </View>
-                    <ChevronRight size={16} color="#DCE0E8" />
                   </TouchableOpacity>
 
                   <TouchableOpacity
@@ -167,9 +164,9 @@ export function FollowedListsModal({
                     />
                   </View>
                 </View>
-              );
-            }}
-          />
+              ))}
+            </View>
+          </ScrollView>
         )}
       </View>
     </Modal>

--- a/apps/expo/src/components/FromTheseSoonlists.tsx
+++ b/apps/expo/src/components/FromTheseSoonlists.tsx
@@ -21,8 +21,15 @@ interface FromTheseSoonlistsProps {
    * - "compact": tighter, borderless, tinted card for inline use.
    */
   variant?: "card" | "compact";
-  /** Whether to show the "From these Soonlists" section label. */
+  /** Whether to show the section label. */
   showLabel?: boolean;
+  /** Override the section label. Defaults to "From these Soonlists:". */
+  label?: string;
+  /**
+   * Override the pill label shown next to the creator row. Defaults to
+   * "captured" (event-detail semantics). List detail uses "owner".
+   */
+  creatorBadgeLabel?: string;
 }
 
 export function FromTheseSoonlists({
@@ -33,6 +40,8 @@ export function FromTheseSoonlists({
   onNavigate,
   variant = "card",
   showLabel = true,
+  label = "From these Soonlists:",
+  creatorBadgeLabel = "captured",
 }: FromTheseSoonlistsProps) {
   // People: creator first, then savers, deduped.
   const people: UserForDisplay[] = [creator];
@@ -127,7 +136,7 @@ export function FromTheseSoonlists({
           {isCreator ? (
             <View className="ml-2 shrink-0 rounded-full bg-accent-yellow px-2 py-0.5">
               <Text className="text-[11px] font-semibold text-neutral-1">
-                captured
+                {creatorBadgeLabel}
               </Text>
             </View>
           ) : null}
@@ -203,7 +212,7 @@ export function FromTheseSoonlists({
             isCompact ? "text-xs" : "text-sm"
           } text-neutral-2`}
         >
-          From these Soonlists:
+          {label}
         </Text>
       ) : null}
       {rows}

--- a/apps/expo/src/components/SavedByModal.tsx
+++ b/apps/expo/src/components/SavedByModal.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 
 import type { UserForDisplay } from "~/types/user";
-import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
+import { AttributionGrid } from "~/components/AttributionGrid";
 import { X } from "~/components/icons";
 import { SheetHeader } from "~/components/SheetHeader";
 
@@ -58,7 +58,7 @@ export function SavedByModal({
             paddingBottom: insets.bottom + 16,
           }}
         >
-          <FromTheseSoonlists
+          <AttributionGrid
             creator={creator}
             savers={savers}
             lists={lists}

--- a/apps/expo/src/components/SavedByModal.tsx
+++ b/apps/expo/src/components/SavedByModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Modal, ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Modal, ScrollView, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
@@ -7,6 +7,7 @@ import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import type { UserForDisplay } from "~/types/user";
 import { FromTheseSoonlists } from "~/components/FromTheseSoonlists";
 import { X } from "~/components/icons";
+import { SheetHeader } from "~/components/SheetHeader";
 
 interface SavedByModalProps {
   visible: boolean;
@@ -35,23 +36,20 @@ export function SavedByModal({
       onRequestClose={onClose}
     >
       <View className="flex-1 bg-white" style={{ paddingTop: insets.top }}>
-        {/* Header — matches the "From these Soonlists" teaching sentence,
-            paired with a tinted close chip that ties to the card tint
-            below. */}
-        <View className="flex-row items-center justify-between px-4 py-3">
-          <Text className="text-lg font-bold text-neutral-1">
-            From these Soonlists:
-          </Text>
-          <TouchableOpacity
-            onPress={onClose}
-            accessibilityRole="button"
-            accessibilityLabel="Close"
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            className="h-8 w-8 items-center justify-center rounded-full bg-interactive-3"
-          >
-            <X size={16} color="#5A32FB" />
-          </TouchableOpacity>
-        </View>
+        <SheetHeader
+          title="From these Soonlists:"
+          trailing={
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              className="h-8 w-8 items-center justify-center rounded-full bg-interactive-3"
+            >
+              <X size={16} color="#5A32FB" />
+            </TouchableOpacity>
+          }
+        />
 
         {/* Scrollable content */}
         <ScrollView

--- a/apps/expo/src/components/SheetHeader.tsx
+++ b/apps/expo/src/components/SheetHeader.tsx
@@ -3,15 +3,9 @@ import { Text, View } from "react-native";
 
 interface SheetHeaderProps {
   title: string;
-  /** Right-aligned content — typically a close chip or text button. */
   trailing?: React.ReactNode;
 }
 
-/**
- * Shared header for page-sheet modals. Matches the "From these Soonlists"
- * and "Subscribed lists" style: title left, optional trailing action right,
- * no bottom border.
- */
 export function SheetHeader({ title, trailing }: SheetHeaderProps) {
   return (
     <View className="flex-row items-center justify-between px-4 py-3">

--- a/apps/expo/src/components/SheetHeader.tsx
+++ b/apps/expo/src/components/SheetHeader.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+interface SheetHeaderProps {
+  title: string;
+  /** Right-aligned content — typically a close chip or text button. */
+  trailing?: React.ReactNode;
+}
+
+/**
+ * Shared header for page-sheet modals. Matches the "From these Soonlists"
+ * and "Subscribed lists" style: title left, optional trailing action right,
+ * no bottom border.
+ */
+export function SheetHeader({ title, trailing }: SheetHeaderProps) {
+  return (
+    <View className="flex-row items-center justify-between px-4 py-3">
+      <Text className="text-lg font-bold text-neutral-1">{title}</Text>
+      {trailing ?? null}
+    </View>
+  );
+}

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -29,11 +29,7 @@ export function SoonlistHero({
   const hasTabs =
     selectedSegment !== undefined && onSegmentChange !== undefined;
   const lastUpdatedLine =
-    lastUpdatedAt === undefined
-      ? null
-      : lastUpdatedAt === null
-        ? "…"
-        : formatLastUpdated(lastUpdatedAt);
+    typeof lastUpdatedAt === "number" ? formatLastUpdated(lastUpdatedAt) : null;
 
   return (
     <View className="px-4 pb-2 pt-2">

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -13,31 +13,12 @@ export type SoonlistHeroSegment = "upcoming" | "past";
 
 interface SoonlistHeroProps {
   title: string;
-  /**
-   * Content between the title and the last-updated / tabs rows.
-   *
-   * - User profile: a full `SoonlistHeroBylineRow` (avatar + @handle +
-   *   secondary line + contact icons).
-   * - List detail: a simple "by <owner>" subtitle text.
-   *
-   * Rendered as-is so each screen can shape its own byline.
-   */
   subtitle?: React.ReactNode;
-  /** Rendered as "Last updated X ago". Omit to hide. */
   lastUpdatedAt?: number | null | undefined;
-  /**
-   * Upcoming / Past segmented control. Both are required to render the
-   * control; omit either to hide it.
-   */
   selectedSegment?: SoonlistHeroSegment;
   onSegmentChange?: (s: SoonlistHeroSegment) => void;
 }
 
-/**
- * Shared hero for user profile (`[username]/index.tsx`) and list detail
- * (`list/[slug].tsx`). Enforces consistent spacing, typography, and the
- * big-purple title treatment across both screens.
- */
 export function SoonlistHero({
   title,
   subtitle,
@@ -48,7 +29,11 @@ export function SoonlistHero({
   const hasTabs =
     selectedSegment !== undefined && onSegmentChange !== undefined;
   const lastUpdatedLine =
-    lastUpdatedAt === undefined ? null : formatLastUpdated(lastUpdatedAt);
+    lastUpdatedAt === undefined
+      ? null
+      : lastUpdatedAt === null
+        ? "…"
+        : formatLastUpdated(lastUpdatedAt);
 
   return (
     <View className="px-4 pb-2 pt-2">
@@ -62,9 +47,7 @@ export function SoonlistHero({
       {subtitle ? <View className="mt-3">{subtitle}</View> : null}
 
       {lastUpdatedLine !== null ? (
-        <Text className="mt-2 text-sm text-neutral-2">
-          {lastUpdatedLine === "" ? "…" : lastUpdatedLine}
-        </Text>
+        <Text className="mt-2 text-sm text-neutral-2">{lastUpdatedLine}</Text>
       ) : null}
 
       {hasTabs ? (
@@ -85,13 +68,9 @@ interface ContactLinkButtonProps {
   children: React.ReactNode;
 }
 
-const BYLINE_CONTACT_ICON_SIZE = 16;
-const BYLINE_CONTACT_ICON_COLOR = "#5A32FB";
+export const SOONLIST_HERO_CONTACT_ICON_SIZE = 16;
+export const SOONLIST_HERO_CONTACT_ICON_COLOR = "#5A32FB";
 
-/**
- * Single circular contact-icon chip used in the hero byline row. Exported so
- * callers can compose their own icon sets (Mail/Phone/Instagram/Globe).
- */
 export function SoonlistHeroContactButton({
   accessibilityLabel,
   onPress,
@@ -110,23 +89,14 @@ export function SoonlistHeroContactButton({
   );
 }
 
-export const SOONLIST_HERO_CONTACT_ICON_SIZE = BYLINE_CONTACT_ICON_SIZE;
-export const SOONLIST_HERO_CONTACT_ICON_COLOR = BYLINE_CONTACT_ICON_COLOR;
-
 interface BylineRowProps {
   avatar: React.ReactNode;
   primaryText: string;
   primaryAccessibilityLabel?: string;
   secondaryText?: string;
-  /** Trailing contact icon chips — use `SoonlistHeroContactButton`. */
   contacts?: React.ReactNode;
 }
 
-/**
- * Standard hero byline: avatar + primary text (`@handle`) + optional
- * secondary line + optional trailing contact icon chips. Used by user
- * profile. List detail uses a plain "by <owner>" subtitle instead.
- */
 export function SoonlistHeroBylineRow({
   avatar,
   primaryText,
@@ -220,8 +190,7 @@ function UpcomingPastSegmentedControl({
   );
 }
 
-function formatLastUpdated(addedAtMs: number | null | undefined): string {
-  if (addedAtMs === null || addedAtMs === undefined) return "";
+function formatLastUpdated(addedAtMs: number): string {
   const now = Date.now();
   const diffMs = Math.max(0, now - addedAtMs);
   const minutes = Math.floor(diffMs / 60_000);

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import {
+  Platform,
+  Pressable,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
+import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
+
+export type SoonlistHeroSegment = "upcoming" | "past";
+
+interface SoonlistHeroProps {
+  title: string;
+  /**
+   * Content between the title and the last-updated / tabs rows.
+   *
+   * - User profile: a full `SoonlistHeroBylineRow` (avatar + @handle +
+   *   secondary line + contact icons).
+   * - List detail: a simple "by <owner>" subtitle text.
+   *
+   * Rendered as-is so each screen can shape its own byline.
+   */
+  subtitle?: React.ReactNode;
+  /** Rendered as "Last updated X ago". Omit to hide. */
+  lastUpdatedAt?: number | null | undefined;
+  /**
+   * Upcoming / Past segmented control. Both are required to render the
+   * control; omit either to hide it.
+   */
+  selectedSegment?: SoonlistHeroSegment;
+  onSegmentChange?: (s: SoonlistHeroSegment) => void;
+  /**
+   * Optional block rendered below the tabs. List detail uses this for a
+   * `FromTheseSoonlists` card showing owner + contributors.
+   */
+  footer?: React.ReactNode;
+}
+
+/**
+ * Shared hero for user profile (`[username]/index.tsx`) and list detail
+ * (`list/[slug].tsx`). Enforces consistent spacing, typography, and the
+ * big-purple title treatment across both screens.
+ */
+export function SoonlistHero({
+  title,
+  subtitle,
+  lastUpdatedAt,
+  selectedSegment,
+  onSegmentChange,
+  footer,
+}: SoonlistHeroProps) {
+  const hasTabs =
+    selectedSegment !== undefined && onSegmentChange !== undefined;
+  const lastUpdatedLine =
+    lastUpdatedAt === undefined ? null : formatLastUpdated(lastUpdatedAt);
+
+  return (
+    <View className="px-4 pb-2 pt-2">
+      <Text
+        className="text-3xl font-bold leading-tight text-interactive-1"
+        numberOfLines={2}
+      >
+        {title}
+      </Text>
+
+      {subtitle ? <View className="mt-3">{subtitle}</View> : null}
+
+      {lastUpdatedLine !== null ? (
+        <Text className="mt-2 text-sm text-neutral-2">
+          {lastUpdatedLine === "" ? "…" : lastUpdatedLine}
+        </Text>
+      ) : null}
+
+      {hasTabs ? (
+        <View className="mt-3" style={{ width: 260 }}>
+          <UpcomingPastSegmentedControl
+            selectedSegment={selectedSegment}
+            onSegmentChange={onSegmentChange}
+          />
+        </View>
+      ) : null}
+
+      {footer ? <View className="mt-4">{footer}</View> : null}
+    </View>
+  );
+}
+
+interface ContactLinkButtonProps {
+  accessibilityLabel: string;
+  onPress: () => void;
+  children: React.ReactNode;
+}
+
+const BYLINE_CONTACT_ICON_SIZE = 16;
+const BYLINE_CONTACT_ICON_COLOR = "#5A32FB";
+
+/**
+ * Single circular contact-icon chip used in the hero byline row. Exported so
+ * callers can compose their own icon sets (Mail/Phone/Instagram/Globe).
+ */
+export function SoonlistHeroContactButton({
+  accessibilityLabel,
+  onPress,
+  children,
+}: ContactLinkButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+      className="h-8 w-8 items-center justify-center rounded-full bg-neutral-4/70 active:opacity-70"
+    >
+      {children}
+    </Pressable>
+  );
+}
+
+export const SOONLIST_HERO_CONTACT_ICON_SIZE = BYLINE_CONTACT_ICON_SIZE;
+export const SOONLIST_HERO_CONTACT_ICON_COLOR = BYLINE_CONTACT_ICON_COLOR;
+
+interface BylineRowProps {
+  avatar: React.ReactNode;
+  primaryText: string;
+  primaryAccessibilityLabel?: string;
+  secondaryText?: string;
+  /** Trailing contact icon chips — use `SoonlistHeroContactButton`. */
+  contacts?: React.ReactNode;
+}
+
+/**
+ * Standard hero byline: avatar + primary text (`@handle`) + optional
+ * secondary line + optional trailing contact icon chips. Used by user
+ * profile. List detail uses a plain "by <owner>" subtitle instead.
+ */
+export function SoonlistHeroBylineRow({
+  avatar,
+  primaryText,
+  primaryAccessibilityLabel,
+  secondaryText,
+  contacts,
+}: BylineRowProps) {
+  return (
+    <View className="flex-row items-center gap-3">
+      {avatar}
+
+      <View className="min-w-0 flex-1">
+        <Text
+          className="text-sm font-semibold text-neutral-1"
+          numberOfLines={1}
+          accessibilityLabel={primaryAccessibilityLabel}
+        >
+          {primaryText}
+        </Text>
+        {secondaryText ? (
+          <Text className="text-xs text-neutral-2" numberOfLines={1}>
+            {secondaryText}
+          </Text>
+        ) : null}
+      </View>
+
+      {contacts ? (
+        <View className="flex-row items-center gap-1.5">{contacts}</View>
+      ) : null}
+    </View>
+  );
+}
+
+function UpcomingPastSegmentedControl({
+  selectedSegment,
+  onSegmentChange,
+}: {
+  selectedSegment: SoonlistHeroSegment;
+  onSegmentChange: (s: SoonlistHeroSegment) => void;
+}) {
+  if (Platform.OS === "ios") {
+    return (
+      <Host matchContents>
+        <Picker
+          selection={selectedSegment}
+          onSelectionChange={onSegmentChange}
+          modifiers={[pickerStyle("segmented")]}
+        >
+          <SwiftUIText modifiers={[tag("upcoming")]}>Upcoming</SwiftUIText>
+          <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
+        </Picker>
+      </Host>
+    );
+  }
+
+  return (
+    <View className="flex-row rounded-lg bg-gray-100 p-1">
+      <TouchableOpacity
+        className={`items-center rounded-md px-4 py-2 ${
+          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => onSegmentChange("upcoming")}
+      >
+        <Text
+          className={
+            selectedSegment === "upcoming"
+              ? "font-semibold text-gray-900"
+              : "text-gray-500"
+          }
+        >
+          Upcoming
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        className={`items-center rounded-md px-4 py-2 ${
+          selectedSegment === "past" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => onSegmentChange("past")}
+      >
+        <Text
+          className={
+            selectedSegment === "past"
+              ? "font-semibold text-gray-900"
+              : "text-gray-500"
+          }
+        >
+          Past
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function formatLastUpdated(addedAtMs: number | null | undefined): string {
+  if (addedAtMs === null || addedAtMs === undefined) return "";
+  const now = Date.now();
+  const diffMs = Math.max(0, now - addedAtMs);
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "Last updated just now";
+  if (minutes < 60) {
+    return `Last updated ${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `Last updated ${hours} hour${hours === 1 ? "" : "s"} ago`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `Last updated ${days} day${days === 1 ? "" : "s"} ago`;
+  }
+  const d = new Date(addedAtMs);
+  return `Last updated ${d.toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  })}`;
+}

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -31,11 +31,6 @@ interface SoonlistHeroProps {
    */
   selectedSegment?: SoonlistHeroSegment;
   onSegmentChange?: (s: SoonlistHeroSegment) => void;
-  /**
-   * Optional block rendered below the tabs. List detail uses this for a
-   * `FromTheseSoonlists` card showing owner + contributors.
-   */
-  footer?: React.ReactNode;
 }
 
 /**
@@ -49,7 +44,6 @@ export function SoonlistHero({
   lastUpdatedAt,
   selectedSegment,
   onSegmentChange,
-  footer,
 }: SoonlistHeroProps) {
   const hasTabs =
     selectedSegment !== undefined && onSegmentChange !== undefined;
@@ -81,8 +75,6 @@ export function SoonlistHero({
           />
         </View>
       ) : null}
-
-      {footer ? <View className="mt-4">{footer}</View> : null}
     </View>
   );
 }

--- a/packages/backend/convex/events.ts
+++ b/packages/backend/convex/events.ts
@@ -99,7 +99,7 @@ export const get = query({
     if (!event) return null;
 
     // Strip lists the viewer can't see so the event-detail attribution
-    // (FromTheseSoonlists / SavedByModal) doesn't leak private list
+    // (AttributionGrid / SavedByModal) doesn't leak private list
     // names or slugs to non-members.
     const identity = await ctx.auth.getUserIdentity();
     const viewerId = identity?.subject ?? null;

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -503,6 +503,16 @@ export const getPublicListFeedLastUpdated = query({
       return null;
     }
 
+    const viewerId = await getUserId(ctx);
+    const viewable = await getViewableListIds(
+      ctx,
+      [{ id: list.id, userId: list.userId, visibility: list.visibility }],
+      viewerId,
+    );
+    if (!viewable.has(list.id)) {
+      return null;
+    }
+
     const feedId = `list_${list.id}`;
     const [upcomingMax, pastMax] = await Promise.all([
       sampleMaxAddedAt(ctx, feedId, false),

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -490,6 +490,29 @@ export const getPublicUserFeedLastUpdated = query({
   },
 });
 
+export const getPublicListFeedLastUpdated = query({
+  args: { slug: v.string() },
+  returns: v.union(v.number(), v.null()),
+  handler: async (ctx, { slug }) => {
+    const list = await ctx.db
+      .query("lists")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .first();
+
+    if (!list) {
+      return null;
+    }
+
+    const feedId = `list_${list.id}`;
+    const [upcomingMax, pastMax] = await Promise.all([
+      sampleMaxAddedAt(ctx, feedId, false),
+      sampleMaxAddedAt(ctx, feedId, true),
+    ]);
+    const max = Math.max(upcomingMax, pastMax);
+    return max > 0 ? max : null;
+  },
+});
+
 // Internal mutation to update hasEndedFlags for a batch of userFeeds entries
 export const updateHasEndedFlagsBatch = internalMutation({
   args: {

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -820,6 +820,72 @@ export const getBySlug = query({
 });
 
 /**
+ * Get contributors (non-owner members with role="contributor") for a list.
+ *
+ * Used by the list detail hero to show who has captured events into the list,
+ * mirroring the "From these Soonlists" attribution on event detail (owner is
+ * the creator-equivalent, contributors are the savers-equivalent).
+ *
+ * Returns a bounded slice of UserForDisplay-shaped users. Respects list
+ * access rules — private lists only yield contributors to authorized viewers.
+ */
+export const getContributorsForList = query({
+  args: {
+    slug: v.string(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      id: v.string(),
+      username: v.string(),
+      displayName: v.string(),
+      userImage: v.string(),
+    }),
+  ),
+  handler: async (ctx, { slug, limit = 20 }) => {
+    const list = await ctx.db
+      .query("lists")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .first();
+
+    if (!list) {
+      return [];
+    }
+
+    const viewerId = await getUserId(ctx);
+    const access = await checkListAccess(ctx, list.id, viewerId);
+    if (access.status !== "ok") {
+      return [];
+    }
+
+    const members = await ctx.db
+      .query("listMembers")
+      .withIndex("by_list_and_role", (q) =>
+        q.eq("listId", list.id).eq("role", "contributor"),
+      )
+      .take(limit);
+
+    const users = await Promise.all(
+      members.map((m) =>
+        ctx.db
+          .query("users")
+          .withIndex("by_custom_id", (q) => q.eq("id", m.userId))
+          .first(),
+      ),
+    );
+
+    return users
+      .filter((u): u is NonNullable<typeof u> => u !== null)
+      .map((u) => ({
+        id: u.id,
+        username: u.username,
+        displayName: u.displayName,
+        userImage: u.userImage,
+      }));
+  },
+});
+
+/**
  * Get all system lists
  */
 export const getSystemLists = query({

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -858,12 +858,13 @@ export const getContributorsForList = query({
       return [];
     }
 
+    const boundedLimit = Math.max(1, Math.min(50, Math.floor(limit)));
     const members = await ctx.db
       .query("listMembers")
       .withIndex("by_list_and_role", (q) =>
         q.eq("listId", list.id).eq("role", "contributor"),
       )
-      .take(limit);
+      .take(boundedLimit);
 
     const users = await Promise.all(
       members.map((m) =>


### PR DESCRIPTION
## Summary
This PR extracts common hero section UI patterns into reusable components and enhances the list detail page with segment filtering, contributor attribution, and improved sharing functionality.

## Key Changes

### New Components
- **`SoonlistHero`**: Extracted hero section component used by both user profiles and list details, supporting:
  - Configurable title and subtitle
  - Last updated timestamp display
  - Optional upcoming/past segment tabs
  - Consistent styling and layout
- **`SoonlistHeroBylineRow`**: Reusable byline component displaying avatar, primary/secondary text, and contact buttons
- **`SoonlistHeroContactButton`**: Contact icon button component with consistent styling
- **`FloatingShareButton`**: Extracted floating share button component used across multiple screens
- **`SheetHeader`**: Reusable modal/sheet header component

### Refactored Components
- **`AttributionGrid`** (formerly `FromTheseSoonlists`):
  - Added `label` prop to customize section title
  - Added `creatorBadgeLabel` prop for context-specific labeling ("captured" vs "owner")
  - Added `background` prop to support white backgrounds (for list detail hero)
  - Renamed for broader semantic meaning beyond event detail context

### User Profile Page
- Simplified by delegating hero UI to `SoonlistHero` component
- Extracted byline rendering to `ProfileBylineRow` function
- Added profile sharing via `FloatingShareButton`
- Removed inline `SegmentedControlFallback` and contact button implementations

### List Detail Page
- Added segment filtering (upcoming/past events) matching user profile behavior
- Integrated `SoonlistHero` for consistent header styling
- Added contributor attribution via `AttributionGrid` in compact mode
- Implemented `FloatingShareButton` for sharing
- Added `getPublicListFeedLastUpdated` query to display last updated timestamp
- Added `getContributorsForList` query to fetch non-owner list members
- Improved share functionality with platform-specific handling (iOS URL vs Android message)

### Backend
- **`lists.ts`**: Added `getContributorsForList` query to fetch contributors for a list, respecting access control
- **`feeds.ts`**: Added `getPublicListFeedLastUpdated` query to get the most recent event addition timestamp for a list

## Implementation Details
- Share functionality now uses platform-specific approaches: iOS uses URL sharing, Android uses message sharing with embedded URL
- List detail now supports the same upcoming/past filtering as user profiles via `SoonlistHeroSegment` type
- Contact icon styling constants (`SOONLIST_HERO_CONTACT_ICON_SIZE`, `SOONLIST_HERO_CONTACT_ICON_COLOR`) are now exported from `SoonlistHero` for consistency
- `Config.apiBaseUrl` is used for generating shareable URLs instead of hardcoded domain

https://claude.ai/code/session_016iovopxEWRGx4jZ3CkCST6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies profile and list headers with a shared `SoonlistHero`, adds Upcoming/Past tabs and “Last updated …”, and introduces a floating share button. List detail now shows owner + contributor attribution via `AttributionGrid` and uses platform-aware sharing backed by new backend queries.

- New Features
  - `SoonlistHero` on profiles and lists: title/subtitle slot, “Last updated …”, and Upcoming/Past tabs.
  - List detail: `AttributionGrid` in the hero (compact, white background) with an owner badge, plus a `FloatingShareButton`.
  - Backend: `getPublicListFeedLastUpdated` and `getContributorsForList`; sharing uses `Config.apiBaseUrl` with iOS URL vs Android message.
  - UI polish: extracted `FloatingShareButton` and `SheetHeader`; Followed Lists modal updated to a single tinted card and now virtualized via `FlatList`.

- Bug Fixes
  - `getPublicListFeedLastUpdated` now respects list visibility before returning timestamps.
  - `SoonlistHero` hides the “Last updated …” line when no timestamp is available.
  - `AttributionGrid` shows “Owned by” in the compact single-creator case when `creatorBadgeLabel="owner"`.
  - `getContributorsForList` clamps `limit` to [1, 50] to prevent oversized queries.

<sup>Written for commit e49a9772158c44cd186c42d8e6bbefda20ba53ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts reusable hero-section UI (`SoonlistHero`, `SoonlistHeroBylineRow`, `FloatingShareButton`, `SheetHeader`) and brings the list detail page up to feature-parity with user profiles (segment filtering, contributor attribution, share button). Two P1 issues need attention before merge:

- `getPublicListFeedLastUpdated` (feeds.ts) has no access check, leaking last-activity timestamps for private lists to any caller — unlike the companion `getContributorsForList` which correctly gates on `checkListAccess`.
- Two `displayName.trim()` calls in `[username]/index.tsx` dropped the `?.` optional chaining that was present in the original code, introducing a crash path when `displayName` is null/undefined.

<h3>Confidence Score: 4/5</h3>

Two P1 issues should be fixed before merging: missing access control in the new feeds query and a null-safety regression on displayName.

The overall refactor is clean and well-structured. The P1 findings are straightforward fixes but represent a real security gap and a crash path respectively.

packages/backend/convex/feeds.ts (access control) and apps/expo/src/app/[username]/index.tsx (null safety).

<details open><summary><h3>Security Review</h3></summary>

- **Private list metadata exposure** (`packages/backend/convex/feeds.ts`): `getPublicListFeedLastUpdated` returns a last-activity timestamp for any list by slug without calling `checkListAccess`. A caller who knows a private list's slug can confirm the list exists and learn when it was last active, even without membership. The parallel query `getContributorsForList` in the same PR enforces access control correctly.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/backend/convex/feeds.ts | Adds `getPublicListFeedLastUpdated` query but omits access control, leaking last-activity timestamps for private lists to any caller. |
| apps/expo/src/app/[username]/index.tsx | Refactored to use new hero/share components; introduces two `displayName.trim()` calls without optional chaining, regressing from the original `?.trim()` guards. |
| apps/expo/src/app/list/[slug].tsx | Adds segment filtering, `SoonlistHero`, `AttributionGrid` for contributors, and `FloatingShareButton`; clean implementation. |
| packages/backend/convex/lists.ts | Adds `getContributorsForList` with proper `checkListAccess` enforcement; clean implementation. |
| apps/expo/src/components/SoonlistHero.tsx | New hero component extracting title, subtitle, last-updated display, and segmented control; well-structured. |
| apps/expo/src/components/FollowedListsModal.tsx | Switches to `SheetHeader` and `Config.apiBaseUrl`; `FlatList`→`ScrollView` migration loses top padding. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as ListDetailScreen
    participant Hero as SoonlistHero
    participant AG as AttributionGrid
    participant FSB as FloatingShareButton
    participant Convex

    Client->>Convex: getBySlug(slug)
    Client->>Convex: getPublicListFeedLastUpdated(slug)
    Client->>Convex: getContributorsForList(slug)
    Client->>Convex: getEventsForList(slug, filter)
    Convex-->>Client: listData, lastUpdatedAt, contributors, events

    Client->>Hero: render(title, lastUpdatedAt, segment)
    Hero->>AG: render(owner, contributors, variant=compact)
    Client->>FSB: render(onPress=handleShare)
    Client->>Convex: Share.share(url or message)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `packages/backend/convex/feeds.ts`, line 1307-1328 ([link](https://github.com/jaronheard/soonlist-turbo/blob/ead5c6588485bb83ced1a44416d450ebd08adea7/packages/backend/convex/feeds.ts#L1307-L1328)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Missing access control for private lists**

   `getPublicListFeedLastUpdated` fetches the last-activity timestamp for any list by slug without checking whether the viewer is authorized to see that list. The sibling query `getContributorsForList` (added in the same PR) correctly calls `checkListAccess` and returns `[]` when the viewer lacks permission. Without that gate here, any authenticated or unauthenticated caller can learn the last-updated timestamp of a private list just by knowing its slug — leaking activity metadata.

   ```ts
   if (!list) {
     return null;
   }

   // Add access check before querying feed data:
   const viewerId = await getUserId(ctx);
   const access = await checkListAccess(ctx, list.id, viewerId);
   if (access.status !== "ok") {
     return null;
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/backend/convex/feeds.ts
   Line: 1307-1328

   Comment:
   **Missing access control for private lists**

   `getPublicListFeedLastUpdated` fetches the last-activity timestamp for any list by slug without checking whether the viewer is authorized to see that list. The sibling query `getContributorsForList` (added in the same PR) correctly calls `checkListAccess` and returns `[]` when the viewer lacks permission. Without that gate here, any authenticated or unauthenticated caller can learn the last-updated timestamp of a private list just by knowing its slug — leaking activity metadata.

   ```ts
   if (!list) {
     return null;
   }

   // Add access check before querying feed data:
   const viewerId = await getUserId(ctx);
   const access = await checkListAccess(ctx, list.id, viewerId);
   if (access.status !== "ok") {
     return null;
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `apps/expo/src/app/[username]/index.tsx`, line 222-226 ([link](https://github.com/jaronheard/soonlist-turbo/blob/ead5c6588485bb83ced1a44416d450ebd08adea7/apps/expo/src/app/[username]/index.tsx#L222-L226)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`displayName.trim()` without null guard**

   The original code used `user.displayName?.trim()` (optional chaining), but the refactored `ProfileBylineRow` calls `.trim()` directly on `displayName`. If `displayName` is `null` or `undefined` (which the `?.` guarded against previously), this will throw a `TypeError` at runtime.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/src/app/[username]/index.tsx
   Line: 222-226

   Comment:
   **`displayName.trim()` without null guard**

   The original code used `user.displayName?.trim()` (optional chaining), but the refactored `ProfileBylineRow` calls `.trim()` directly on `displayName`. If `displayName` is `null` or `undefined` (which the `?.` guarded against previously), this will throw a `TypeError` at runtime.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `apps/expo/src/app/[username]/index.tsx`, line 379-382 ([link](https://github.com/jaronheard/soonlist-turbo/blob/ead5c6588485bb83ced1a44416d450ebd08adea7/apps/expo/src/app/[username]/index.tsx#L379-L382)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Same `displayName.trim()` null-safety issue**

   `targetUser.displayName` can be null/undefined (hence why the rest of the codebase guards with `?.`). Calling `.trim()` directly here will crash if the field is absent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/src/app/[username]/index.tsx
   Line: 379-382

   Comment:
   **Same `displayName.trim()` null-safety issue**

   `targetUser.displayName` can be null/undefined (hence why the rest of the codebase guards with `?.`). Calling `.trim()` directly here will crash if the field is absent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


4. `apps/expo/src/components/FollowedListsModal.tsx`, line 922-926 ([link](https://github.com/jaronheard/soonlist-turbo/blob/ead5c6588485bb83ced1a44416d450ebd08adea7/apps/expo/src/components/FollowedListsModal.tsx#L922-L926)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing top padding after `FlatList` → `ScrollView` migration**

   The `FlatList` had `paddingTop: 16` in its `contentContainerStyle`. The replacement `ScrollView` only sets `paddingBottom`, removing the visual breathing room between the `SheetHeader` and the first list row.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/src/components/FollowedListsModal.tsx
   Line: 922-926

   Comment:
   **Missing top padding after `FlatList` → `ScrollView` migration**

   The `FlatList` had `paddingTop: 16` in its `contentContainerStyle`. The replacement `ScrollView` only sets `paddingBottom`, removing the visual breathing room between the `SheetHeader` and the first list row.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/feeds.ts
Line: 1307-1328

Comment:
**Missing access control for private lists**

`getPublicListFeedLastUpdated` fetches the last-activity timestamp for any list by slug without checking whether the viewer is authorized to see that list. The sibling query `getContributorsForList` (added in the same PR) correctly calls `checkListAccess` and returns `[]` when the viewer lacks permission. Without that gate here, any authenticated or unauthenticated caller can learn the last-updated timestamp of a private list just by knowing its slug — leaking activity metadata.

```ts
if (!list) {
  return null;
}

// Add access check before querying feed data:
const viewerId = await getUserId(ctx);
const access = await checkListAccess(ctx, list.id, viewerId);
if (access.status !== "ok") {
  return null;
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/app/[username]/index.tsx
Line: 222-226

Comment:
**`displayName.trim()` without null guard**

The original code used `user.displayName?.trim()` (optional chaining), but the refactored `ProfileBylineRow` calls `.trim()` directly on `displayName`. If `displayName` is `null` or `undefined` (which the `?.` guarded against previously), this will throw a `TypeError` at runtime.

```suggestion
      primaryAccessibilityLabel={
        user.displayName?.trim()
          ? `${user.displayName.trim()}, @${user.username}`
          : `@${user.username}`
      }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/app/[username]/index.tsx
Line: 379-382

Comment:
**Same `displayName.trim()` null-safety issue**

`targetUser.displayName` can be null/undefined (hence why the rest of the codebase guards with `?.`). Calling `.trim()` directly here will crash if the field is absent.

```suggestion
          accessibilityLabel={`Share ${
            targetUser.displayName?.trim() || targetUser.username
          }'s Soonlist`}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/FollowedListsModal.tsx
Line: 922-926

Comment:
**Missing top padding after `FlatList` → `ScrollView` migration**

The `FlatList` had `paddingTop: 16` in its `contentContainerStyle`. The replacement `ScrollView` only sets `paddingBottom`, removing the visual breathing room between the `SheetHeader` and the first list row.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: prettier formatting"](https://github.com/jaronheard/soonlist-turbo/commit/ead5c6588485bb83ced1a44416d450ebd08adea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29200576)</sub>

<!-- /greptile_comment -->