### PR TITLE
feat(expo): redesign My Soonlist & My Scene attribution rows

### DIFF
--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -1,3 +1,4 @@
+import type { StyleProp, TextStyle } from "react-native";
 import React, { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { router } from "expo-router";
@@ -29,6 +30,23 @@ interface EventAttributionRowProps {
 }
 
 const HIT_SLOP = { top: 8, bottom: 8, left: 4, right: 4 } as const;
+// Wider right side for the "+N" chip at the end of the row; the row has
+// 12px horizontal padding so this stays inside the card.
+const OVERFLOW_HIT_SLOP = { top: 8, bottom: 8, left: 6, right: 12 } as const;
+
+// Handoff spec values that don't map to existing Tailwind tokens.
+const ROW_HEIGHT = 28;
+const ROW_FONT_SIZE = 12.5;
+const AVATAR_OVERLAP = -6;
+
+// Hex forms of design tokens for imperative color props (SVG icon color,
+// shadowColor) that don't accept className.
+const INTERACTIVE_1_HEX = "#5A32FB"; // --interactive-1
+const NEUTRAL_0_HEX = "#162135"; // --neutral-0
+
+function displayName(user: UserForDisplay) {
+  return user.displayName || user.username;
+}
 
 function combineUsers(creator: UserForDisplay, savers: UserForDisplay[]) {
   const out: UserForDisplay[] = [creator];
@@ -40,10 +58,232 @@ function combineUsers(creator: UserForDisplay, savers: UserForDisplay[]) {
   return out;
 }
 
-function ListChip({ name, slug }: { name?: string; slug?: string }) {
+function RowWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <View className="mt-0.5 px-3">
+      <View
+        className="flex-row items-center"
+        style={{ minHeight: ROW_HEIGHT, columnGap: 7 }}
+      >
+        {children}
+      </View>
+    </View>
+  );
+}
+
+function RowText({
+  children,
+  className,
+  style,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  style?: StyleProp<TextStyle>;
+}) {
+  return (
+    <Text
+      numberOfLines={1}
+      className={className}
+      style={[{ fontSize: ROW_FONT_SIZE }, style]}
+    >
+      {children}
+    </Text>
+  );
+}
+
+function StackAvatar({
+  user,
+  size,
+  isFirst,
+}: {
+  user: UserForDisplay;
+  size: number;
+  isFirst: boolean;
+}) {
+  const inner = Math.max(size - 4, 1);
+  return (
+    <View
+      className="items-center justify-center rounded-full bg-white"
+      style={{
+        width: size,
+        height: size,
+        marginLeft: isFirst ? 0 : AVATAR_OVERLAP,
+      }}
+    >
+      <UserAvatar user={user} size={inner} />
+    </View>
+  );
+}
+
+function CapturerAvatar({
+  user,
+  size,
+  isFirst = true,
+}: {
+  user: UserForDisplay;
+  size: number;
+  isFirst?: boolean;
+}) {
+  const halo = size + 5;
+  const inner = Math.max(size - 4, 1);
+  return (
+    <View
+      className="items-center justify-center rounded-full bg-accent-yellow"
+      style={{
+        width: halo,
+        height: halo,
+        marginLeft: isFirst ? 0 : AVATAR_OVERLAP,
+        shadowColor: NEUTRAL_0_HEX,
+        shadowOpacity: 0.06,
+        shadowRadius: 0,
+        shadowOffset: { width: 0, height: 1 },
+      }}
+    >
+      <UserAvatar user={user} size={inner} />
+    </View>
+  );
+}
+
+function AvatarStack({
+  users,
+  size,
+  capturerId,
+  onPress,
+}: {
+  users: UserForDisplay[];
+  size: number;
+  capturerId?: string;
+  onPress?: () => void;
+}) {
+  if (users.length === 0) return null;
+  const content = (
+    <View className="flex-row items-center">
+      {users.map((user, i) =>
+        user.id === capturerId ? (
+          <CapturerAvatar
+            key={user.id}
+            user={user}
+            size={size}
+            isFirst={i === 0}
+          />
+        ) : (
+          <StackAvatar
+            key={user.id}
+            user={user}
+            size={size}
+            isFirst={i === 0}
+          />
+        ),
+      )}
+    </View>
+  );
+  if (!onPress) return content;
+  return (
+    <Pressable onPress={onPress} hitSlop={HIT_SLOP}>
+      {content}
+    </Pressable>
+  );
+}
+
+// Names render inside a single shrinking Text so ellipsis kicks in before the
+// row overflows. The "+N" stays pinned outside the truncating Text.
+function NameList({
+  users,
+  extraCount,
+  maxNames,
+  currentUserId,
+  onOverflowPress,
+}: {
+  users: UserForDisplay[];
+  extraCount: number;
+  maxNames: number;
+  currentUserId?: string;
+  onOverflowPress?: () => void;
+}) {
+  const nameUsers = users.slice(0, maxNames);
+  if (nameUsers.length === 0 && extraCount === 0) return null;
+  return (
+    <View
+      className="flex-row items-center"
+      style={{ flexShrink: 1, minWidth: 0, columnGap: 4 }}
+    >
+      {nameUsers.length > 0 ? (
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          className="font-medium text-neutral-1"
+          style={{ flexShrink: 1, minWidth: 0, fontSize: ROW_FONT_SIZE }}
+        >
+          {nameUsers.map((user, i) => (
+            <Text
+              key={user.id}
+              onPress={() => navigateToUser(user, currentUserId)}
+            >
+              {displayName(user)}
+              {i < nameUsers.length - 1 ? ", " : ""}
+            </Text>
+          ))}
+        </Text>
+      ) : null}
+      {extraCount > 0 ? (
+        <Pressable
+          onPress={onOverflowPress}
+          hitSlop={OVERFLOW_HIT_SLOP}
+          accessibilityLabel="View everyone who saved this"
+        >
+          <Text className="text-neutral-2" style={{ fontSize: ROW_FONT_SIZE }}>
+            +{extraCount}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+function ListChip({
+  name,
+  slug,
+  size,
+}: {
+  name?: string;
+  slug?: string;
+  size: number;
+}) {
+  const shrink = { flexShrink: 1, minWidth: 0 } as const;
+  const content = (
+    <View className="flex-row items-center" style={{ columnGap: 5, ...shrink }}>
+      <List size={size} color={INTERACTIVE_1_HEX} strokeWidth={1.75} />
+      {name ? (
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          className="font-semibold text-interactive-1"
+          style={{ ...shrink, fontSize: ROW_FONT_SIZE }}
+        >
+          {name}
+        </Text>
+      ) : null}
+    </View>
+  );
+  if (slug) {
+    return (
+      <Pressable
+        onPress={() => router.push(`/list/${slug}`)}
+        hitSlop={HIT_SLOP}
+        accessibilityLabel={name ? `Open list ${name}` : "Open list"}
+        style={shrink}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+  return content;
+}
+
+function ListChipLegacy({ name, slug }: { name?: string; slug?: string }) {
   const content = (
     <>
-      <List size={13} color="#5A32FB" />
+      <List size={13} color={INTERACTIVE_1_HEX} />
       {name ? (
         <Text
           className={
@@ -85,7 +325,7 @@ export function EventAttributionRow({
 }: EventAttributionRowProps) {
   if (variant === "people-only") {
     return (
-      <PeopleOnlyRow
+      <MySoonlistRow
         creator={creator}
         savers={savers}
         iconSize={iconSize}
@@ -96,7 +336,7 @@ export function EventAttributionRow({
 
   if (variant === "list-primary" && sourceListSlug) {
     return (
-      <ListPrimaryRow
+      <MySceneRow
         creator={creator}
         savers={savers}
         iconSize={iconSize}
@@ -109,8 +349,6 @@ export function EventAttributionRow({
     );
   }
 
-  // list-primary with no sourceListSlug degrades to people-primary layout,
-  // dropping the "via" connector since there's no list to attribute to.
   return (
     <PeoplePrimaryRow
       creator={creator}
@@ -121,12 +359,11 @@ export function EventAttributionRow({
       sourceListSlug={sourceListSlug}
       additionalSourceCount={additionalSourceCount}
       lists={lists}
-      showListConnector={variant === "people-primary"}
     />
   );
 }
 
-function PeopleOnlyRow({
+function MySoonlistRow({
   creator,
   savers,
   iconSize,
@@ -137,50 +374,104 @@ function PeopleOnlyRow({
   iconSize: number;
   currentUserId?: string;
 }) {
+  const [showModal, setShowModal] = useState(false);
   const isOwnEvent = currentUserId === creator.id;
-  const avatarSize = iconSize * 0.9;
+  const avatarSize = Math.round(iconSize * 1.25); // 20px at fontScale=1
+  const otherSavers = savers.filter(
+    (s) => s.id !== creator.id && s.id !== currentUserId,
+  );
+  const openModal = () => setShowModal(true);
 
-  // Hide the viewer from their own savers row in either branch — they
-  // already know they have it.
-  const displayUsers = isOwnEvent
-    ? savers.filter((s) => s.id !== creator.id)
-    : combineUsers(creator, savers).filter((u) => u.id !== currentUserId);
-
-  if (displayUsers.length === 0) {
+  // Viewer captured alone: handoff says collapse the row entirely.
+  if (isOwnEvent && otherSavers.length === 0) {
     return null;
   }
 
-  const maxInline = 2;
-  const inlineUsers = displayUsers.slice(0, maxInline);
-  const remainingUsersCount = displayUsers.length - inlineUsers.length;
+  if (isOwnEvent) {
+    const stackUsers = otherSavers.slice(0, 3);
+    const extraNameCount = Math.max(otherSavers.length - 2, 0);
+    return (
+      <>
+        <RowWrapper>
+          <RowText className="text-neutral-2">Also saved by</RowText>
+          <AvatarStack
+            users={stackUsers}
+            size={avatarSize}
+            onPress={openModal}
+          />
+          <NameList
+            users={otherSavers}
+            extraCount={extraNameCount}
+            maxNames={2}
+            currentUserId={currentUserId}
+            onOverflowPress={openModal}
+          />
+        </RowWrapper>
+        <SavedByModal
+          visible={showModal}
+          onClose={() => setShowModal(false)}
+          creator={creator}
+          savers={savers}
+          lists={[]}
+          currentUserId={currentUserId}
+        />
+      </>
+    );
+  }
 
+  const capturerBadge = (
+    <Pressable
+      onPress={() => navigateToUser(creator, currentUserId)}
+      hitSlop={HIT_SLOP}
+      className="flex-row items-center"
+      style={{ columnGap: 7, flexShrink: 1, minWidth: 0 }}
+    >
+      <CapturerAvatar user={creator} size={avatarSize} />
+      <RowText className="font-semibold text-black" style={{ flexShrink: 1 }}>
+        {displayName(creator)}
+      </RowText>
+    </Pressable>
+  );
+
+  if (otherSavers.length === 0) {
+    return (
+      <RowWrapper>
+        <RowText className="text-neutral-2">Captured by</RowText>
+        {capturerBadge}
+      </RowWrapper>
+    );
+  }
+
+  const stackUsers = otherSavers.slice(0, 3);
+  const extraNameCount = Math.max(otherSavers.length - 1, 0);
   return (
-    <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
-      {isOwnEvent ? (
-        <Text className="text-xs text-neutral-2">Saved by</Text>
-      ) : null}
-      {inlineUsers.map((user, index) => (
-        <Pressable
-          key={user.id}
-          onPress={() => navigateToUser(user, currentUserId)}
-          hitSlop={HIT_SLOP}
-          className="flex-row items-center gap-1"
-        >
-          <UserAvatar user={user} size={avatarSize} />
-          <Text className="text-xs text-neutral-2">
-            {user.displayName || user.username}
-            {index < inlineUsers.length - 1 || remainingUsersCount > 0
-              ? ","
-              : ""}
-          </Text>
-        </Pressable>
-      ))}
-      <OverflowPill count={remainingUsersCount} />
-    </View>
+    <>
+      <RowWrapper>
+        <RowText className="text-neutral-2">Captured by</RowText>
+        {capturerBadge}
+        <RowText className="text-neutral-3">·</RowText>
+        <AvatarStack users={stackUsers} size={avatarSize} onPress={openModal} />
+        <NameList
+          users={otherSavers}
+          extraCount={extraNameCount}
+          maxNames={1}
+          currentUserId={currentUserId}
+          onOverflowPress={openModal}
+        />
+      </RowWrapper>
+      <SavedByModal
+        visible={showModal}
+        onClose={() => setShowModal(false)}
+        creator={creator}
+        savers={savers}
+        lists={[]}
+        currentUserId={currentUserId}
+      />
+    </>
   );
 }
 
-function ListPrimaryRow({
+function MySceneRow({
   creator,
   savers,
   iconSize,
@@ -200,66 +491,33 @@ function ListPrimaryRow({
   lists?: Doc<"lists">[];
 }) {
   const [showModal, setShowModal] = useState(false);
-  const isOwnEvent = currentUserId === creator.id;
-  const allUsers = combineUsers(creator, savers);
-  const remainingListsCount = additionalSourceCount ?? 0;
-  const avatarSize = iconSize * 0.9;
+  const avatarSize = Math.round(iconSize * 1.25); // 20px at fontScale=1
+  const listIconSize = Math.round(iconSize * 0.8125); // 13px at fontScale=1
   const openModal = () => setShowModal(true);
 
-  const maxStack = 3;
-  // Own-event: "You" is already shown, so the stack surfaces other savers
-  // only. Otherwise the stack combines creator + savers.
-  const stackCandidates = isOwnEvent
-    ? savers.filter((s) => s.id !== creator.id)
-    : allUsers;
-  const stackUsers = stackCandidates.slice(0, maxStack);
-  const extraCount = Math.max(stackCandidates.length - maxStack, 0);
-
-  const ownBadge = (
-    <Pressable
-      onPress={() => navigateToUser(creator, currentUserId)}
-      hitSlop={HIT_SLOP}
-      accessibilityLabel="Go to your profile"
-      className="flex-row items-center gap-1"
-    >
-      <UserAvatar user={creator} size={avatarSize} />
-      <Text className="text-xs text-neutral-2">You</Text>
-    </Pressable>
-  );
-
-  const stack =
-    stackUsers.length > 0 ? (
-      <Pressable
-        onPress={openModal}
-        hitSlop={HIT_SLOP}
-        accessibilityLabel="View everyone who saved this"
-        className="flex-row items-center gap-2"
-      >
-        {stackUsers.map((user) => (
-          <UserAvatar key={user.id} user={user} size={avatarSize} />
-        ))}
-        <OverflowPill count={extraCount} className="ml-1" />
-      </Pressable>
-    ) : null;
+  // Capturer first, then savers in order, dedup'd.
+  const stackUsers = combineUsers(creator, savers).slice(0, 3);
+  const remainingListsCount = additionalSourceCount ?? 0;
 
   return (
     <>
-      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
-        {isOwnEvent ? (
-          <>
-            {ownBadge}
-            <Text className="text-xs text-neutral-2">·</Text>
-          </>
+      <RowWrapper>
+        <ListChip
+          name={sourceListName}
+          slug={sourceListSlug}
+          size={listIconSize}
+        />
+        {remainingListsCount > 0 ? (
+          <OverflowPill count={remainingListsCount} onPress={openModal} />
         ) : null}
-        <ListChip name={sourceListName} slug={sourceListSlug} />
-        <OverflowPill count={remainingListsCount} onPress={openModal} />
-        {stack ? (
-          <>
-            <Text className="text-xs text-neutral-2">·</Text>
-            {stack}
-          </>
-        ) : null}
-      </View>
+        <RowText className="text-neutral-3">·</RowText>
+        <AvatarStack
+          users={stackUsers}
+          size={avatarSize}
+          capturerId={creator.id}
+          onPress={openModal}
+        />
+      </RowWrapper>
       <SavedByModal
         visible={showModal}
         onClose={() => setShowModal(false)}
@@ -272,6 +530,8 @@ function ListPrimaryRow({
   );
 }
 
+// Discover tab and List detail page. Not covered by the attribution-row
+// redesign; kept unchanged so those screens render as before.
 function PeoplePrimaryRow({
   creator,
   savers,
@@ -281,7 +541,6 @@ function PeoplePrimaryRow({
   sourceListSlug,
   additionalSourceCount,
   lists,
-  showListConnector,
 }: {
   creator: UserForDisplay;
   savers: UserForDisplay[];
@@ -291,7 +550,6 @@ function PeoplePrimaryRow({
   sourceListSlug?: string;
   additionalSourceCount?: number;
   lists?: Doc<"lists">[];
-  showListConnector: boolean;
 }) {
   const [showModal, setShowModal] = useState(false);
   const isOwnEvent = currentUserId === creator.id;
@@ -302,7 +560,6 @@ function PeoplePrimaryRow({
   const avatarSize = iconSize * 0.9;
   const openModal = () => setShowModal(true);
 
-  const listConnector = isOwnEvent ? "· Shared to" : "via";
   const hasAnyListInfo =
     !!sourceListSlug || !!sourceListName || remainingListsCount > 0;
 
@@ -340,13 +597,10 @@ function PeoplePrimaryRow({
           <OverflowPill count={remainingUsersCount} onPress={openModal} />
         )}
         {hasAnyListInfo && (
-          <>
-            {showListConnector ? (
-              <Text className="text-xs text-neutral-2">{listConnector}</Text>
-            ) : null}
-            <ListChip name={sourceListName} slug={sourceListSlug} />
-            <OverflowPill count={remainingListsCount} onPress={openModal} />
-          </>
+          <ListChipLegacy name={sourceListName} slug={sourceListSlug} />
+        )}
+        {remainingListsCount > 0 && (
+          <OverflowPill count={remainingListsCount} onPress={openModal} />
         )}
       </View>
       <SavedByModal

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -137,6 +137,7 @@ function CapturerAvatar({
         shadowOpacity: 0.06,
         shadowRadius: 0,
         shadowOffset: { width: 0, height: 1 },
+        elevation: 1,
       }}
     >
       <UserAvatar user={user} size={inner} />
@@ -495,7 +496,8 @@ function MySceneRow({
   const listIconSize = Math.round(iconSize * 0.8125); // 13px at fontScale=1
   const openModal = () => setShowModal(true);
 
-  // Capturer first, then savers in order, dedup'd.
+  // Capturer first, then savers in order, dedup'd. Per the handoff the Scene
+  // row shows no "+N" for extra savers — tapping the stack opens the modal.
   const stackUsers = combineUsers(creator, savers).slice(0, 3);
   const remainingListsCount = additionalSourceCount ?? 0;
 
@@ -597,10 +599,15 @@ function PeoplePrimaryRow({
           <OverflowPill count={remainingUsersCount} onPress={openModal} />
         )}
         {hasAnyListInfo && (
-          <ListChipLegacy name={sourceListName} slug={sourceListSlug} />
-        )}
-        {remainingListsCount > 0 && (
-          <OverflowPill count={remainingListsCount} onPress={openModal} />
+          <>
+            <Text className="text-xs text-neutral-2">
+              {isOwnEvent ? "· Shared to" : "via"}
+            </Text>
+            <ListChipLegacy name={sourceListName} slug={sourceListSlug} />
+            {remainingListsCount > 0 && (
+              <OverflowPill count={remainingListsCount} onPress={openModal} />
+            )}
+          </>
         )}
       </View>
       <SavedByModal

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -137,7 +137,6 @@ function CapturerAvatar({
         shadowOpacity: 0.06,
         shadowRadius: 0,
         shadowOffset: { width: 0, height: 1 },
-        elevation: 1,
       }}
     >
       <UserAvatar user={user} size={inner} />


### PR DESCRIPTION
## Summary

Implements the v3 attribution-row design handoff for the two feed tabs on mobile.

- **My Soonlist** (`people-only`): never shows the viewer. Four cases — row collapses when the viewer captured alone; otherwise labels "Also saved by …" or "Captured by …" with a yellow-halo capturer avatar when a friend captured.
- **My Scene** (`list-primary`): leads with the source list (purple, 13px list icon) followed by a capturer-first avatar stack with the yellow ring on the capturer.
- **Discover / List detail** (`people-primary`): untouched — not covered by the handoff.

## What's new

- New shared primitives: `RowWrapper`, `StackAvatar` (20px w/ 2px white ring), `CapturerAvatar` (25px yellow halo), `AvatarStack` (−6px overlap), `NameList`, `ListChip`.
- Names render inside a single shrinking `Text` so they truncate with an ellipsis before the row wraps; `+N` stays pinned outside the truncating text and taps to open the savers modal.
- 12px horizontal padding on the row so attribution lines up with the card's inner text (matches the card's `p-3`).
- Row wrapper uses NativeWind design tokens throughout (`text-neutral-*`, `text-interactive-1`, `bg-accent-yellow`); no new color constants.

## Test plan

- [ ] Scroll the My Soonlist feed — verify each of the four cases renders (own event + others saved, own event alone collapses, friend captured + only you, friend captured + others).
- [ ] Scroll the My Scene feed — verify list name leads, capturer has the yellow ring, stack truncates to 3 avatars.
- [ ] Tap a name → navigates to that user's profile.
- [ ] Tap `+N` → opens the savers modal.
- [ ] Tap the avatar stack → opens the savers modal.
- [ ] Tap the list chip on My Scene → navigates to the list.
- [ ] Verify Discover and List-detail attribution rows render unchanged.
- [ ] Long display names ellipsize instead of wrapping to a second line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the mobile attribution rows for My Soonlist and My Scene to match the v3 handoff. Clearer labels, a capturer‑first avatar stack, and better truncation; Discover/List‑detail remain unchanged.

- **New Features**
  - My Soonlist (`people-only`): never shows the viewer. Collapses if you captured alone. Otherwise shows “Also saved by …” or “Captured by …” with a yellow‑halo avatar for the friend who captured.
  - My Scene (`list-primary`): starts with the source list chip (purple, 13px icon), then a capturer‑first avatar stack; the capturer has a yellow halo. No “+N” for extra savers; tap the stack to open the modal. Extra lists still show a `+N` pill.
  - Shared UI primitives: RowWrapper, RowText, StackAvatar, CapturerAvatar, AvatarStack, NameList, ListChip. Uses `NativeWind` tokens and 12px horizontal padding. Names ellipsize; `+N` sits outside and is tappable where shown.
  - Interactions: tap a name → profile. Tap avatar stack (or `+N` where shown) → savers modal. Tap list chip → list.

- **Bug Fixes**
  - Restored the “via” / “· Shared to” connector in PeoplePrimaryRow so Discover and List‑detail render exactly as before.
  - Removed Android `elevation` from CapturerAvatar; the app is iOS‑only. Kept the iOS shadow.

<sup>Written for commit 39d8c4f5910689899640753de403d89321945c25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the `PeopleOnlyRow` and `ListPrimaryRow` components with `MySoonlistRow` and `MySceneRow`, implementing the v3 attribution-row design handoff. It introduces a set of reusable primitives (`RowWrapper`, `StackAvatar`, `CapturerAvatar`, `AvatarStack`, `NameList`, `ListChip`) and handles the four My Soonlist display cases and the My Scene list-first layout. `PeoplePrimaryRow` (Discover / List detail) is intentionally left unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style and UX suggestions that do not affect correctness.

The logic for all four My Soonlist cases and the My Scene layout is correctly implemented. The only findings are an iOS-only shadow with no Android elevation counterpart, and a missing +N overflow indicator on the My Scene avatar stack — both are style/UX concerns, not data or runtime errors.

No files require special attention beyond the two P2 suggestions in EventAttributionRow.tsx.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/EventAttributionRow.tsx | Full redesign of My Soonlist (people-only) and My Scene (list-primary) attribution rows, adding shared primitives (RowWrapper, StackAvatar, CapturerAvatar, AvatarStack, NameList, ListChip); PeoplePrimaryRow is unchanged. Two P2 findings: iOS-only shadow on CapturerAvatar, and no +N overflow indicator for user count in MySceneRow. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventAttributionRow] --> B{variant?}
    B -->|people-only| C[MySoonlistRow]
    B -->|list-primary + sourceListSlug| D[MySceneRow]
    B -->|people-primary / fallthrough| E[PeoplePrimaryRow\nunchanged]

    C --> F{isOwnEvent?}
    F -->|true, otherSavers=0| G[return null\ncollapse row]
    F -->|true, otherSavers>0| H[Also saved by\nAvatarStack + NameList]
    F -->|false, otherSavers=0| I[Captured by\nCapturerAvatar + name]
    F -->|false, otherSavers>0| J[Captured by badge\n· AvatarStack + NameList]

    D --> K[ListChip + OverflowPill\n· AvatarStack with yellow ring on creator]

    H --> L[SavedByModal]
    J --> L
    K --> L
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 130-144

Comment:
**iOS-only shadow — no Android elevation**

`shadowColor`, `shadowOpacity`, `shadowRadius`, and `shadowOffset` are silently ignored on Android. If the shadow should be visible on both platforms, add an `elevation` value alongside the iOS props.

```suggestion
      style={{
        width: halo,
        height: halo,
        marginLeft: isFirst ? 0 : AVATAR_OVERLAP,
        shadowColor: NEUTRAL_0_HEX,
        shadowOpacity: 0.06,
        shadowRadius: 0,
        shadowOffset: { width: 0, height: 1 },
        elevation: 1, // Android shadow
      }}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 499-519

Comment:
**No overflow indicator for the `MySceneRow` avatar stack**

`combineUsers` can return more than 3 users, but the stack silently clips to 3 with no `+N` affordance. The `OverflowPill` is only shown for `remainingListsCount` (extra lists), not for extra users. Tapping the stack does open the modal, but users with 4+ savers get no visual cue that the stack is truncated.

If the design intentionally omits a user count here, a brief comment or `TODO` would help future maintainers understand it's deliberate rather than forgotten.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): redesign My Soonlist &amp; My Sc..."](https://github.com/jaronheard/soonlist-turbo/commit/510d1edbbbf24c809e5dda9d4fea58fef8237649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29363528)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->