### PR TITLE
 @coderabbitai

### DIFF
--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -180,7 +180,7 @@ function PeopleOnlyRow({
   const remainingUsersCount = displayUsers.length - inlineUsers.length;
 
   return (
-    <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
+    <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
       {isOwnEvent ? (
         <Text className="text-xs text-neutral-2">Saved by</Text>
       ) : null}
@@ -258,12 +258,10 @@ function ListPrimaryRow({
         onPress={openModal}
         hitSlop={HIT_SLOP}
         accessibilityLabel="View everyone who saved this"
-        className="flex-row items-center"
+        className="flex-row items-center gap-2"
       >
-        {stackUsers.map((user, index) => (
-          <View key={user.id} style={{ marginLeft: index === 0 ? 0 : -6 }}>
-            <UserAvatar user={user} size={avatarSize} />
-          </View>
+        {stackUsers.map((user) => (
+          <UserAvatar key={user.id} user={user} size={avatarSize} />
         ))}
         <OverflowPill count={extraCount} className="ml-1" />
       </Pressable>
@@ -271,7 +269,7 @@ function ListPrimaryRow({
 
   return (
     <>
-      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
+      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
         {isOwnEvent ? (
           <>
             {ownBadge}
@@ -335,7 +333,7 @@ function PeoplePrimaryRow({
 
   return (
     <>
-      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-1">
+      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
         {isOwnEvent ? (
           <Pressable
             onPress={() => navigateToUser(creator, currentUserId)}

--- a/apps/expo/src/components/UserProfileFlair.tsx
+++ b/apps/expo/src/components/UserProfileFlair.tsx
@@ -17,13 +17,23 @@ interface UserProfileFlairProps {
   size?: Size;
 }
 
-const sizeClasses: Record<Size, string> = {
-  xs: "text-xs top-0 -right-2 min-w-[1.25rem]",
-  sm: "text-sm top-0 -right-2 min-w-[1.5rem]",
-  md: "text-base top-0 -right-2 min-w-[1.75rem]",
-  lg: "text-lg top-0 -right-2 min-w-[2rem]",
-  xl: "text-xl top-0 -right-2 min-w-[2.25rem]",
-  "2xl": "text-2xl top-0 -right-2 min-w-[2.5rem]",
+const flairContainerClasses: Record<Size, string> = {
+  xs: "top-0 -right-1.5 min-w-[0.9375rem]",
+  sm: "top-0 -right-2 min-w-[1.5rem]",
+  md: "top-0 -right-2 min-w-[1.75rem]",
+  lg: "top-0 -right-2 min-w-[2rem]",
+  xl: "top-0 -right-2 min-w-[2.25rem]",
+  "2xl": "top-0 -right-2 min-w-[2.5rem]",
+};
+
+/** `xs` is list / attribution avatars; compact flair vs `text-sm`+ sizes. */
+const flairEmojiTextClasses: Record<Size, string> = {
+  xs: "text-[0.5625rem] leading-none",
+  sm: "text-sm leading-none",
+  md: "text-base leading-none",
+  lg: "text-lg leading-none",
+  xl: "text-xl leading-none",
+  "2xl": "text-2xl leading-none",
 };
 
 function UserEmoji({
@@ -47,11 +57,16 @@ function UserEmoji({
     <View
       className={cn(
         "absolute z-10 overflow-visible",
-        sizeClasses[size],
+        flairContainerClasses[size],
         flairClassName,
       )}
     >
-      <Text className="flex items-center justify-center text-interactive-1">
+      <Text
+        className={cn(
+          "flex items-center justify-center text-interactive-1",
+          flairEmojiTextClasses[size],
+        )}
+      >
         {userEmoji}
       </Text>
     </View>


### PR DESCRIPTION
Made-with: Cursor

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases spacing between attribution avatars and fine-tunes profile emoji flair sizing (especially `xs`) for better readability and less visual crowding.
Simplifies the avatar stack layout by removing negative margins and splits flair sizing into container and text classes for consistent scaling across sizes.

<sup>Written for commit 5886df47d3e7269f5f84f8aad108fa36ea7e540b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies two visual polish changes to the Expo attribution components: it widens inter-element spacing from `gap-1` to `gap-2` across three row variants and replaces the inline negative-margin avatar-stacking pattern with a CSS gap layout; it also splits `UserProfileFlair`'s single `sizeClasses` map into separate container and text records so the `xs` size can use a compact 9 px emoji font without affecting larger sizes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely visual styling with no logic or data-flow impact.

All findings are P2 style suggestions. The only notable item is the residual `ml-1` on `OverflowPill` creating slightly uneven spacing, which is cosmetic and does not block merge.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/EventAttributionRow.tsx | Visual polish: widens row gap from `gap-1` to `gap-2` in three places and removes the inline negative-margin avatar-stacking in favour of CSS gap; one minor residual `ml-1` on OverflowPill may be unnecessary. |
| apps/expo/src/components/UserProfileFlair.tsx | Splits the single `sizeClasses` map into separate `flairContainerClasses` and `flairEmojiTextClasses` records, allowing the `xs` size to use a custom compact font size (`text-[0.5625rem]`) and tighter positioning without affecting larger sizes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventAttributionRow] --> B[PeopleOnlyRow\ngap-1 → gap-2]
    A --> C[ListPrimaryRow\ngap-1 → gap-2]
    A --> D[PeoplePrimaryRow\ngap-1 → gap-2]
    C --> E[Avatar stack\nnegative marginLeft → gap-2]
    E --> F[OverflowPill\nml-1 still present]

    G[UserProfileFlair] --> H[UserEmoji]
    H --> I[flairContainerClasses\nposition per size]
    H --> J[flairEmojiTextClasses\nfont size per size]
    J --> K[xs: text-0.5625rem\nleading-none]
    J --> L[sm–2xl: text-sm…2xl\nleading-none]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 266

Comment:
**Redundant `ml-1` alongside `gap-2`**

Now that the parent `Pressable` has `gap-2` (8 px) applied to space all its children uniformly, the `ml-1` (4 px) on `OverflowPill` stacks on top of that gap, giving it 12 px of separation from the last avatar while avatars are only 8 px apart. If the intent is equal spacing throughout, `ml-1` can be removed.

```suggestion
        <OverflowPill count={extraCount} />
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): increase attribution avatar s..."](https://github.com/jaronheard/soonlist-turbo/commit/5886df47d3e7269f5f84f8aad108fa36ea7e540b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29218331)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->