### PR TITLE
fix(expo): accurate My Scene badge + subscribe feedback + richer manage sheet

### DIFF
--- a/apps/expo/src/app/(tabs)/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/_layout.tsx
@@ -1,4 +1,7 @@
 import { NativeTabs } from "expo-router/unstable-native-tabs";
+import { useQuery } from "convex/react";
+
+import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useAppStore } from "~/store";
@@ -12,7 +15,10 @@ export const unstable_settings = {
 
 export default function TabsLayout() {
   const myListBadgeCount = useAppStore((s) => s.myListBadgeCount);
-  const communityBadgeCount = useAppStore((s) => s.communityBadgeCount);
+  const communityBadgeCountQuery = useQuery(
+    api.feeds.getFollowedListsUpcomingCount,
+  );
+  const communityBadgeCount = communityBadgeCountQuery ?? 0;
 
   return (
     <NativeTabs

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -158,14 +158,6 @@ function FollowingFeedContent() {
       }));
   }, [events, stableTimestamp, selectedSegment]);
 
-  // Update tab badge count based on upcoming events
-  const setCommunityBadgeCount = useAppStore((s) => s.setCommunityBadgeCount);
-  useEffect(() => {
-    if (selectedSegment === "upcoming") {
-      setCommunityBadgeCount(enrichedEvents.length);
-    }
-  }, [enrichedEvents.length, selectedSegment, setCommunityBadgeCount]);
-
   const followedListCount = followedLists?.length ?? 0;
   const singleFollowedList =
     followedListCount === 1 ? followedLists?.[0] : null;

--- a/apps/expo/src/components/DefaultEmptyState.tsx
+++ b/apps/expo/src/components/DefaultEmptyState.tsx
@@ -107,25 +107,36 @@ export function DefaultEmptyState({
             </View>
           ) : null}
 
-          {hasFollowings ? (
-            <View className="mt-4 items-center">
-              <Text className="mb-1 text-sm text-neutral-2">
-                {followedEventCount === 1
-                  ? "1 event added to My Scene"
-                  : `${followedEventCount}${
-                      hasMoreFollowedEvents ? "+" : ""
-                    } events added to My Scene`}
-              </Text>
+          {hasFollowings && followedEventCount > 0 ? (
+            <View className="mt-4">
+              <TouchableOpacity
+                onPress={onExitToFeed}
+                activeOpacity={0.85}
+                accessibilityRole="button"
+                accessibilityLabel="View My Scene"
+                className="w-full rounded-full bg-interactive-1 py-3 shadow"
+              >
+                <Text className="text-center text-base font-semibold text-white">
+                  {followedEventCount === 1
+                    ? "View My Scene (1 event)"
+                    : `View My Scene (${followedEventCount}${
+                        hasMoreFollowedEvents ? "+" : ""
+                      } events)`}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {!hasFollowings ? (
+            <View className="mt-6 items-center py-4">
               <TouchableOpacity
                 onPress={onExitToFeed}
                 activeOpacity={0.7}
                 accessibilityRole="button"
-                accessibilityLabel="View My Scene"
-                className="px-2 py-2"
+                accessibilityLabel="Skip for now"
+                className="px-4 py-2"
               >
-                <Text className="text-base font-semibold text-interactive-1">
-                  View My Scene →
-                </Text>
+                <Text className="text-sm text-neutral-2">Skip for now</Text>
               </TouchableOpacity>
             </View>
           ) : null}

--- a/apps/expo/src/components/FeaturedListRow.tsx
+++ b/apps/expo/src/components/FeaturedListRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
@@ -100,11 +100,11 @@ export function FeaturedListRow({
     return followedLists.some((l) => l.id === personalList.id);
   }, [personalList, followedLists]);
 
-  const isMutatingRef = useRef(false);
+  const [isMutating, setIsMutating] = useState(false);
 
   const handleToggleSubscribe = useCallback(() => {
-    if (!personalList || isSelf || isMutatingRef.current) return;
-    isMutatingRef.current = true;
+    if (!personalList || isSelf || isMutating) return;
+    setIsMutating(true);
     const promise = isSubscribed
       ? unfollowListMutation({ listId: personalList.id })
       : followListMutation({ listId: personalList.id });
@@ -118,11 +118,12 @@ export function FeaturedListRow({
         );
       })
       .finally(() => {
-        isMutatingRef.current = false;
+        setIsMutating(false);
       });
   }, [
     personalList,
     isSelf,
+    isMutating,
     isSubscribed,
     unfollowListMutation,
     followListMutation,
@@ -179,6 +180,7 @@ export function FeaturedListRow({
           isSubscribed={isSubscribed}
           onPress={handleToggleSubscribe}
           size="sm"
+          loading={isMutating}
           accessibilityLabel={
             isSubscribed
               ? `Unsubscribe from ${displayName}`

--- a/apps/expo/src/components/FollowedListsModal.tsx
+++ b/apps/expo/src/components/FollowedListsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -16,9 +16,9 @@ import { useMutation, useQuery } from "convex/react";
 import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { List, ShareIcon } from "~/components/icons";
+import { ShareIcon } from "~/components/icons";
 import { SheetHeader } from "~/components/SheetHeader";
-import { SubscribeButton } from "~/components/SubscribeButton";
+import { SubscribedListRow } from "~/components/SubscribedListRow";
 import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
@@ -33,25 +33,54 @@ export function FollowedListsModal({
   onClose,
 }: FollowedListsModalProps) {
   const insets = useSafeAreaInsets();
-  const followedLists = useQuery(api.lists.getFollowedLists);
+  const followedLists = useQuery(api.lists.getFollowedListsWithPreview);
+  const [unsubscribingIds, setUnsubscribingIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
   const unfollowListMutation = useMutation(
     api.lists.unfollowList,
   ).withOptimisticUpdate((localStore, args) => {
     const current = localStore.getQuery(api.lists.getFollowedLists, {});
-    if (current === undefined) return;
-    localStore.setQuery(
-      api.lists.getFollowedLists,
+    if (current !== undefined) {
+      localStore.setQuery(
+        api.lists.getFollowedLists,
+        {},
+        current.filter((l) => l.id !== args.listId),
+      );
+    }
+    const currentWithPreview = localStore.getQuery(
+      api.lists.getFollowedListsWithPreview,
       {},
-      current.filter((l) => l.id !== args.listId),
     );
+    if (currentWithPreview !== undefined) {
+      localStore.setQuery(
+        api.lists.getFollowedListsWithPreview,
+        {},
+        currentWithPreview.filter((row) => row.list.id !== args.listId),
+      );
+    }
   });
 
   const handleUnfollow = useCallback(
     (listId: string) => {
-      unfollowListMutation({ listId }).catch((error: unknown) => {
-        logError("Error unfollowing list", error);
-        toast.error("Failed to unsubscribe");
+      setUnsubscribingIds((prev) => {
+        const next = new Set(prev);
+        next.add(listId);
+        return next;
       });
+      unfollowListMutation({ listId })
+        .catch((error: unknown) => {
+          logError("Error unfollowing list", error);
+          toast.error("Failed to unsubscribe");
+        })
+        .finally(() => {
+          setUnsubscribingIds((prev) => {
+            const next = new Set(prev);
+            next.delete(listId);
+            return next;
+          });
+        });
     },
     [unfollowListMutation],
   );
@@ -116,63 +145,41 @@ export function FollowedListsModal({
         ) : (
           <FlatList
             data={followedLists}
-            keyExtractor={(list) => list.id}
+            keyExtractor={(row) => row.list.id}
             contentContainerStyle={{
               paddingHorizontal: 16,
               paddingBottom: insets.bottom + 16,
             }}
-            renderItem={({ item: list, index }) => {
-              const isFirst = index === 0;
-              const isLast = index === followedLists.length - 1;
-              return (
-                <View
-                  className={`flex-row items-center bg-interactive-3/60 px-4 py-2.5 ${
-                    isFirst ? "rounded-t-2xl pt-3" : ""
-                  } ${isLast ? "rounded-b-2xl pb-3" : ""}`}
-                >
-                  <TouchableOpacity
-                    className="min-w-0 flex-1 flex-row items-center"
-                    onPress={() => handleListPress(list)}
-                    activeOpacity={0.7}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Open list ${list.name}`}
-                  >
-                    <View className="h-11 w-11 shrink-0 items-center justify-center rounded-full bg-interactive-3">
-                      <List size={20} color="#5A32FB" />
-                    </View>
-                    <View className="ml-3 min-w-0 flex-1">
-                      <Text
-                        className="text-base font-semibold text-neutral-1"
-                        numberOfLines={1}
-                      >
-                        {list.name}
-                      </Text>
-                    </View>
-                  </TouchableOpacity>
-
-                  <TouchableOpacity
-                    onPress={() =>
-                      void handleShareList(list.name, list.slug ?? undefined)
-                    }
-                    className="ml-2 rounded-full p-2"
-                    activeOpacity={0.7}
-                    accessibilityLabel={`Share ${list.name}`}
-                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  >
-                    <ShareIcon size={18} color="#5A32FB" />
-                  </TouchableOpacity>
-
-                  <View className="ml-1">
-                    <SubscribeButton
-                      isSubscribed={true}
-                      onPress={() => handleUnfollow(list.id)}
-                      size="sm"
-                      accessibilityLabel={`Unsubscribe from ${list.name}`}
-                    />
-                  </View>
+            renderItem={({ item }) => (
+              <View className="flex-row items-center gap-1">
+                <View className="min-w-0 flex-1">
+                  <SubscribedListRow
+                    list={item.list}
+                    owner={item.owner}
+                    previewImageUrls={item.previewImageUrls}
+                    upcomingCount={item.upcomingCount}
+                    hasMoreUpcoming={item.hasMoreUpcoming}
+                    onPress={() => handleListPress(item.list)}
+                    onUnsubscribe={() => handleUnfollow(item.list.id)}
+                    isUnsubscribing={unsubscribingIds.has(item.list.id)}
+                  />
                 </View>
-              );
-            }}
+                <TouchableOpacity
+                  onPress={() =>
+                    void handleShareList(
+                      item.list.name,
+                      item.list.slug ?? undefined,
+                    )
+                  }
+                  className="rounded-full p-2"
+                  activeOpacity={0.7}
+                  accessibilityLabel={`Share ${item.list.name}`}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  <ShareIcon size={18} color="#5A32FB" />
+                </TouchableOpacity>
+              </View>
+            )}
           />
         )}
       </View>

--- a/apps/expo/src/components/SubscribeButton.tsx
+++ b/apps/expo/src/components/SubscribeButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, TouchableOpacity } from "react-native";
+import { ActivityIndicator, Text, TouchableOpacity } from "react-native";
 
 import { Check, PlusIcon } from "~/components/icons";
 import { hapticLight } from "~/utils/feedback";
@@ -11,6 +11,8 @@ interface SubscribeButtonProps {
   size?: "sm" | "md";
   /** Override the default a11y label. */
   accessibilityLabel?: string;
+  /** When true, shows a spinner in place of the icon + label and blocks taps. */
+  loading?: boolean;
 }
 
 export function SubscribeButton({
@@ -18,6 +20,7 @@ export function SubscribeButton({
   onPress,
   size = "md",
   accessibilityLabel,
+  loading = false,
 }: SubscribeButtonProps) {
   const containerSize = size === "sm" ? "px-3 py-1" : "px-4 py-1.5";
   const textSize = size === "sm" ? "text-xs" : "text-sm";
@@ -27,7 +30,9 @@ export function SubscribeButton({
 
   return (
     <TouchableOpacity
+      disabled={loading}
       onPress={() => {
+        if (loading) return;
         void hapticLight();
         onPress();
       }}
@@ -41,14 +46,23 @@ export function SubscribeButton({
         isSubscribed ? "bg-interactive-2" : "bg-interactive-1"
       }`}
     >
-      <Icon size={iconSize} color={iconColor} strokeWidth={2.5} />
-      <Text
-        className={`${textSize} font-semibold ${
-          isSubscribed ? "text-interactive-1" : "text-white"
-        }`}
-      >
-        {isSubscribed ? "Subscribed" : "Subscribe"}
-      </Text>
+      {loading ? (
+        <ActivityIndicator
+          size="small"
+          color={isSubscribed ? "#5A32FB" : "#FFFFFF"}
+        />
+      ) : (
+        <>
+          <Icon size={iconSize} color={iconColor} strokeWidth={2.5} />
+          <Text
+            className={`${textSize} font-semibold ${
+              isSubscribed ? "text-interactive-1" : "text-white"
+            }`}
+          >
+            {isSubscribed ? "Subscribed" : "Subscribe"}
+          </Text>
+        </>
+      )}
     </TouchableOpacity>
   );
 }

--- a/apps/expo/src/components/SubscribedListRow.tsx
+++ b/apps/expo/src/components/SubscribedListRow.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+import { Image } from "expo-image";
+
+import type { Doc } from "@soonlist/backend/convex/_generated/dataModel";
+
+import { User } from "~/components/icons";
+import ScenePreviewThreeUp from "~/components/ScenePreviewThreeUp";
+import { SubscribeButton } from "~/components/SubscribeButton";
+
+interface SubscribedListRowProps {
+  list: Doc<"lists">;
+  owner: {
+    id: string;
+    username: string;
+    displayName: string;
+    userImage: string | null;
+  } | null;
+  previewImageUrls: (string | null)[];
+  upcomingCount: number;
+  hasMoreUpcoming: boolean;
+  onPress: () => void;
+  onUnsubscribe: () => void;
+  isUnsubscribing: boolean;
+}
+
+export function SubscribedListRow({
+  list,
+  owner,
+  previewImageUrls,
+  upcomingCount,
+  hasMoreUpcoming,
+  onPress,
+  onUnsubscribe,
+  isUnsubscribing,
+}: SubscribedListRowProps) {
+  const displayName = owner?.displayName ?? list.name;
+  const upcomingLabel =
+    upcomingCount === 1
+      ? "1 upcoming event"
+      : `${upcomingCount}${hasMoreUpcoming ? "+" : ""} upcoming events`;
+
+  return (
+    <View className="flex-row items-center gap-3 py-2">
+      <TouchableOpacity
+        onPress={onPress}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={`Open ${displayName}`}
+        className="min-w-0 flex-1 flex-row items-center gap-3"
+      >
+        <ScenePreviewThreeUp imageUris={previewImageUrls} align="start" />
+        <View className="min-w-0 flex-1">
+          <View className="flex-row items-center gap-1.5">
+            {owner?.userImage ? (
+              <Image
+                source={{ uri: owner.userImage }}
+                style={{ width: 20, height: 20, borderRadius: 10 }}
+                contentFit="cover"
+                cachePolicy="disk"
+              />
+            ) : (
+              <View className="h-5 w-5 items-center justify-center rounded-full bg-neutral-4">
+                <User size={12} color="#627496" />
+              </View>
+            )}
+            <Text
+              className="flex-1 text-base font-semibold text-neutral-1"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {displayName}
+            </Text>
+          </View>
+          <Text
+            className="text-sm text-neutral-2"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {upcomingLabel}
+          </Text>
+        </View>
+      </TouchableOpacity>
+      <SubscribeButton
+        isSubscribed={true}
+        onPress={onUnsubscribe}
+        size="sm"
+        loading={isUnsubscribing}
+        accessibilityLabel={`Unsubscribe from ${displayName}`}
+      />
+    </View>
+  );
+}

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -358,6 +358,23 @@ export const getFollowedListsFeed = query({
   },
 });
 
+export const getFollowedListsUpcomingCount = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return 0;
+    const feedId = `followedLists_${userId}`;
+    return await userFeedsAggregate.count(ctx, {
+      namespace: feedId,
+      bounds: {
+        lower: { key: 0, inclusive: true },
+        upper: { key: 0, inclusive: true },
+      },
+    });
+  },
+});
+
 // Helper query to get followed users feed (events from users you follow)
 export const getFollowedUsersFeed = query({
   args: {

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -10,7 +10,7 @@ import {
   mutation,
   query,
 } from "./_generated/server";
-import { listFollowsAggregate } from "./aggregates";
+import { listFollowsAggregate, userFeedsAggregate } from "./aggregates";
 import {
   addEventToListFeedInline,
   listFeedId,
@@ -519,6 +519,101 @@ export const getFollowedLists = query({
 
     return lists.filter(
       (list): list is NonNullable<typeof list> => list !== null,
+    );
+  },
+});
+
+/**
+ * Get followed lists enriched with owner, a 3-up image preview, and upcoming
+ * event counts. Drives the My Scene management sheet.
+ */
+export const getFollowedListsWithPreview = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) {
+      return [];
+    }
+
+    const follows = await ctx.db
+      .query("listFollows")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+
+    const results = await Promise.all(
+      follows.map(async (follow) => {
+        const list = await ctx.db
+          .query("lists")
+          .withIndex("by_custom_id", (q) => q.eq("id", follow.listId))
+          .first();
+
+        if (!list) return null;
+
+        const canView = await canUserViewList(ctx, follow.listId, userId);
+        if (!canView) return null;
+
+        const feedId = `list_${list.id}`;
+
+        const [owner, upcomingCount, previewEntries] = await Promise.all([
+          ctx.db
+            .query("users")
+            .withIndex("by_custom_id", (q) => q.eq("id", list.userId))
+            .first(),
+          userFeedsAggregate.count(ctx, {
+            namespace: feedId,
+            bounds: {
+              lower: { key: 0, inclusive: true },
+              upper: { key: 0, inclusive: true },
+            },
+          }),
+          ctx.db
+            .query("userFeeds")
+            .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
+              q
+                .eq("feedId", feedId)
+                .eq("eventVisibility", "public")
+                .eq("hasEnded", false),
+            )
+            .order("asc")
+            .take(3),
+        ]);
+
+        const previewEvents = await Promise.all(
+          previewEntries.map((entry) =>
+            ctx.db
+              .query("events")
+              .withIndex("by_custom_id", (q) => q.eq("id", entry.eventId))
+              .first(),
+          ),
+        );
+
+        const previewImageUrls: (string | null)[] = [0, 1, 2].map((i) => {
+          const event = previewEvents[i];
+          if (!event) return null;
+          return typeof event.image === "string" && event.image.length > 0
+            ? event.image
+            : null;
+        });
+
+        return {
+          list,
+          owner: owner
+            ? {
+                id: owner.id,
+                username: owner.username,
+                displayName: owner.displayName,
+                userImage: owner.userImage,
+              }
+            : null,
+          previewImageUrls,
+          upcomingCount,
+          hasMoreUpcoming: upcomingCount > 3,
+        };
+      }),
+    );
+
+    return results.filter(
+      (row): row is NonNullable<typeof row> => row !== null,
     );
   },
 });


### PR DESCRIPTION
## Summary

Addresses several interrelated My Scene / subscribe flow issues in the Expo app.

### Badge count now accurate
- The My Scene tab badge count was previously set from the paginated feed results in `FollowingFeedContent`, which meant it only recomputed while that tab was mounted. Off-tab subscribe/unsubscribe produced stale counts.
- New Convex query `feeds.getFollowedListsUpcomingCount` uses the existing `userFeedsAggregate` for an O(log n) count of upcoming events in the user's followed-lists feed. The tab layout (always mounted) subscribes to it directly.
- Removed the `setCommunityBadgeCount` effect in `following/index.tsx`.

### Empty state: clear exit + clear "done"
- Promoted the small "View My Scene →" text link to a full-width primary CTA (shows event count inline), visible once the user has subscribed — so "you've subscribed, now go!" is obvious without forcing auto-dismiss.
- Added a subtle "Skip for now" link when the user has zero subscriptions, so they aren't trapped on the empty state.
- The featured-lists carousel stays above the CTA so users can subscribe to multiple recommendations before advancing.

### Subscribe loading state
- `SubscribeButton` gains a `loading` prop — `ActivityIndicator` replaces the icon+label, button disabled while loading, dimensions preserved.
- `FeaturedListRow` swaps its `isMutatingRef` double-click guard for `useState<boolean>` so it can drive the visible spinner. Convex's `useMutation` returns only the callable (no built-in pending state), so tracking pending state in React state is the standard pattern.

### Management sheet redesign
- New component `SubscribedListRow` mirrors `FeaturedListRow` visuals: 3-up scene preview, owner avatar + display name, upcoming event count, prominent unsubscribe button with loading state.
- New Convex query `lists.getFollowedListsWithPreview` returns each followed list enriched with owner info, upcoming count (via aggregate), and first 3 upcoming event image URLs.
- `FollowedListsModal` rewritten to use it. Optimistic update now keeps both `getFollowedLists` and the preview query in sync. Per-list `unsubscribingIds` drives the per-row loading spinner. Share button preserved.

## Test plan

- [ ] Subscribe to a featured list in the empty state — button shows spinner while mutation pending.
- [ ] Subscribe to multiple featured lists in a row — each row independently shows loading, empty state stays put.
- [ ] After first subscription, big "View My Scene (N events)" button appears; tapping dismisses empty state.
- [ ] With zero subscriptions, "Skip for now" link dismisses empty state.
- [ ] Tab badge number matches upcoming count; updates live on subscribe/unsubscribe from any surface.
- [ ] Open "Subscribed lists" sheet — each row shows 3-up preview, avatar, "N upcoming events", unsubscribe button.
- [ ] Tap unsubscribe — button shows spinner, row disappears on success.
- [ ] Unfollow all from the sheet — returning to My Scene shows the empty state with featured recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the My Scene badge to update live and adds clear subscribe feedback, plus a richer “Subscribed lists” sheet with previews and per-row actions. Also improves the empty state with a primary “View My Scene” CTA and a “Skip for now” option.

- New Features
  - `SubscribeButton` adds a `loading` state (spinner, disabled); used in `FeaturedListRow` and the new `SubscribedListRow`.
  - Empty state: large “View My Scene (N)” CTA after first subscribe; “Skip for now” when there are no subscriptions.
  - Redesigned “Subscribed lists” sheet rows with 3-up image preview, owner avatar/name, upcoming count, and an unsubscribe button with loading.
  - Backend: `lists.getFollowedListsWithPreview` returns owner info, upcoming count, and first 3 image URLs for each followed list.

- Bug Fixes
  - Accurate My Scene tab badge by subscribing in the always-mounted tab layout to `feeds.getFollowedListsUpcomingCount` from `@soonlist/backend/convex`; removed the stale client-side setter in the My Scene screen.

<sup>Written for commit 94b8dd015b2ea31d231765890505350662c62e7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several interrelated My Scene / subscribe-flow issues: the tab badge now uses a live Convex aggregate query (`getFollowedListsUpcomingCount`) in the always-mounted layout instead of a stale Zustand effect; the empty state gains a prominent "View My Scene" CTA and a "Skip for now" link; `SubscribeButton` gains a `loading` prop; and `FollowedListsModal` is rewritten with a richer `SubscribedListRow` backed by a new `getFollowedListsWithPreview` query.

- **Missing exit path in `DefaultEmptyState`**: when a user has subscriptions but zero upcoming events (`hasFollowings && followedEventCount === 0`), neither the CTA nor "Skip for now" renders, leaving the user with no way to dismiss the empty state.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the missing dismiss path for users with subscriptions but no upcoming events.

One P1 logic gap in DefaultEmptyState traps users when they have follows but zero upcoming events; all other changes are well-structured and correct.

apps/expo/src/components/DefaultEmptyState.tsx — missing `!hasFollowings || followedEventCount === 0` dismiss path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/_layout.tsx | Switches community badge count from Zustand (stale, component-mount-dependent) to a live Convex query — always-mounted layout now reflects subscribe/unsubscribe immediately. |
| apps/expo/src/app/(tabs)/following/index.tsx | Removes the stale `setCommunityBadgeCount` effect; badge is now owned entirely by the layout's Convex query. |
| apps/expo/src/components/DefaultEmptyState.tsx | Promotes CTA to full-width button (correct) but the "Skip for now" condition only guards `!hasFollowings`, leaving users who have subscriptions but zero upcoming events with no dismiss path. |
| apps/expo/src/components/FeaturedListRow.tsx | Swaps `useRef` double-click guard for `useState` so the loading spinner can be driven by React state — correct pattern for Convex mutations that have no built-in pending state. |
| apps/expo/src/components/FollowedListsModal.tsx | Rewritten to use `getFollowedListsWithPreview`; optimistic update correctly syncs both `getFollowedLists` and the preview query; per-list loading spinners via `unsubscribingIds` Set. |
| apps/expo/src/components/SubscribeButton.tsx | Adds `loading` prop with `ActivityIndicator`, disables taps while loading, and preserves button dimensions — clean addition. |
| apps/expo/src/components/SubscribedListRow.tsx | New component: 3-up scene preview + owner avatar + upcoming count + unsubscribe button with loading state. Well-structured and mirrors FeaturedListRow visuals. |
| packages/backend/convex/feeds.ts | New `getFollowedListsUpcomingCount` query uses `userFeedsAggregate` (O(log n)) with correct bounds (`key: 0` = upcoming) against the `followedLists_${userId}` namespace. |
| packages/backend/convex/lists.ts | New `getFollowedListsWithPreview` enriches followed lists with owner info, preview images, and aggregate count. Count includes private events while preview only shows public ones — minor but visible inconsistency. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TabLayout as TabsLayout (always mounted)
    participant Convex as Convex Backend
    participant EmptyState as DefaultEmptyState
    participant Modal as FollowedListsModal

    TabLayout->>Convex: useQuery(getFollowedListsUpcomingCount)
    Convex-->>TabLayout: count (O(log n) aggregate)
    TabLayout->>TabLayout: render badge

    EmptyState->>EmptyState: hasFollowings && followedEventCount > 0?
    EmptyState-->>EmptyState: show View My Scene CTA
    EmptyState->>EmptyState: !hasFollowings?
    EmptyState-->>EmptyState: show Skip for now

    Modal->>Convex: useQuery(getFollowedListsWithPreview)
    Convex-->>Modal: list + owner + previewImageUrls + upcomingCount
    Modal->>Modal: render SubscribedListRow per list
    Modal->>Convex: unfollowList (optimistic update)
    Convex-->>Modal: updates getFollowedLists + getFollowedListsWithPreview
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/DefaultEmptyState.tsx
Line: 130-142

Comment:
**Missing exit path when subscribed but no upcoming events**

When `hasFollowings` is `true` but `followedEventCount === 0` (e.g. a user subscribed only to lists whose events have all ended), neither the "View My Scene" CTA nor "Skip for now" renders. The user is trapped on the empty state with no dismiss action.

The "Skip for now" condition should also cover the case where the user has subscriptions but zero upcoming events:

```suggestion
          {!hasFollowings || followedEventCount === 0 ? (
            <View className="mt-6 items-center py-4">
              <TouchableOpacity
                onPress={onExitToFeed}
                activeOpacity={0.7}
                accessibilityRole="button"
                accessibilityLabel="Skip for now"
                className="px-4 py-2"
              >
                <Text className="text-sm text-neutral-2">Skip for now</Text>
              </TouchableOpacity>
            </View>
          ) : null}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/lists.ts
Line: 562-610

Comment:
**`upcomingCount` from aggregate includes private events; preview images only show public ones**

The `upcomingCount` is fetched from `userFeedsAggregate` with no visibility filter (counts all events in `list_${list.id}` where `hasEnded = false`), while `previewEntries` is filtered to `eventVisibility === "public"`. For a list with, say, 5 upcoming events (3 public, 2 private), the UI would display "5 upcoming events" but the preview would only show 3 public thumbnails — and `hasMoreUpcoming` would be `true` when all 3 visible slots are already filled by public events.

Consider whether the aggregate count should also reflect only what the subscriber can see (public events), or at least ensure `hasMoreUpcoming` is derived from the public count rather than the total.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): accurate My Scene badge + sub..."](https://github.com/jaronheard/soonlist-turbo/commit/94b8dd015b2ea31d231765890505350662c62e7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29359215)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->