### PR TITLE
feat(expo): drop react-native-modal from date/time pickers

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -102,7 +102,6 @@
     "react-native-ios-context-menu": "catalog:",
     "react-native-ios-utilities": "catalog:",
     "react-native-keyboard-controller": "catalog:",
-    "react-native-modal": "catalog:",
     "react-native-notifier": "catalog:",
     "react-native-onesignal": "catalog:",
     "react-native-purchases": "catalog:",

--- a/apps/expo/src/components/date-picker/DatePickerField.tsx
+++ b/apps/expo/src/components/date-picker/DatePickerField.tsx
@@ -6,8 +6,14 @@ import type {
   Path,
 } from "react-hook-form";
 import React, { useState } from "react";
-import { Platform, Text, TouchableOpacity, View } from "react-native";
-import Modal from "react-native-modal";
+import {
+  Modal,
+  Platform,
+  Text,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Controller } from "react-hook-form";
 
@@ -52,15 +58,13 @@ export function DatePickerField<T extends FieldValues>({
     setIsPickerVisible(false);
   };
 
-  // Use the specific FieldOnChange type
-  const handleModalHide = (onChange: FieldOnChange) => {
+  const commitAndHide = (onChange: FieldOnChange) => {
     if (Platform.OS === "ios") {
-      const formatted = formatDateForStorage(tempDate);
-      onChange(formatted);
+      onChange(formatDateForStorage(tempDate));
     }
+    hidePicker();
   };
 
-  // Use the specific FieldOnChange type
   const onDateChange = (
     onChange: FieldOnChange,
     _: unknown,
@@ -70,8 +74,7 @@ export function DatePickerField<T extends FieldValues>({
     setTempDate(currentDate);
 
     if (Platform.OS === "android") {
-      const formatted = formatDateForStorage(currentDate);
-      onChange(formatted);
+      onChange(formatDateForStorage(currentDate));
       hidePicker();
     }
   };
@@ -95,31 +98,42 @@ export function DatePickerField<T extends FieldValues>({
             </TouchableOpacity>
 
             <Modal
-              isVisible={isPickerVisible}
-              onBackdropPress={hidePicker}
-              onModalHide={() => handleModalHide(onChange as FieldOnChange)}
-              style={{ justifyContent: "flex-end", margin: 0 }}
-              animationIn="slideInUp"
-              animationOut="slideOutDown"
-              backdropTransitionOutTiming={0}
+              visible={isPickerVisible}
+              transparent
+              animationType="slide"
+              onRequestClose={() => commitAndHide(onChange as FieldOnChange)}
             >
-              <View className="rounded-t-lg bg-white p-4">
-                <DateTimePicker
-                  testID="datePickerModal"
-                  value={tempDate}
-                  mode="date"
-                  display={Platform.OS === "ios" ? "inline" : "default"}
-                  themeVariant="light"
-                  onChange={(event, date) =>
-                    onDateChange(onChange as FieldOnChange, event, date)
-                  }
-                  style={
-                    Platform.OS === "ios"
-                      ? { height: 300, alignSelf: "center" }
-                      : {}
-                  }
-                />
-              </View>
+              <TouchableWithoutFeedback
+                onPress={() => commitAndHide(onChange as FieldOnChange)}
+              >
+                <View
+                  style={{
+                    flex: 1,
+                    justifyContent: "flex-end",
+                    backgroundColor: "rgba(0,0,0,0.5)",
+                  }}
+                >
+                  <TouchableWithoutFeedback>
+                    <View className="rounded-t-lg bg-white p-4">
+                      <DateTimePicker
+                        testID="datePickerModal"
+                        value={tempDate}
+                        mode="date"
+                        display={Platform.OS === "ios" ? "inline" : "default"}
+                        themeVariant="light"
+                        onChange={(event, date) =>
+                          onDateChange(onChange as FieldOnChange, event, date)
+                        }
+                        style={
+                          Platform.OS === "ios"
+                            ? { height: 300, alignSelf: "center" }
+                            : {}
+                        }
+                      />
+                    </View>
+                  </TouchableWithoutFeedback>
+                </View>
+              </TouchableWithoutFeedback>
             </Modal>
           </>
         )}

--- a/apps/expo/src/components/date-picker/TimePickerField.tsx
+++ b/apps/expo/src/components/date-picker/TimePickerField.tsx
@@ -6,8 +6,14 @@ import type {
   Path,
 } from "react-hook-form";
 import React, { useState } from "react";
-import { Platform, Text, TouchableOpacity, View } from "react-native";
-import Modal from "react-native-modal";
+import {
+  Modal,
+  Platform,
+  Text,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { Controller } from "react-hook-form";
 
@@ -55,11 +61,11 @@ export function TimePickerField<T extends FieldValues>({
     setIsPickerVisible(false);
   };
 
-  const handleModalHide = (onChange: FieldOnChange) => {
+  const commitAndHide = (onChange: FieldOnChange) => {
     if (Platform.OS === "ios") {
-      const formatted = formatTimeForStorage(tempTime);
-      onChange(formatted);
+      onChange(formatTimeForStorage(tempTime));
     }
+    hidePicker();
   };
 
   const onTimeChange = (
@@ -74,8 +80,7 @@ export function TimePickerField<T extends FieldValues>({
     setTempTime(currentTime);
 
     if (Platform.OS === "android") {
-      const formatted = formatTimeForStorage(currentTime);
-      onChange(formatted);
+      onChange(formatTimeForStorage(currentTime));
       hidePicker();
     }
   };
@@ -99,32 +104,43 @@ export function TimePickerField<T extends FieldValues>({
             </TouchableOpacity>
 
             <Modal
-              isVisible={isPickerVisible}
-              onBackdropPress={hidePicker}
-              onModalHide={() => handleModalHide(onChange as FieldOnChange)}
-              style={{ justifyContent: "flex-end", margin: 0 }}
-              animationIn="slideInUp"
-              animationOut="slideOutDown"
-              backdropTransitionOutTiming={0}
+              visible={isPickerVisible}
+              transparent
+              animationType="slide"
+              onRequestClose={() => commitAndHide(onChange as FieldOnChange)}
             >
-              <View className="rounded-t-lg bg-white p-4">
-                <DateTimePicker
-                  testID="timePickerModal"
-                  value={tempTime}
-                  mode="time"
-                  minuteInterval={minuteInterval}
-                  display={Platform.OS === "ios" ? "spinner" : "default"}
-                  themeVariant="light"
-                  onChange={(event, time) =>
-                    onTimeChange(onChange as FieldOnChange, event, time)
-                  }
-                  style={
-                    Platform.OS === "ios"
-                      ? { height: 200, alignSelf: "center" }
-                      : {}
-                  }
-                />
-              </View>
+              <TouchableWithoutFeedback
+                onPress={() => commitAndHide(onChange as FieldOnChange)}
+              >
+                <View
+                  style={{
+                    flex: 1,
+                    justifyContent: "flex-end",
+                    backgroundColor: "rgba(0,0,0,0.5)",
+                  }}
+                >
+                  <TouchableWithoutFeedback>
+                    <View className="rounded-t-lg bg-white p-4">
+                      <DateTimePicker
+                        testID="timePickerModal"
+                        value={tempTime}
+                        mode="time"
+                        minuteInterval={minuteInterval}
+                        display={Platform.OS === "ios" ? "spinner" : "default"}
+                        themeVariant="light"
+                        onChange={(event, time) =>
+                          onTimeChange(onChange as FieldOnChange, event, time)
+                        }
+                        style={
+                          Platform.OS === "ios"
+                            ? { height: 200, alignSelf: "center" }
+                            : {}
+                        }
+                      />
+                    </View>
+                  </TouchableWithoutFeedback>
+                </View>
+              </TouchableWithoutFeedback>
             </Modal>
           </>
         )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,9 +399,6 @@ catalogs:
     react-native-keyboard-controller:
       specifier: 1.20.7
       version: 1.20.7
-    react-native-modal:
-      specifier: 14.0.0-rc.1
-      version: 14.0.0-rc.1
     react-native-notifier:
       specifier: ^2.0.0
       version: 2.0.0
@@ -780,9 +777,6 @@ importers:
       react-native-keyboard-controller:
         specifier: 'catalog:'
         version: 1.20.7(react-native-reanimated@4.2.2(react-native-worklets@0.7.1(@babel/core@7.28.5)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-modal:
-        specifier: 'catalog:'
-        version: 14.0.0-rc.1(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-notifier:
         specifier: 'catalog:'
         version: 2.0.0(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -9250,9 +9244,6 @@ packages:
   react-is@19.2.3:
     resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
 
-  react-native-animatable@1.4.0:
-    resolution: {integrity: sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw==}
-
   react-native-appsflyer@6.17.8:
     resolution: {integrity: sha512-mm/PfkxnHYwF/QGbs/NkGWyp9snESPVyztRsjjoo9yHuZUp/dxJNX9gCl3uvImZ2rP8suRAhDIjMUxhE7RRHkA==}
 
@@ -9303,12 +9294,6 @@ packages:
       react: 19.2.0
       react-native: '*'
       react-native-reanimated: '>=3.0.0'
-
-  react-native-modal@14.0.0-rc.1:
-    resolution: {integrity: sha512-v5pvGyx1FlmBzdHyPqBsYQyS2mIJhVmuXyNo5EarIzxicKhuoul6XasXMviGcXboEUT0dTYWs88/VendojPiVw==}
-    peerDependencies:
-      react: 19.2.0
-      react-native: '>=0.70.0'
 
   react-native-notifier@2.0.0:
     resolution: {integrity: sha512-CKaoldBM2Lz9FIWn1frUZ70R8n1jCwaUsO4hGfqbNYFUZLV4OYy/UeEicWvrLy3Ce8fEg7WyYWVd0q+crsFQlA==}
@@ -20277,10 +20262,6 @@ snapshots:
 
   react-is@19.2.3: {}
 
-  react-native-animatable@1.4.0:
-    dependencies:
-      prop-types: 15.8.1
-
   react-native-appsflyer@6.17.8: {}
 
   react-native-css-interop@0.2.1(react-native-reanimated@4.2.2(react-native-worklets@0.7.1(@babel/core@7.28.5)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-svg@15.15.3(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(tailwindcss@3.4.19(yaml@2.8.2)):
@@ -20332,12 +20313,6 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-reanimated: 4.2.2(react-native-worklets@0.7.1(@babel/core@7.28.5)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-
-  react-native-modal@14.0.0-rc.1(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
-    dependencies:
-      react: 19.2.0
-      react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
-      react-native-animatable: 1.4.0
 
   react-native-notifier@2.0.0(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -123,7 +123,6 @@ catalog:
   "react-native-ios-context-menu": 3.2.0
   "react-native-ios-utilities": 5.2.0
   "react-native-keyboard-controller": 1.20.7
-  "react-native-modal": 14.0.0-rc.1
   "react-native-onesignal": ^5.2.8
   "react-native-purchases-ui": ^8.9.1
   "react-native-qrcode-svg": ^6.3.0


### PR DESCRIPTION
## Summary

- Replace `react-native-modal` with React Native's built-in `Modal` in `DatePickerField` and `TimePickerField`.
- Drop the `react-native-modal` dependency from `apps/expo/package.json`, the pnpm catalog, and the lockfile.

UX is preserved on both platforms:

- **iOS**: slide-up bottom sheet with the inline calendar (date) or spinner (time). Tap the backdrop to commit the staged value and dismiss.
- **Android**: native system dialog as before (rendering `DateTimePicker` triggers it). Android back button also commits/dismisses.

No call sites change — `edit.tsx` continues to use `<DatePickerField />` / `<TimePickerField />` unchanged.

## Why

Part of the larger "migrate RN Modal → Expo Router sheet" effort (PR 2 of Option A). This one is scoped to dropping `react-native-modal` since it's a different library with its own testing surface — kept separate from PR 1's `(modals)` route-group foundation so each can ship independently.

## Implementation notes

- Replaced `react-native-modal`'s `isVisible` / `onBackdropPress` / `onModalHide` with RN's `visible` / `onRequestClose` plus a `TouchableWithoutFeedback` backdrop.
- Inner `TouchableWithoutFeedback` wraps the sheet content so taps on the picker don't dismiss.
- The iOS commit-on-hide flow moves from `onModalHide` to a `commitAndHide` helper fired from backdrop tap and `onRequestClose`. Android still commits on `onChange` and hides immediately (unchanged).

## Test plan

- [ ] iOS: open event edit, tap Start date → inline calendar appears in a bottom sheet; pick a date; tap backdrop → sheet dismisses and the field shows the new date.
- [ ] iOS: open Start time → spinner appears; scroll to a new time; tap backdrop → field updates.
- [ ] iOS: open End date + End time and verify same flow.
- [ ] Android: tap Start date → native Android date dialog; pick → dialog closes and field updates.
- [ ] Android: tap Start time → native time dialog; pick → field updates.
- [ ] Android: tap Start date, press system back → dialog dismisses with no crash.
- [ ] `pnpm --filter @soonlist/expo typecheck` passes.
- [ ] Verify `react-native-modal` is no longer in `pnpm-lock.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `react-native-modal` with React Native `Modal` in date/time pickers and removed the dependency, preserving the iOS sheet and Android dialog UX.

- **Refactors**
  - Swapped to RN `Modal` in `DatePickerField` and `TimePickerField` with a tappable backdrop using `TouchableWithoutFeedback`.
  - iOS: slide-up sheet kept; staged value commits on backdrop tap or `onRequestClose`.
  - Android: native dialog unchanged; commits on change; back button handled.
  - No call sites changed.

- **Dependencies**
  - Removed `react-native-modal` from `apps/expo/package.json`, the workspace catalog, and `pnpm-lock.yaml`.

<sup>Written for commit 7d1222cfefc3f8262b62d356e1bc3b8653e94bbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the third-party `react-native-modal` dependency with React Native's built-in `Modal` in `DatePickerField` and `TimePickerField`, and removes `react-native-modal` (plus its transitive dep `react-native-animatable`) from the pnpm catalog and lockfile. The `commitAndHide` helper cleanly unifies the iOS commit-on-dismiss path, and the Android flow is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only finding is a minor defensive coding suggestion on the inner TouchableWithoutFeedback

All findings are P2. The logic for both platforms is correct — iOS commits via commitAndHide on backdrop/onRequestClose, Android commits immediately in onChange. The dependency removal is clean and complete.

DatePickerField.tsx and TimePickerField.tsx — both have the inner TouchableWithoutFeedback without an explicit onPress noop, which is worth hardening

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/date-picker/DatePickerField.tsx | Replaces react-native-modal with RN's built-in Modal; uses nested TouchableWithoutFeedback for backdrop/content touch handling — inner wrapper lacks an explicit onPress noop which may be unreliable |
| apps/expo/src/components/date-picker/TimePickerField.tsx | Mirrors DatePickerField changes; same nested-TouchableWithoutFeedback pattern with missing onPress noop on the inner wrapper |
| apps/expo/package.json | Removes react-native-modal catalog dependency cleanly |
| pnpm-workspace.yaml | Removes react-native-modal and react-native-animatable entries from the pnpm catalog |
| pnpm-lock.yaml | Lockfile updated to remove react-native-modal and its react-native-animatable transitive dep |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant F as DatePickerField
    participant M as RN Modal
    participant DP as DateTimePicker

    U->>F: Tap field
    F->>M: visible=true
    M->>DP: render picker

    alt iOS — backdrop tap
        U->>M: Tap backdrop (outer TWF)
        M->>F: commitAndHide(onChange)
        F->>F: onChange(formatDateForStorage(tempDate))
        F->>M: visible=false
    end

    alt iOS — onRequestClose
        U->>M: onRequestClose fires
        M->>F: commitAndHide(onChange)
        F->>F: onChange(formatDateForStorage(tempDate))
        F->>M: visible=false
    end

    alt Android — native picker
        DP-->>F: onDateChange fires
        F->>F: onChange(formatDateForStorage(date))
        F->>M: hidePicker() visible=false
    end

    alt Android — hardware back
        U->>M: onRequestClose fires
        M->>F: commitAndHide (iOS guard skips onChange)
        F->>M: hidePicker() visible=false
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/date-picker/DatePickerField.tsx
Line: 116

Comment:
**Inner `TouchableWithoutFeedback` missing explicit `onPress` noop**

The inner `TouchableWithoutFeedback` (line 116) has no `onPress` prop. While this pattern is commonly used to "eat" touches and prevent the outer backdrop handler from firing, React Native's gesture responder system doesn't guarantee that a `TouchableWithoutFeedback` without any press handler will claim the touch in all environments/versions. Adding an explicit no-op ensures the touch is consistently absorbed and the picker interaction doesn't inadvertently commit and dismiss.

```suggestion
                  <TouchableWithoutFeedback onPress={() => undefined}>
```

The same pattern appears in `TimePickerField.tsx` at the equivalent line.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(expo): drop react-native-modal dep..."](https://github.com/jaronheard/soonlist-turbo/commit/7d1222cfefc3f8262b62d356e1bc3b8653e94bbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29340008)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->