### PR TITLE
fix(expo): iOS capture overlay, native tabs, and UI polish

### DIFF
--- a/apps/expo/src/app/(tabs)/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/_layout.tsx
@@ -1,5 +1,6 @@
 import { NativeTabs } from "expo-router/unstable-native-tabs";
 
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useAppStore } from "~/store";
 
 // Export Expo Router's error boundary
@@ -16,7 +17,9 @@ export default function TabsLayout() {
   return (
     <NativeTabs
       tintColor="#5A32FB"
-      minimizeBehavior="onScrollDown"
+      {...(SUPPORTS_LIQUID_GLASS
+        ? { minimizeBehavior: "onScrollDown" as const }
+        : {})}
       blurEffect="systemChromeMaterialLight" /* interactive-1 */
     >
       <NativeTabs.Trigger name="feed">

--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -5,13 +5,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Platform, Text, TouchableOpacity, View } from "react-native";
+import { Text, View } from "react-native";
 import * as Location from "expo-location";
 import { Redirect } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
-import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
-import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
 import {
   Authenticated,
   AuthLoading,
@@ -23,6 +21,7 @@ import { usePostHog } from "posthog-react-native";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
+import { UpcomingPastSegmentedControl } from "~/components/UpcomingPastSegmentedControl";
 import UserEventsList from "~/components/UserEventsList";
 import { useShareListPrompt } from "~/hooks/useShareListPrompt";
 import { useShareMyList } from "~/hooks/useShareMyList";
@@ -32,51 +31,6 @@ import { useAppStore, useStableTimestamp } from "~/store";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type Segment = "upcoming" | "past";
-
-function SegmentedControlFallback({
-  selectedSegment,
-  onSegmentChange,
-}: {
-  selectedSegment: Segment;
-  onSegmentChange: (segment: Segment) => void;
-}) {
-  return (
-    <View className="flex-row rounded-lg bg-gray-100 p-1">
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("upcoming")}
-      >
-        <Text
-          className={
-            selectedSegment === "upcoming"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Upcoming
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "past" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("past")}
-      >
-        <Text
-          className={
-            selectedSegment === "past"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Past
-        </Text>
-      </TouchableOpacity>
-    </View>
-  );
-}
 
 function MyFeedContent() {
   const { user } = useUser();
@@ -262,27 +216,10 @@ function MyFeedContent() {
           </View>
         )}
         <View style={{ width: 260 }}>
-          {Platform.OS === "ios" ? (
-            <Host matchContents>
-              <Picker
-                selection={selectedSegment}
-                onSelectionChange={(value) => {
-                  handleSegmentChange(value as Segment);
-                }}
-                modifiers={[pickerStyle("segmented")]}
-              >
-                <SwiftUIText modifiers={[tag("upcoming")]}>
-                  Upcoming
-                </SwiftUIText>
-                <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
-              </Picker>
-            </Host>
-          ) : (
-            <SegmentedControlFallback
-              selectedSegment={selectedSegment}
-              onSegmentChange={handleSegmentChange}
-            />
-          )}
+          <UpcomingPastSegmentedControl
+            selectedSegment={selectedSegment}
+            onSegmentChange={handleSegmentChange}
+          />
         </View>
       </View>
     );

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -5,12 +5,10 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Platform, Share, Text, TouchableOpacity, View } from "react-native";
+import { Share, Text, TouchableOpacity, View } from "react-native";
 import { Redirect } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
-import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
-import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
 import {
   Authenticated,
   AuthLoading,
@@ -24,6 +22,7 @@ import { DefaultEmptyState } from "~/components/DefaultEmptyState";
 import { FollowedListsModal } from "~/components/FollowedListsModal";
 import { MatchAuthLoadingSurface } from "~/components/MatchAuthLoadingSurface";
 import { ReferralEmptyState } from "~/components/ReferralEmptyState";
+import { UpcomingPastSegmentedControl } from "~/components/UpcomingPastSegmentedControl";
 import UserEventsList from "~/components/UserEventsList";
 import { useStableFeedListBodyLoading } from "~/hooks/useStableFeedListBodyLoading";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
@@ -32,51 +31,6 @@ import { logError } from "~/utils/errorLogging";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
 
 type Segment = "upcoming" | "past";
-
-function SegmentedControlFallback({
-  selectedSegment,
-  onSegmentChange,
-}: {
-  selectedSegment: Segment;
-  onSegmentChange: (segment: Segment) => void;
-}) {
-  return (
-    <View className="flex-row rounded-lg bg-gray-100 p-1">
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("upcoming")}
-      >
-        <Text
-          className={
-            selectedSegment === "upcoming"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Upcoming
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "past" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("past")}
-      >
-        <Text
-          className={
-            selectedSegment === "past"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Past
-        </Text>
-      </TouchableOpacity>
-    </View>
-  );
-}
 
 function FollowingFeedContent() {
   const { user } = useUser();
@@ -271,27 +225,10 @@ function FollowingFeedContent() {
           </TouchableOpacity>
         )}
         <View style={{ width: 260 }}>
-          {Platform.OS === "ios" ? (
-            <Host matchContents>
-              <Picker
-                selection={selectedSegment}
-                onSelectionChange={(value) => {
-                  handleSegmentChange(value as Segment);
-                }}
-                modifiers={[pickerStyle("segmented")]}
-              >
-                <SwiftUIText modifiers={[tag("upcoming")]}>
-                  Upcoming
-                </SwiftUIText>
-                <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
-              </Picker>
-            </Host>
-          ) : (
-            <SegmentedControlFallback
-              selectedSegment={selectedSegment}
-              onSegmentChange={handleSegmentChange}
-            />
-          )}
+          <UpcomingPastSegmentedControl
+            selectedSegment={selectedSegment}
+            onSegmentChange={handleSegmentChange}
+          />
         </View>
       </View>
     );

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -396,7 +396,8 @@ function RootLayoutContent() {
   return (
     <View style={{ flex: 1 }}>
       <InitialLayout />
-      <StatusBar style="auto" />
+      {/* App is light-only (app.config userInterfaceStyle: light); force dark status bar content */}
+      <StatusBar style="dark" />
     </View>
   );
 }

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -597,7 +597,7 @@ function EventDetail({ id }: { id: string }) {
               Lives after the event content and source attribution so the
               reading order is: what it is → what it's about → where it
               came from → who has it. */}
-          {showDiscover && event.user && (
+          {event.user && (
             <View className="mb-4">
               <AttributionGrid
                 creator={{

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -123,7 +123,7 @@ export function AttributionGrid({
       <TouchableOpacity
         key={`user-${user.id}`}
         onPress={() => handleUserPress(user)}
-        className={`flex-row items-center ${rowPaddingY}`}
+        className={`flex-row items-center overflow-visible ${rowPaddingY}`}
         activeOpacity={0.7}
         accessibilityRole="button"
         accessibilityLabel={`Open ${

--- a/apps/expo/src/components/CaptureOverlayButton.tsx
+++ b/apps/expo/src/components/CaptureOverlayButton.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from "react";
 import { ActivityIndicator, Platform, Pressable, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { PlusIcon } from "~/components/icons";
 import { useAddEventFlow } from "~/hooks/useAddEventFlow";
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useNetworkStatus } from "~/hooks/useNetworkStatus";
 import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 
@@ -24,12 +26,16 @@ const CAPTURING_TIMEOUT_MS = 30_000;
  * Floating capture entry point rendered inside the tab screen layouts (feed
  * and following). Positioned relative to the tab content area.
  *
+ * Before iOS 26, bottom inset includes the safe area so the control clears the
+ * home indicator; on iOS 26 and later, positioning matches the original floating layout.
+ *
  * iOS-only — the app does not ship Android.
  */
 export function CaptureOverlayButton({
   bottomOffset = 24,
   rightOffset = 16,
 }: CaptureOverlayButtonProps = {}) {
+  const insets = useSafeAreaInsets();
   const isOnline = useNetworkStatus();
   const isCapturing = useInFlightEventStore((s) => s.isCapturing);
   const { triggerAddEventFlow } = useAddEventFlow();
@@ -66,7 +72,8 @@ export function CaptureOverlayButton({
       style={{
         position: "absolute",
         right: rightOffset,
-        bottom: bottomOffset,
+        bottom:
+          bottomOffset + (SUPPORTS_LIQUID_GLASS ? 0 : insets.bottom),
         zIndex: 100,
       }}
     >

--- a/apps/expo/src/components/CaptureOverlayButton.tsx
+++ b/apps/expo/src/components/CaptureOverlayButton.tsx
@@ -72,8 +72,7 @@ export function CaptureOverlayButton({
       style={{
         position: "absolute",
         right: rightOffset,
-        bottom:
-          bottomOffset + (SUPPORTS_LIQUID_GLASS ? 0 : insets.bottom),
+        bottom: bottomOffset + (SUPPORTS_LIQUID_GLASS ? 0 : insets.bottom),
         zIndex: 100,
       }}
     >

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -1,15 +1,10 @@
 import React from "react";
-import {
-  Platform,
-  Pressable,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
-import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
-import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
+import { Pressable, Text, View } from "react-native";
 
-export type SoonlistHeroSegment = "upcoming" | "past";
+import { UpcomingPastSegmentedControl } from "~/components/UpcomingPastSegmentedControl";
+import type { UpcomingPastSegment } from "~/components/UpcomingPastSegmentedControl";
+
+export type SoonlistHeroSegment = UpcomingPastSegment;
 
 interface SoonlistHeroProps {
   title: string;
@@ -122,66 +117,6 @@ export function SoonlistHeroBylineRow({
       {contacts ? (
         <View className="flex-row items-center gap-1.5">{contacts}</View>
       ) : null}
-    </View>
-  );
-}
-
-function UpcomingPastSegmentedControl({
-  selectedSegment,
-  onSegmentChange,
-}: {
-  selectedSegment: SoonlistHeroSegment;
-  onSegmentChange: (s: SoonlistHeroSegment) => void;
-}) {
-  if (Platform.OS === "ios") {
-    return (
-      <Host matchContents>
-        <Picker
-          selection={selectedSegment}
-          onSelectionChange={onSegmentChange}
-          modifiers={[pickerStyle("segmented")]}
-        >
-          <SwiftUIText modifiers={[tag("upcoming")]}>Upcoming</SwiftUIText>
-          <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
-        </Picker>
-      </Host>
-    );
-  }
-
-  return (
-    <View className="flex-row rounded-lg bg-gray-100 p-1">
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("upcoming")}
-      >
-        <Text
-          className={
-            selectedSegment === "upcoming"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Upcoming
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        className={`items-center rounded-md px-4 py-2 ${
-          selectedSegment === "past" ? "bg-white shadow-sm" : ""
-        }`}
-        onPress={() => onSegmentChange("past")}
-      >
-        <Text
-          className={
-            selectedSegment === "past"
-              ? "font-semibold text-gray-900"
-              : "text-gray-500"
-          }
-        >
-          Past
-        </Text>
-      </TouchableOpacity>
     </View>
   );
 }

--- a/apps/expo/src/components/SoonlistHero.tsx
+++ b/apps/expo/src/components/SoonlistHero.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Pressable, Text, View } from "react-native";
 
-import { UpcomingPastSegmentedControl } from "~/components/UpcomingPastSegmentedControl";
 import type { UpcomingPastSegment } from "~/components/UpcomingPastSegmentedControl";
+import { UpcomingPastSegmentedControl } from "~/components/UpcomingPastSegmentedControl";
 
 export type SoonlistHeroSegment = UpcomingPastSegment;
 

--- a/apps/expo/src/components/UpcomingPastSegmentedControl.tsx
+++ b/apps/expo/src/components/UpcomingPastSegmentedControl.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Platform, Text, TouchableOpacity, View } from "react-native";
+import { Host, Picker, Text as SwiftUIText } from "@expo/ui/swift-ui";
+import { pickerStyle, tag } from "@expo/ui/swift-ui/modifiers";
+
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
+import { hapticSelection } from "~/utils/feedback";
+
+export type UpcomingPastSegment = "upcoming" | "past";
+
+function isUpcomingPastSegment(value: string): value is UpcomingPastSegment {
+  return value === "upcoming" || value === "past";
+}
+
+interface UpcomingPastSegmentedControlProps {
+  selectedSegment: UpcomingPastSegment;
+  onSegmentChange: (segment: UpcomingPastSegment) => void;
+}
+
+/**
+ * Upcoming / Past toggle. On iOS 26+ uses SwiftUI segmented picker (Liquid Glass).
+ * On older iOS, RN fallback avoids low-contrast SwiftUI segmented styling in light mode.
+ * Fires selection haptic on change (iOS HIG: UISelectionFeedbackGenerator).
+ */
+export function UpcomingPastSegmentedControl({
+  selectedSegment,
+  onSegmentChange,
+}: UpcomingPastSegmentedControlProps) {
+  const emitChange = (segment: UpcomingPastSegment) => {
+    if (segment === selectedSegment) return;
+    void hapticSelection();
+    onSegmentChange(segment);
+  };
+
+  if (Platform.OS === "ios" && SUPPORTS_LIQUID_GLASS) {
+    return (
+      <Host matchContents>
+        <Picker
+          selection={selectedSegment}
+          onSelectionChange={(value) => {
+            if (!isUpcomingPastSegment(value)) return;
+            emitChange(value);
+          }}
+          modifiers={[pickerStyle("segmented")]}
+        >
+          <SwiftUIText modifiers={[tag("upcoming")]}>Upcoming</SwiftUIText>
+          <SwiftUIText modifiers={[tag("past")]}>Past</SwiftUIText>
+        </Picker>
+      </Host>
+    );
+  }
+
+  return (
+    <View className="flex-row rounded-lg bg-gray-200 p-1">
+      <TouchableOpacity
+        className={`flex-1 items-center rounded-md px-3 py-2 ${
+          selectedSegment === "upcoming" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => emitChange("upcoming")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: selectedSegment === "upcoming" }}
+      >
+        <Text
+          className={
+            selectedSegment === "upcoming"
+              ? "font-semibold text-gray-950"
+              : "font-medium text-gray-800"
+          }
+        >
+          Upcoming
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        className={`flex-1 items-center rounded-md px-3 py-2 ${
+          selectedSegment === "past" ? "bg-white shadow-sm" : ""
+        }`}
+        onPress={() => emitChange("past")}
+        accessibilityRole="button"
+        accessibilityState={{ selected: selectedSegment === "past" }}
+      >
+        <Text
+          className={
+            selectedSegment === "past"
+              ? "font-semibold text-gray-950"
+              : "font-medium text-gray-800"
+          }
+        >
+          Past
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/apps/expo/src/components/UserAvatar.tsx
+++ b/apps/expo/src/components/UserAvatar.tsx
@@ -12,9 +12,12 @@ interface UserAvatarProps {
   recyclingKey?: string;
 }
 
+/** Bit bigger avatars (e.g. From these Soonlists 32–44px) use standard `lg` flair. */
 export function UserAvatar({ user, size, recyclingKey }: UserAvatarProps) {
+  const flairSize = size >= 28 ? "lg" : "xs";
+
   return (
-    <UserProfileFlair username={user.username} size="xs">
+    <UserProfileFlair username={user.username} size={flairSize}>
       {user.userImage ? (
         <ExpoImage
           source={{ uri: user.userImage }}

--- a/apps/expo/src/components/UserProfileFlair.tsx
+++ b/apps/expo/src/components/UserProfileFlair.tsx
@@ -68,7 +68,9 @@ function UserEmoji({
           flairEmojiTextClasses[size],
         )}
         maxFontSizeMultiplier={
-          size === "xs" || size === "sm" || size === "lg" ? 1.25 : undefined
+          size === "xs" || size === "sm" || size === "md" || size === "lg"
+            ? 1.25
+            : undefined
         }
         style={{ includeFontPadding: false }}
       >

--- a/apps/expo/src/components/UserProfileFlair.tsx
+++ b/apps/expo/src/components/UserProfileFlair.tsx
@@ -18,22 +18,23 @@ interface UserProfileFlairProps {
 }
 
 const flairContainerClasses: Record<Size, string> = {
-  xs: "top-0 -right-1.5 min-w-[0.9375rem]",
-  sm: "top-0 -right-2 min-w-[1.5rem]",
-  md: "top-0 -right-2 min-w-[1.75rem]",
-  lg: "top-0 -right-2 min-w-[2rem]",
+  /* xs–lg: rim placement so emoji isn’t sheared at the circle edge */
+  xs: "-top-1 -right-2.5 min-w-[1rem]",
+  sm: "-top-1 -right-2.5 min-w-[1.5rem]",
+  md: "-top-1 -right-2.5 min-w-[1.75rem]",
+  lg: "-top-1 -right-2.5 min-w-[2rem]",
   xl: "top-0 -right-2 min-w-[2.25rem]",
   "2xl": "top-0 -right-2 min-w-[2.5rem]",
 };
 
-/** `xs` is list / attribution avatars; compact flair vs `text-sm`+ sizes. */
 const flairEmojiTextClasses: Record<Size, string> = {
-  xs: "text-[0.5625rem] leading-none",
-  sm: "text-sm leading-none",
-  md: "text-base leading-none",
-  lg: "text-lg leading-none",
-  xl: "text-xl leading-none",
-  "2xl": "text-2xl leading-none",
+  xs: "text-[0.625rem] leading-[1.25]",
+  /* leading-none clips emoji; py-px gives color-glyph breathing room */
+  sm: "text-sm leading-[1.25] py-px",
+  md: "text-base leading-[1.25] py-px",
+  lg: "text-lg leading-[1.25] py-px",
+  xl: "text-xl leading-[1.2] py-px",
+  "2xl": "text-2xl leading-[1.2] py-px",
 };
 
 function UserEmoji({
@@ -63,9 +64,13 @@ function UserEmoji({
     >
       <Text
         className={cn(
-          "flex items-center justify-center text-interactive-1",
+          "text-center text-interactive-1",
           flairEmojiTextClasses[size],
         )}
+        maxFontSizeMultiplier={
+          size === "xs" || size === "sm" || size === "lg" ? 1.25 : undefined
+        }
+        style={{ includeFontPadding: false }}
       >
         {userEmoji}
       </Text>
@@ -81,7 +86,7 @@ export function UserProfileFlair({
   size = "md",
 }: UserProfileFlairProps) {
   return (
-    <View className={cn("relative", className)}>
+    <View className={cn("relative overflow-visible", className)}>
       {children}
       <UserEmoji
         username={username}


### PR DESCRIPTION
## Summary
- **Capture overlay (iOS 26)**: Restores the capture overlay with correct behavior on iOS 26; improves safe area handling on older iOS.
- **Segmented control**: Haptics and contrast improvements for the upcoming/past control.
- **Status bar**: Forces dark status bar content for the light-only UI.
- **Avatars**: Fixes emoji flair sizing, rim placement, and overflow.
- **Event attribution grid**: Shows the event attribution grid without the Discover gate.

## Test plan
- [ ] Verify capture overlay on iOS 26 and older iOS.
- [ ] Check upcoming/past segment control haptics and readability.
- [ ] Confirm status bar on light screens.
- [ ] Spot-check avatars and event attribution grid in relevant flows.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the iOS capture overlay on iOS 26 and polishes key UI elements. Improves the segmented control with haptics and contrast, forces dark status bar content, fixes avatar flair layout, and always shows the attribution grid.

- **Bug Fixes**
  - Capture overlay: restored on iOS 26; correct safe-area spacing on older iOS using insets.
  - Native tabs: apply minimizeBehavior only when `SUPPORTS_LIQUID_GLASS`.
  - Segmented control: new `UpcomingPastSegmentedControl` with SwiftUI segmented UI on iOS 26+ and RN fallback elsewhere; adds selection haptic and better contrast.
  - Status bar: force `dark` content for the light-only app.
  - Avatars: dynamic flair size for larger avatars; fix emoji rim placement; cap accessibility font scaling for `md` flair; prevent clipping via overflow-visible.
  - Attribution grid: show without the Discover gate; enable row overflow visibility.

<sup>Written for commit 04f7427af8419ca9d0148686b7fe64c10f35d405. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the iOS Expo app across several areas: restoring the capture overlay with correct safe-area handling differentiated by iOS 26+ detection, extracting the duplicated segmented control into a shared `UpcomingPastSegmentedControl` component with haptics and improved contrast, fixing emoji flair sizing/placement in `UserProfileFlair`, forcing dark status bar content for the light-only UI, and removing the `showDiscover` gate from the attribution grid. The refactoring cleanly eliminates three copies of near-identical segmented control code.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions that don't affect correctness.

The changes are well-scoped UI polish and refactoring with no logic regressions identified. The two P2 findings (potential double haptic on iOS 26+ SwiftUI picker and a missing maxFontSizeMultiplier for the md flair size) are minor UX concerns, not functional bugs.

apps/expo/src/components/UpcomingPastSegmentedControl.tsx — verify haptic behaviour on physical iOS 26 device to confirm no double-fire.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/UpcomingPastSegmentedControl.tsx | New shared segmented control component; extracts duplicated inline controls from feed/following/hero. Haptic firing via emitChange on the SwiftUI path may double-fire with native picker haptics on iOS 26+. |
| apps/expo/src/components/CaptureOverlayButton.tsx | Adds safe area inset to bottom offset for pre-iOS-26 devices so button clears the home indicator; skips the inset on iOS 26+ where native tab layout handles safe area. |
| apps/expo/src/components/UserProfileFlair.tsx | Visual polish: rim placement, emoji font sizing, leading fix, and maxFontSizeMultiplier capping for xs/sm/lg sizes; adds overflow-visible to wrapper View. |
| apps/expo/src/components/UserAvatar.tsx | Flair size now dynamically chosen as 'lg' for avatars ≥28px, 'xs' for smaller ones, instead of always 'xs'. |
| apps/expo/src/app/(tabs)/_layout.tsx | Conditionally applies minimizeBehavior='onScrollDown' only on iOS 26+ (Liquid Glass), avoiding the prop on older iOS where it was causing issues. |
| apps/expo/src/app/event/[id]/index.tsx | Removes the showDiscover gate from AttributionGrid rendering so it always shows when event.user exists. |
| apps/expo/src/app/_layout.tsx | Forces dark status bar content since the app is light-only; replaces auto style which could render incorrectly on certain screens. |
| apps/expo/src/app/(tabs)/feed/index.tsx | Replaces inline segmented control (SwiftUI Picker + fallback) with shared UpcomingPastSegmentedControl; removes unused imports. |
| apps/expo/src/app/(tabs)/following/index.tsx | Same refactor as feed/index.tsx — inline control replaced with shared UpcomingPastSegmentedControl component. |
| apps/expo/src/components/SoonlistHero.tsx | Removes the third duplicate inline segmented control; now uses shared UpcomingPastSegmentedControl and re-exports its type alias. |
| apps/expo/src/components/AttributionGrid.tsx | Adds overflow-visible to user row TouchableOpacity so emoji flair isn't clipped by the row's bounds. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UpcomingPastSegmentedControl] --> B{iOS 26+ / SUPPORTS_LIQUID_GLASS?}
    B -- Yes --> C[SwiftUI Host + Picker\nsegmented style]
    B -- No --> D[RN fallback\nbg-gray-200 toggle]
    C --> E[emitChange\nhapticSelection + onSegmentChange]
    D --> E

    F[CaptureOverlayButton] --> G{SUPPORTS_LIQUID_GLASS?}
    G -- Yes --> H[bottom = bottomOffset]
    G -- No --> I[bottom = bottomOffset + insets.bottom]

    J[TabsLayout NativeTabs] --> K{SUPPORTS_LIQUID_GLASS?}
    K -- Yes --> L[minimizeBehavior: onScrollDown]
    K -- No --> M[no minimizeBehavior prop]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/UpcomingPastSegmentedControl.tsx
Line: 40-43

Comment:
**Possible double haptic on iOS 26+ SwiftUI picker**

The SwiftUI `Picker` with `pickerStyle("segmented")` fires its own native selection haptic. Calling `hapticSelection()` inside `emitChange` before forwarding to `onSegmentChange` means users on iOS 26+ will experience two haptic pulses per tap — one from the native control and one from `emitChange`. Consider skipping the manual haptic when on the SwiftUI path, or confirm the native picker doesn't generate its own feedback.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/UserProfileFlair.tsx
Line: 70-72

Comment:
**`maxFontSizeMultiplier` not applied to `md` size**

`xs`, `sm`, and `lg` get a 1.25 cap, but `md` is absent from the condition, leaving it uncapped. If a user has a large accessibility font scale and the flair is rendered at `md` (the component default), the emoji could overflow its container unexpectedly. Likely an oversight given the adjacent sizes are capped.

```suggestion
        maxFontSizeMultiplier={
          size === "xs" || size === "sm" || size === "md" || size === "lg" ? 1.25 : undefined
        }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): show event attribution grid w..."](https://github.com/jaronheard/soonlist-turbo/commit/f1d9d8d149c51481015a426ea833dfe49289b93d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29328942)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->