### PR TITLE
Expo onboarding: paywall layout, real notification prompt, QuestionContainer

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import { router } from "expo-router";
 
 import { Bell } from "~/components/icons";
 import { QuestionContainer } from "~/components/QuestionContainer";
@@ -28,7 +27,11 @@ export default function NotificationsScreen() {
     void hapticLight();
 
     if (hasNotificationPermission) {
-      router.navigate("/(onboarding)/onboarding/04-paywall");
+      saveStep(
+        "notifications",
+        { notificationsEnabled: true },
+        "/(onboarding)/onboarding/04-paywall",
+      );
       return;
     }
 

--- a/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
@@ -1,16 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withTiming,
-} from "react-native-reanimated";
-import { BlurView } from "expo-blur";
 import { router } from "expo-router";
 
-import { ChevronUp } from "~/components/icons";
+import { Bell } from "~/components/icons";
 import { QuestionContainer } from "~/components/QuestionContainer";
 import { useOnboarding } from "~/hooks/useOnboarding";
 import { useOneSignal } from "~/providers/OneSignalProvider";
@@ -23,50 +15,25 @@ export default function NotificationsScreen() {
     useOneSignal();
   const { saveStep } = useOnboarding();
   const pendingFollowUsername = usePendingFollowUsername();
-  const translateY = useSharedValue(0);
   const [isLoading, setIsLoading] = useState(false);
 
   const totalSteps = pendingFollowUsername ? 7 : 6;
   const currentStep = pendingFollowUsername ? 4 : 3;
 
-  useEffect(() => {
-    translateY.value = withRepeat(
-      withTiming(-12, {
-        duration: 500,
-        easing: Easing.inOut(Easing.sin),
-      }),
-      -1,
-      true,
-    );
-  }, [translateY]);
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      position: "absolute",
-      left: "25%",
-      top: "100%",
-      paddingLeft: 8,
-      paddingTop: 0,
-      transform: [{ translateY: translateY.value }],
-    };
-  });
-
   const handleNotificationPermission = async () => {
     if (isLoading) return;
     void hapticLight();
+
+    if (hasNotificationPermission) {
+      router.navigate("/(onboarding)/onboarding/04-paywall");
+      return;
+    }
+
     setIsLoading(true);
 
     try {
-      if (hasNotificationPermission) {
-        // Already has permission, just continue
-        router.navigate("/(onboarding)/onboarding/04-paywall");
-        return;
-      }
-
-      // Request permissions and get the result
       const isPermissionGranted = await registerForPushNotifications();
 
-      // Save the step with the permission result
       saveStep(
         "notifications",
         {
@@ -82,6 +49,16 @@ export default function NotificationsScreen() {
     }
   };
 
+  const handleNotNow = () => {
+    if (isLoading) return;
+    void hapticLight();
+    saveStep(
+      "notifications",
+      { notificationsEnabled: false },
+      "/(onboarding)/onboarding/04-paywall",
+    );
+  };
+
   return (
     <QuestionContainer
       question="Stay in the loop"
@@ -89,86 +66,43 @@ export default function NotificationsScreen() {
       currentStep={currentStep}
       totalSteps={totalSteps}
     >
-      <View className="flex-1">
-        <View className="flex-1 items-center justify-center px-12">
-          <View
-            className="relative"
-            style={{
-              borderRadius: 14,
-              overflow: "hidden",
-              shadowColor: "#000",
-              shadowOffset: { width: 0, height: 2 },
-              shadowOpacity: 0.15,
-              shadowRadius: 20,
-              elevation: 10,
-            }}
-          >
-            <BlurView
-              tint="systemUltraThinMaterialLight"
-              intensity={100}
-              style={{
-                borderRadius: 14,
-                overflow: "hidden",
-                backgroundColor: "rgba(255,255,255,0.75)",
-              }}
-            >
-              <View className="px-4 pb-4 pt-5">
-                <Text className="mb-1 text-center text-[17px] font-semibold leading-[22px] text-black">
-                  Allow {'"'}Soonlist{'"'} to send you notifications?
-                </Text>
-                <Text className="mt-1 text-center text-[13px] leading-[18px] text-black/50">
-                  Soonlist will notify you when events are saved and with
-                  updates from shared lists
-                </Text>
-              </View>
-              <View
-                style={{
-                  height: 0.5,
-                  backgroundColor: "rgba(60,60,67,0.36)",
-                }}
-              />
-              <View className="flex-row" style={{ height: 44 }}>
-                <Pressable
-                  className="flex-1 items-center justify-center"
-                  disabled
-                >
-                  <Text className="text-[17px] font-normal text-blue-500/30">
-                    Don{"'"}t Allow
-                  </Text>
-                </Pressable>
-                <View
-                  style={{
-                    width: 0.5,
-                    backgroundColor: "rgba(60,60,67,0.36)",
-                  }}
-                />
-                <View className="flex-1">
-                  <Pressable
-                    className="flex-1 items-center justify-center"
-                    onPress={handleNotificationPermission}
-                    hitSlop={40}
-                    disabled={isLoading}
-                  >
-                    <Text
-                      className={`text-[17px] font-semibold ${
-                        isLoading ? "text-blue-500/50" : "text-blue-500"
-                      }`}
-                    >
-                      {isLoading ? "Loading..." : "Allow"}
-                    </Text>
-                  </Pressable>
-                  <Animated.View style={animatedStyle}>
-                    <ChevronUp size={64} color="#FFF" strokeWidth={4} />
-                  </Animated.View>
-                </View>
-              </View>
-            </BlurView>
-          </View>
+      <View className="flex-1 justify-between">
+        <View className="flex-1 items-center justify-center px-2">
+          <Bell color="#FFFFFF" size={100} strokeWidth={1.5} />
         </View>
 
-        <Text className="px-6 pb-4 text-center text-sm text-white/60">
-          You can always update this later in your settings!
-        </Text>
+        <View>
+          <Text className="mb-4 text-center text-sm text-white/70">
+            You can always update this later in your settings.
+          </Text>
+          <Pressable
+            onPress={handleNotificationPermission}
+            disabled={isLoading}
+            className="rounded-full bg-white py-4 active:scale-[0.98] active:bg-neutral-100"
+          >
+            <Text
+              className={`text-center text-lg font-semibold text-interactive-1 ${
+                isLoading ? "text-interactive-1/50" : ""
+              }`}
+            >
+              {hasNotificationPermission
+                ? "Continue"
+                : isLoading
+                  ? "Loading…"
+                  : "Enable notifications"}
+            </Text>
+          </Pressable>
+          {!hasNotificationPermission && (
+            <Pressable
+              onPress={handleNotNow}
+              disabled={isLoading}
+              className="mt-2 py-3"
+              hitSlop={12}
+            >
+              <Text className="text-center text-base text-white/60">Not now</Text>
+            </Pressable>
+          )}
+        </View>
       </View>
     </QuestionContainer>
   );

--- a/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
@@ -11,8 +11,11 @@ import { logError } from "~/utils/errorLogging";
 import { hapticLight, toast } from "~/utils/feedback";
 
 export default function NotificationsScreen() {
-  const { registerForPushNotifications, hasNotificationPermission } =
-    useOneSignal();
+  const {
+    registerForPushNotifications,
+    hasNotificationPermission,
+    isPermissionResolved,
+  } = useOneSignal();
   const { saveStep } = useOnboarding();
   const pendingFollowUsername = usePendingFollowUsername();
   const [isLoading, setIsLoading] = useState(false);
@@ -92,7 +95,7 @@ export default function NotificationsScreen() {
                   : "Enable notifications"}
             </Text>
           </Pressable>
-          {!hasNotificationPermission && (
+          {isPermissionResolved && !hasNotificationPermission && (
             <Pressable
               onPress={handleNotNow}
               disabled={isLoading}

--- a/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx
@@ -99,7 +99,9 @@ export default function NotificationsScreen() {
               className="mt-2 py-3"
               hitSlop={12}
             >
-              <Text className="text-center text-base text-white/60">Not now</Text>
+              <Text className="text-center text-base text-white/60">
+                Not now
+              </Text>
             </Pressable>
           )}
         </View>

--- a/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx
@@ -24,12 +24,12 @@ const FEATURE_ROWS: {
   },
   {
     emoji: "🛡️",
-    title: "No ads. No algorithm. No data sold.",
+    title: "No ads, no infinite scroll.",
     description: "We value your attention.",
   },
   {
     emoji: "💝",
-    title: "Support for extras, not access",
+    title: "Support for extras",
     description: "Optional extras fund the app.",
   },
 ];
@@ -71,22 +71,23 @@ export default function CommunitySupportedScreen() {
     <QuestionContainer
       question="Soonlist is free."
       subtitle="Free because community access matters."
+      questionTextClassName="text-4xl"
       currentStep={currentStep}
       totalSteps={totalSteps}
     >
       <View className="flex-1 justify-between">
         <View className="flex-1 justify-center">
-          <View className="gap-6">
+          <View className="gap-10">
             {FEATURE_ROWS.map(({ emoji, title, description }) => (
-              <View key={title} className="flex-row items-start gap-4">
-                <View className="h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-white">
-                  <Text className="text-3xl">{emoji}</Text>
-                </View>
-                <View className="min-w-0 flex-1 pt-0.5">
-                  <Text className="text-lg font-semibold text-white">
+              <View key={title} className="flex-row items-center gap-4">
+                <Text className="mt-1 shrink-0 text-5xl leading-none">
+                  {emoji}
+                </Text>
+                <View className="min-w-0 flex-1">
+                  <Text className="text-2xl font-semibold text-white">
                     {title}
                   </Text>
-                  <Text className="mt-1 text-base leading-snug text-white/70">
+                  <Text className="mt-1 text-lg leading-snug text-white/70">
                     {description}
                   </Text>
                 </View>

--- a/apps/expo/src/components/QuestionContainer.tsx
+++ b/apps/expo/src/components/QuestionContainer.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { cn } from "~/utils/cn";
+
 import { ProgressBar } from "./ProgressBar";
 
 interface QuestionContainerProps {
@@ -10,6 +12,8 @@ interface QuestionContainerProps {
   children: React.ReactNode;
   currentStep: number;
   totalSteps: number;
+  questionTextClassName?: string;
+  subtitleTextClassName?: string;
 }
 
 export function QuestionContainer({
@@ -18,6 +22,8 @@ export function QuestionContainer({
   children,
   currentStep,
   totalSteps,
+  questionTextClassName,
+  subtitleTextClassName,
 }: QuestionContainerProps) {
   return (
     <SafeAreaView className="flex-1 bg-interactive-1">
@@ -28,9 +34,21 @@ export function QuestionContainer({
         foregroundColor="bg-neutral-1"
       />
       <View className="flex-1 px-6 pt-8">
-        <Text className="mb-8 text-3xl font-bold text-white">{question}</Text>
+        <Text
+          className={cn(
+            "mb-8 text-3xl font-bold text-white",
+            questionTextClassName,
+          )}
+        >
+          {question}
+        </Text>
         {subtitle && (
-          <Text className="-mt-4 mb-4 text-xl font-medium text-white/80">
+          <Text
+            className={cn(
+              "-mt-4 mb-4 text-xl font-medium text-white/80",
+              subtitleTextClassName,
+            )}
+          >
             {subtitle}
           </Text>
         )}

--- a/apps/expo/src/components/QuestionContainer.tsx
+++ b/apps/expo/src/components/QuestionContainer.tsx
@@ -3,7 +3,6 @@ import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { cn } from "~/utils/cn";
-
 import { ProgressBar } from "./ProgressBar";
 
 interface QuestionContainerProps {

--- a/apps/expo/src/providers/OneSignalProvider.tsx
+++ b/apps/expo/src/providers/OneSignalProvider.tsx
@@ -18,6 +18,7 @@ import { logError, logMessage } from "~/utils/errorLogging";
 
 interface OneSignalContextType {
   hasNotificationPermission: boolean;
+  isPermissionResolved: boolean;
   registerForPushNotifications: () => Promise<boolean>;
   checkPermissionStatus: () => Promise<boolean>;
 }
@@ -121,6 +122,7 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
   const { userId } = useAuth();
   const [hasNotificationPermission, setHasNotificationPermission] =
     useState(false);
+  const [isPermissionResolved, setIsPermissionResolved] = useState(false);
   const posthog = usePostHog();
 
   // Initialize OneSignal
@@ -156,6 +158,9 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
       })
       .catch((error) => {
         logError("Error checking notification permission", error);
+      })
+      .finally(() => {
+        setIsPermissionResolved(true);
       });
 
     // Set up notification handlers
@@ -261,9 +266,11 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
         permission === OSNotificationPermission.Ephemeral;
 
       setHasNotificationPermission(isPermissionGranted);
+      setIsPermissionResolved(true);
       return isPermissionGranted;
     } catch (error) {
       logError("Error checking notification permission", error);
+      setIsPermissionResolved(true);
       return false;
     }
   };
@@ -286,6 +293,7 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
   // Provide context values
   const contextValue: OneSignalContextType = {
     hasNotificationPermission,
+    isPermissionResolved,
     registerForPushNotifications,
     checkPermissionStatus,
   };

--- a/apps/expo/src/providers/OneSignalProvider.tsx
+++ b/apps/expo/src/providers/OneSignalProvider.tsx
@@ -146,7 +146,9 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
     // Initialize the OneSignal SDK
     OneSignal.initialize(oneSignalAppId);
 
-    // Check permission status
+    // Check permission status. Only mark resolved on a successful lookup —
+    // on error the real OS permission state is unknown, so downstream UI
+    // must not expose an opt-out that would persist a false negative.
     void OneSignal.Notifications.permissionNative()
       .then((permission) => {
         // Check if permission is granted
@@ -155,12 +157,10 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
             permission === OSNotificationPermission.Provisional ||
             permission === OSNotificationPermission.Ephemeral,
         );
+        setIsPermissionResolved(true);
       })
       .catch((error) => {
         logError("Error checking notification permission", error);
-      })
-      .finally(() => {
-        setIsPermissionResolved(true);
       });
 
     // Set up notification handlers
@@ -270,7 +270,6 @@ export function OneSignalProvider({ children }: OneSignalProviderProps) {
       return isPermissionGranted;
     } catch (error) {
       logError("Error checking notification permission", error);
-      setIsPermissionResolved(true);
       return false;
     }
   };


### PR DESCRIPTION
## Summary
Polishes the Expo **Soonlist is free** and **Stay in the loop** onboarding steps and extends `QuestionContainer` so a screen can opt into different title/subtitle typography when needed.

## Paywall (Soonlist is free)
- Copy updates: e.g. “No ads, no infinite scroll,” “Support for extras,” and related tweaks over the iteration.
- Feature rows: larger main headline via optional classes, improved vertical rhythm (e.g. spacing between rows and title/description), emojis at `text-5xl` with a small vertical nudge, centered with the two-line text without a fixed icon box, `gap-10` between feature blocks.
- Footer layout aligned with the notifications step: supporting line above the primary button where applicable.

## Stay in the loop
- Replaces the mock system-style sheet with a **real** push permission request via OneSignal (`requestPermission`), primary **Enable notifications** (or **Continue** if already allowed), **Not now** to skip, and a large bell affordance.
- Moves **“You can always update this later in your settings.”** above the primary button to match the paywall footer pattern.

## Technical
- `QuestionContainer`: optional `questionTextClassName` and `subtitleTextClassName` merged with defaults via `cn()`.

## Testing
- [ ] iOS: onboarding through notifications → system prompt appears; deny/allow and continue; paywall layout on small and large devices.
- [ ] Android: same as above (permission behavior per OS).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the mock notifications sheet with a real `OneSignal` permission prompt and updates the paywall layout and copy. Adds optional title/subtitle classes to `QuestionContainer`.

- **New Features**
  - Notifications: real `OneSignal` request; shows "Enable notifications" (or "Continue" if already allowed) and "Not now"; saves choice and advances; helper text above the primary button.
  - Paywall: refined copy, larger headline via `questionTextClassName="text-4xl"`, bigger emoji at `text-5xl`, wider spacing, and footer text above the primary button.
  - `QuestionContainer`: supports `questionTextClassName` and `subtitleTextClassName`, merged with defaults.

- **Bug Fixes**
  - Hide "Not now" until `isPermissionResolved` from `OneSignalProvider` is true; only mark resolved after a successful permission check to avoid persisting a false opt-out on lookup errors.
  - Persist the notifications step when permission is already granted by calling `saveStep` (ensures state and analytics are recorded).

<sup>Written for commit d4c2063cc83ebc4d6e65cf44aa2406327860870d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the **Stay in the loop** and **Soonlist is free** onboarding screens: the mock system-dialog is replaced with a real OneSignal `requestPermission` call, the "Not now" skip path is added, and `QuestionContainer` gains optional `questionTextClassName`/`subtitleTextClassName` props. The paywall receives copy and layout tweaks (larger emoji, bigger headline, wider row spacing). All changes are UI/UX refinements with no data-model impact; the async save pattern in `saveStep` is intentional fire-and-forget with immediate optimistic navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are UI polish and a straightforward real-permission integration with no data-integrity risk.

No P0 or P1 findings. The real notification-permission flow is correctly gated behind loading state, the 'Not now' path uses the same fire-and-forget saveStep pattern already established in the codebase, and QuestionContainer extension is additive and backwards-compatible.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(onboarding)/onboarding/03-notifications.tsx | Major refactor: replaces the static mock system-dialog UI with a real OneSignal push permission request, adds a 'Not now' skip path, and simplifies the bell affordance to a single icon. |
| apps/expo/src/app/(onboarding)/onboarding/04-paywall.tsx | Copy and layout-only changes: updated feature row text, emoji size/alignment at text-5xl, gap-10 between rows, and larger headline via questionTextClassName='text-4xl'. |
| apps/expo/src/components/QuestionContainer.tsx | Adds optional questionTextClassName and subtitleTextClassName props merged with defaults via cn(); clean, non-breaking extension of the shared container. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User lands on Stay in the loop] --> B{hasNotificationPermission?}
    B -- Yes --> C[Show 'Continue' button only]
    B -- No --> D[Show 'Enable notifications' + 'Not now']
    C --> E[router.navigate to 04-paywall]
    D --> F{User taps...}
    F -- Enable notifications --> G[setIsLoading true]
    G --> H[await registerForPushNotifications]
    H -- success --> I[saveStep notificationsEnabled=result navigate to 04-paywall]
    H -- error --> J[toast.error + setIsLoading false]
    F -- Not now --> K[saveStep notificationsEnabled=false navigate to 04-paywall]
    I --> L[04-paywall]
    K --> L
    E --> L
```

<sub>Reviews (1): Last reviewed commit: ["refactor(expo): polish onboarding paywal..."](https://github.com/jaronheard/soonlist-turbo/commit/1dc847b694cb95c9e84485e1e3a15e6fa9b80fbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29359429)</sub>

<!-- /greptile_comment -->