### PR TITLE
fix(cursor): use pnpm install for worktree setup

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,5 +1,5 @@
 {
   "setup-worktree": [
-    "npm install"
+    "pnpm install"
   ]
 }


### PR DESCRIPTION
Cursor's `.cursor/worktrees.json` ran `npm install`, which does not match this repo's pnpm workspace (`packageManager`, `pnpm-lock.yaml`, `workspace:*`). Worktree setup was failing; switching to `pnpm install` aligns with the monorepo and matches the existing Claude worktree hook.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Cursor worktree setup to run `pnpm install` instead of `npm install`. This matches the repo’s `pnpm` workspace and prevents worktree setup failures.

<sup>Written for commit f9904f93297c82770b05f3a13d282032de79b565. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Cursor worktree setup command by replacing `npm install` with `pnpm install` in `.cursor/worktrees.json`, aligning it with the monorepo's `pnpm` workspace toolchain (`pnpm-lock.yaml`, `workspace:*` dependencies). The change is minimal and correct — it mirrors the existing Claude worktree hook pattern already used in the repo.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config fix with no functional risk.

The change is a one-line fix to a config file, swapping the wrong package manager for the correct one. No logic, no application code, and no issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .cursor/worktrees.json | Replaces `npm install` with `pnpm install` in the Cursor worktree setup command to align with the repo's pnpm workspace configuration. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cursor opens new worktree] --> B[Runs setup-worktree commands]
    B --> C{Before PR}
    B --> D{After PR}
    C --> E[npm install ❌\nIgnores pnpm-lock.yaml\nBreaks workspace: deps]
    D --> F[pnpm install ✅\nHonors pnpm-lock.yaml\nResolves workspace: deps]
```

<sub>Reviews (1): Last reviewed commit: ["fix(cursor): use pnpm install for worktr..."](https://github.com/jaronheard/soonlist-turbo/commit/f9904f93297c82770b05f3a13d282032de79b565) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29331385)</sub>

<!-- /greptile_comment -->