### PR TITLE
feat(expo): Collapse inline attribution to avatar stack

### DIFF
--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -1,13 +1,32 @@
-import React from "react";
-import { Text, TouchableOpacity, View } from "react-native";
+import React, { useState } from "react";
+import { Pressable, Text, TouchableOpacity, View } from "react-native";
 import { router } from "expo-router";
 
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 
 import type { UserForDisplay } from "~/types/user";
-import { ChevronRight, List as ListIcon } from "~/components/icons";
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  List as ListIcon,
+} from "~/components/icons";
 import { UserAvatar } from "~/components/UserAvatar";
 import { navigateToUser } from "~/utils/navigateToUser";
+
+/** At this many people (4+), compact inline mode uses a collapsed avatar stack. */
+const MIN_PEOPLE_FOR_STACK = 4;
+
+/**
+ * Avatars shown in the overlapping stack before the +N circle (3 faces + 1
+ * count chip matches common iOS group rows).
+ */
+const STACK_FACE_COUNT = 5;
+
+/** How far each subsequent avatar / +N chip overlaps the previous (px). */
+const AVATAR_STACK_OVERLAP = 8;
+
+const ROW_HIT_SLOP = { top: 8, bottom: 8, left: 4, right: 4 } as const;
 
 interface AttributionGridProps {
   creator: UserForDisplay;
@@ -53,6 +72,8 @@ export function AttributionGrid({
   creatorBadgeLabel = "captured",
   background = "tint",
 }: AttributionGridProps) {
+  const [peopleExpanded, setPeopleExpanded] = useState(false);
+
   // People: creator first, then savers, deduped.
   const people: UserForDisplay[] = [creator];
   for (const saver of savers) {
@@ -109,15 +130,77 @@ export function AttributionGrid({
     );
   }
 
+  const needsPeopleStack =
+    isCompact && people.length >= MIN_PEOPLE_FOR_STACK;
+  const stackOverflowCount = needsPeopleStack
+    ? people.length - STACK_FACE_COUNT
+    : 0;
+
   const avatarSize = isCompact ? 32 : 44;
   const rowPaddingY = isCompact ? "py-2" : "py-2.5";
   const containerPadding = isCompact ? "px-3 pb-2 pt-2" : "px-4 pb-3 pt-3";
   const labelMargin = isCompact ? "mb-1" : "mb-2";
   const chevronColor = "#8F7AD6";
 
+  const bgClass = background === "white" ? "bg-white" : "bg-interactive-3/60";
+  const containerClass = `rounded-2xl ${bgClass} ${containerPadding}`;
+
+  const addListRowNodes = (out: React.ReactNode[]) => {
+    visibleLists.forEach((list) => {
+      const iconSize = isCompact ? 32 : 44;
+      const listIcon = (
+        <View
+          className="items-center justify-center rounded-full bg-interactive-3"
+          style={{ width: iconSize, height: iconSize }}
+        >
+          <ListIcon size={isCompact ? 16 : 20} color="#5A32FB" />
+        </View>
+      );
+      const listLabel = (
+        <View className="ml-3 flex-1">
+          <Text
+            className={`${
+              isCompact ? "text-sm" : "text-base"
+            } font-semibold text-neutral-1`}
+            numberOfLines={1}
+          >
+            {list.name}
+          </Text>
+        </View>
+      );
+
+      if (list.slug) {
+        out.push(
+          <TouchableOpacity
+            key={`list-${list.id}`}
+            onPress={() => handleListPress(list)}
+            className={`flex-row items-center ${rowPaddingY}`}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`Open list ${list.name}`}
+          >
+            {listIcon}
+            {listLabel}
+            <ChevronRight size={16} color={chevronColor} />
+          </TouchableOpacity>,
+        );
+      } else {
+        out.push(
+          <View
+            key={`list-${list.id}`}
+            className={`flex-row items-center ${rowPaddingY}`}
+          >
+            {listIcon}
+            {listLabel}
+          </View>,
+        );
+      }
+    });
+  };
+
   const rows: React.ReactNode[] = [];
 
-  people.forEach((user) => {
+  const pushPersonRow = (user: UserForDisplay) => {
     const isCreator = user.id === creator.id;
     rows.push(
       <TouchableOpacity
@@ -151,63 +234,101 @@ export function AttributionGrid({
         <ChevronRight size={16} color={chevronColor} />
       </TouchableOpacity>,
     );
-  });
+  };
 
-  visibleLists.forEach((list) => {
-    const iconSize = isCompact ? 32 : 44;
-    const icon = (
-      <View
-        className="items-center justify-center rounded-full bg-interactive-3"
-        style={{ width: iconSize, height: iconSize }}
+  if (needsPeopleStack && !peopleExpanded) {
+    rows.push(
+      <Pressable
+        key="people-avatar-stack"
+        onPress={() => setPeopleExpanded(true)}
+        hitSlop={ROW_HIT_SLOP}
+        accessibilityRole="button"
+        accessibilityLabel={`${people.length} people. Show full list.`}
+        className="w-full flex-row items-center justify-between pr-0"
+        style={{ paddingTop: 6, paddingBottom: 6 }}
       >
-        <ListIcon size={isCompact ? 16 : 20} color="#5A32FB" />
-      </View>
+        <View className="min-w-0 flex-1 flex-row items-center">
+          {people.slice(0, STACK_FACE_COUNT).map((user, index) => (
+            <View
+              key={user.id}
+              className="rounded-full bg-white"
+              style={{
+                marginLeft: index === 0 ? 0 : -AVATAR_STACK_OVERLAP,
+                zIndex: index + 1,
+                elevation: index + 1,
+              }}
+            >
+              <UserAvatar user={user} size={avatarSize} />
+            </View>
+          ))}
+          {stackOverflowCount > 0 ? (
+            <View
+              className="items-center justify-center rounded-full border border-white bg-interactive-2"
+              style={{
+                width: avatarSize,
+                height: avatarSize,
+                marginLeft: -AVATAR_STACK_OVERLAP,
+                zIndex: STACK_FACE_COUNT + 1,
+                elevation: STACK_FACE_COUNT + 1,
+              }}
+            >
+              <Text
+                className="text-sm font-bold text-interactive-1"
+                maxFontSizeMultiplier={1.25}
+              >
+                +{stackOverflowCount}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+        <View className="pl-1">
+          <ChevronDown
+            size={isCompact ? 20 : 22}
+            color={chevronColor}
+          />
+        </View>
+      </Pressable>,
     );
-    const label = (
-      <View className="ml-3 flex-1">
-        <Text
-          className={`${
-            isCompact ? "text-sm" : "text-base"
-          } font-semibold text-neutral-1`}
-          numberOfLines={1}
-        >
-          {list.name}
-        </Text>
-      </View>
-    );
-
-    if (list.slug) {
+  } else {
+    if (needsPeopleStack && peopleExpanded) {
+      people.forEach((user) => {
+        pushPersonRow(user);
+      });
       rows.push(
-        <TouchableOpacity
-          key={`list-${list.id}`}
-          onPress={() => handleListPress(list)}
-          className={`flex-row items-center ${rowPaddingY}`}
-          activeOpacity={0.7}
+        <Pressable
+          key="show-less-people"
+          onPress={() => setPeopleExpanded(false)}
+          hitSlop={ROW_HIT_SLOP}
           accessibilityRole="button"
-          accessibilityLabel={`Open list ${list.name}`}
+          accessibilityLabel="Show fewer people"
+          className="w-full flex-row items-center justify-between"
+          style={{ paddingTop: 6, paddingBottom: 6 }}
         >
-          {icon}
-          {label}
-          <ChevronRight size={16} color={chevronColor} />
-        </TouchableOpacity>,
+          <Text
+            className={
+              isCompact
+                ? "text-sm font-semibold text-interactive-1"
+                : "text-base font-semibold text-interactive-1"
+            }
+          >
+            Show less
+          </Text>
+          <ChevronUp
+            size={isCompact ? 20 : 22}
+            color={chevronColor}
+          />
+        </Pressable>,
       );
     } else {
-      rows.push(
-        <View
-          key={`list-${list.id}`}
-          className={`flex-row items-center ${rowPaddingY}`}
-        >
-          {icon}
-          {label}
-        </View>,
-      );
+      people.forEach((user) => {
+        pushPersonRow(user);
+      });
     }
-  });
+  }
+
+  addListRowNodes(rows);
 
   if (rows.length === 0) return null;
-
-  const bgClass = background === "white" ? "bg-white" : "bg-interactive-3/60";
-  const containerClass = `rounded-2xl ${bgClass} ${containerPadding}`;
 
   return (
     <View className={containerClass}>

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -130,8 +130,7 @@ export function AttributionGrid({
     );
   }
 
-  const needsPeopleStack =
-    isCompact && people.length >= MIN_PEOPLE_FOR_STACK;
+  const needsPeopleStack = isCompact && people.length >= MIN_PEOPLE_FOR_STACK;
   const stackOverflowCount = needsPeopleStack
     ? people.length - STACK_FACE_COUNT
     : 0;
@@ -282,10 +281,7 @@ export function AttributionGrid({
           ) : null}
         </View>
         <View className="pl-1">
-          <ChevronDown
-            size={isCompact ? 20 : 22}
-            color={chevronColor}
-          />
+          <ChevronDown size={isCompact ? 20 : 22} color={chevronColor} />
         </View>
       </Pressable>,
     );
@@ -313,10 +309,7 @@ export function AttributionGrid({
           >
             Show less
           </Text>
-          <ChevronUp
-            size={isCompact ? 20 : 22}
-            color={chevronColor}
-          />
+          <ChevronUp size={isCompact ? 20 : 22} color={chevronColor} />
         </Pressable>,
       );
     } else {

--- a/apps/expo/src/components/AttributionGrid.tsx
+++ b/apps/expo/src/components/AttributionGrid.tsx
@@ -17,10 +17,7 @@ import { navigateToUser } from "~/utils/navigateToUser";
 /** At this many people (4+), compact inline mode uses a collapsed avatar stack. */
 const MIN_PEOPLE_FOR_STACK = 4;
 
-/**
- * Avatars shown in the overlapping stack before the +N circle (3 faces + 1
- * count chip matches common iOS group rows).
- */
+/** Avatars shown in the overlapping stack before the +N circle. */
 const STACK_FACE_COUNT = 5;
 
 /** How far each subsequent avatar / +N chip overlaps the previous (px). */
@@ -132,7 +129,7 @@ export function AttributionGrid({
 
   const needsPeopleStack = isCompact && people.length >= MIN_PEOPLE_FOR_STACK;
   const stackOverflowCount = needsPeopleStack
-    ? people.length - STACK_FACE_COUNT
+    ? Math.max(0, people.length - STACK_FACE_COUNT)
     : 0;
 
   const avatarSize = isCompact ? 32 : 44;

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -6,6 +6,7 @@ import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 
 import type { UserForDisplay } from "~/types/user";
 import { List } from "~/components/icons";
+import { OverflowPill } from "~/components/OverflowPill";
 import { SavedByModal } from "~/components/SavedByModal";
 import { UserAvatar } from "~/components/UserAvatar";
 import { navigateToUser } from "~/utils/navigateToUser";
@@ -69,32 +70,6 @@ function ListChip({ name, slug }: { name?: string; slug?: string }) {
     );
   }
   return <View className="flex-row items-center gap-1">{content}</View>;
-}
-
-function OverflowPill({
-  count,
-  onPress,
-  className,
-}: {
-  count: number;
-  onPress?: () => void;
-  className?: string;
-}) {
-  if (count <= 0) return null;
-  const pillClass = `rounded-full bg-interactive-3 px-1.5 py-0.5${
-    className ? ` ${className}` : ""
-  }`;
-  const text = (
-    <Text className="text-xs font-medium text-interactive-1">+{count}</Text>
-  );
-  if (!onPress) {
-    return <View className={pillClass}>{text}</View>;
-  }
-  return (
-    <Pressable className={pillClass} onPress={onPress} hitSlop={HIT_SLOP}>
-      {text}
-    </Pressable>
-  );
 }
 
 export function EventAttributionRow({

--- a/apps/expo/src/components/OverflowPill.tsx
+++ b/apps/expo/src/components/OverflowPill.tsx
@@ -1,0 +1,33 @@
+import { Pressable, Text, View } from "react-native";
+
+const HIT_SLOP = { top: 8, bottom: 8, left: 4, right: 4 } as const;
+
+export function OverflowPill({
+  count,
+  onPress,
+  className,
+}: {
+  count: number;
+  onPress?: () => void;
+  className?: string;
+}) {
+  if (count <= 0) return null;
+  const pillClass = `rounded-full bg-interactive-3 px-1.5 py-0.5${
+    className ? ` ${className}` : ""
+  }`;
+  const text = (
+    <Text className="text-xs font-medium text-interactive-1">+{count}</Text>
+  );
+  if (!onPress) {
+    return <View className={pillClass}>{text}</View>;
+  }
+  return (
+    <Pressable
+      className={pillClass}
+      onPress={onPress}
+      hitSlop={HIT_SLOP}
+    >
+      {text}
+    </Pressable>
+  );
+}

--- a/apps/expo/src/components/OverflowPill.tsx
+++ b/apps/expo/src/components/OverflowPill.tsx
@@ -22,11 +22,7 @@ export function OverflowPill({
     return <View className={pillClass}>{text}</View>;
   }
   return (
-    <Pressable
-      className={pillClass}
-      onPress={onPress}
-      hitSlop={HIT_SLOP}
-    >
+    <Pressable className={pillClass} onPress={onPress} hitSlop={HIT_SLOP}>
       {text}
     </Pressable>
   );


### PR DESCRIPTION
Compact `AttributionGrid` (4+ people) uses an overlapping avatar row, +N chip, and disclosure chevrons; expands to full rows with Show less. List contributors and event detail share the same behavior. Extracts `OverflowPill` for `EventAttributionRow`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse compact `AttributionGrid` to an overlapping avatar stack for 4+ people, with a +N chip and chevrons. Tap to expand to full rows; Show less collapses back.

- **New Features**
  - Compact mode shows an overlapping avatar stack (up to 5 faces) with a +N chip.
  - Tap the stack to expand into full person rows; Show less collapses.
  - Adds chevrons, larger hit areas, and accessibility labels for better navigation.

- **Refactors**
  - Extracted `OverflowPill` into `apps/expo/src/components/OverflowPill.tsx` and reused in `EventAttributionRow`.
  - Clamped `stackOverflowCount` to 0 to avoid negative values and removed a stale comment.
  - Applied Prettier formatting.

<sup>Written for commit 2f74810463c94e1c68f5cc57aeda607892d02e21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a collapsed overlapping-avatar-stack mode to `AttributionGrid` for 4+ people in compact variant — tapping expands to full rows and "Show less" collapses back. Also extracts the inline `OverflowPill` from `EventAttributionRow` into a shared component reused in both files.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 style findings remain.

All remaining findings are P2 (stale comment, cosmetic negative value). No logic bugs, no data-loss risk, and the expand/collapse state machine is correct across all people-count edge cases.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/AttributionGrid.tsx | Adds collapsible avatar-stack mode for 4+ people in compact variant; two minor style issues (stale comment on STACK_FACE_COUNT, negative stackOverflowCount for edge sizes). |
| apps/expo/src/components/EventAttributionRow.tsx | Removes local OverflowPill definition and imports the new shared component; no logic changes. |
| apps/expo/src/components/OverflowPill.tsx | New shared component extracted verbatim from EventAttributionRow; logic and styling are identical to the removed inline version. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["AttributionGrid (compact variant)"] --> B{people.length >= 4?}
    B -- No --> C["Render all person rows (pushPersonRow)"]
    B -- Yes --> D{peopleExpanded?}
    D -- No --> E["Collapsed: avatar stack (≤5 faces) + +N chip + ChevronDown"]
    D -- Yes --> F["Expanded: all person rows + 'Show less' + ChevronUp"]
    E -->|"tap"| F
    F -->|"tap 'Show less'"| E
    C --> G["addListRowNodes — list rows appended"]
    F --> G
    E --> G
    G --> H["Render container View"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/AttributionGrid.tsx
Line: 21-25

Comment:
**Stale JSDoc comment contradicts constant value**

The comment says "3 faces + 1 count chip" but `STACK_FACE_COUNT` is `5`. If this was a draft at 3 or 4 that got bumped to 5, the comment was not updated and will mislead future readers.

```suggestion
/**
 * Avatars shown in the overlapping stack before the +N circle.
 */
const STACK_FACE_COUNT = 5;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/AttributionGrid.tsx
Line: 134-136

Comment:
**`stackOverflowCount` can be negative**

When `people.length` is 4 or 5 (both ≥ `MIN_PEOPLE_FOR_STACK`), the expression `people.length - STACK_FACE_COUNT` yields `-1` or `0`. The `> 0` guard at line 263 prevents rendering incorrectly, but a negative count is semantically odd and could confuse future readers or callers. Clamping to zero at the definition site is cleaner.

```suggestion
  const stackOverflowCount = needsPeopleStack
    ? Math.max(0, people.length - STACK_FACE_COUNT)
    : 0;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["style(expo): apply prettier formatting"](https://github.com/jaronheard/soonlist-turbo/commit/8fdc374c6518b1d6883a4286d7c744d073c02082) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29339540)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->