### PR TITLE
Support inline large titles on iOS (add `largeTitleInline` / `headerLargeTitleInline`)

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/feed/_layout.tsx
@@ -14,6 +14,7 @@ export default function FeedLayout() {
       <Stack
         screenOptions={{
           headerLargeTitle: true,
+          headerLargeTitleInline: true,
           headerLargeTitleStyle: { color: "#5A32FB" },
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,

--- a/apps/expo/src/app/(tabs)/following/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/following/_layout.tsx
@@ -11,6 +11,7 @@ export default function FollowingLayout() {
       <Stack
         screenOptions={{
           headerLargeTitle: true,
+          headerLargeTitleInline: true,
           headerLargeTitleStyle: { color: "#5A32FB" },
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
       "@radix-ui/react-visually-hidden": "1.2.4"
     },
     "patchedDependencies": {
-      "xcode@3.0.1": "patches/xcode@3.0.1.patch"
+      "xcode@3.0.1": "patches/xcode@3.0.1.patch",
+      "@react-navigation/native-stack@7.10.1": "patches/@react-navigation__native-stack@7.10.1.patch",
+      "react-native-screens@4.23.0": "patches/react-native-screens@4.23.0.patch"
     },
     "onlyBuiltDependencies": [
       "@clerk/shared",

--- a/patches/@react-navigation__native-stack@7.10.1.patch
+++ b/patches/@react-navigation__native-stack@7.10.1.patch
@@ -1,0 +1,78 @@
+diff --git a/lib/module/views/useHeaderConfigProps.js b/lib/module/views/useHeaderConfigProps.js
+index 492390b5fad0e48d8f25f11179935754f8402f75..96a4ad0444adffe2b811448bde41bc652e5ee354 100644
+--- a/lib/module/views/useHeaderConfigProps.js
++++ b/lib/module/views/useHeaderConfigProps.js
+@@ -126,6 +126,7 @@ export function useHeaderConfigProps({
+   headerLargeTitle: headerLargeTitleDeprecated,
+   headerLargeTitleEnabled = headerLargeTitleDeprecated,
+   headerLargeTitleShadowVisible,
++  headerLargeTitleInline,
+   headerLargeTitleStyle,
+   headerBackground,
+   headerLeft,
+@@ -336,6 +337,7 @@ export function useHeaderConfigProps({
+     largeTitleFontSize,
+     largeTitleFontWeight,
+     largeTitleHideShadow: headerLargeTitleShadowVisible === false,
++    largeTitleInline: Platform.OS === 'ios' && headerLargeTitleInline === true,
+     title: titleText,
+     titleColor,
+     titleFontFamily,
+diff --git a/lib/typescript/src/types.d.ts b/lib/typescript/src/types.d.ts
+index 5bbdb198f6392171e42c57ceb7153395477d8c2f..2097812a60430dd3273332259361a8518a065098 100644
+--- a/lib/typescript/src/types.d.ts
++++ b/lib/typescript/src/types.d.ts
+@@ -213,6 +213,14 @@ export type NativeStackNavigationOptions = {
+      * @platform ios
+      */
+     headerLargeTitleShadowVisible?: boolean;
++    /**
++     * Whether the large title should be shown inline instead of expanded.
++     *
++     * Only supported on iOS.
++     *
++     * @platform ios
++     */
++    headerLargeTitleInline?: boolean;
+     /**
+      * Style object for large title in header. Supported properties:
+      * - fontFamily
+diff --git a/src/types.tsx b/src/types.tsx
+index f01dbddb99c046a50ff6385d02ef55c22502f40d..0fae08f6fba74a63153b1ad40471bd901feca4b9 100644
+--- a/src/types.tsx
++++ b/src/types.tsx
+@@ -257,6 +257,14 @@ export type NativeStackNavigationOptions = {
+    * @platform ios
+    */
+   headerLargeTitleShadowVisible?: boolean;
++  /**
++   * Whether the large title should be shown inline instead of expanded.
++   *
++   * Only supported on iOS.
++   *
++   * @platform ios
++   */
++  headerLargeTitleInline?: boolean;
+   /**
+    * Style object for large title in header. Supported properties:
+    * - fontFamily
+diff --git a/src/views/useHeaderConfigProps.tsx b/src/views/useHeaderConfigProps.tsx
+index 14a00939c903b735314ea2cc934ed1918f4f87de..d9524792c1230ddceb0b1e6d64a5d43e2ad7b8ab 100644
+--- a/src/views/useHeaderConfigProps.tsx
++++ b/src/views/useHeaderConfigProps.tsx
+@@ -177,6 +177,7 @@ export function useHeaderConfigProps({
+   headerLargeTitle: headerLargeTitleDeprecated,
+   headerLargeTitleEnabled = headerLargeTitleDeprecated,
+   headerLargeTitleShadowVisible,
++  headerLargeTitleInline,
+   headerLargeTitleStyle,
+   headerBackground,
+   headerLeft,
+@@ -489,6 +490,7 @@ export function useHeaderConfigProps({
+     largeTitleFontSize,
+     largeTitleFontWeight,
+     largeTitleHideShadow: headerLargeTitleShadowVisible === false,
++    largeTitleInline: Platform.OS === 'ios' && headerLargeTitleInline === true,
+     title: titleText,
+     titleColor,
+     titleFontFamily,

--- a/patches/react-native-screens@4.23.0.patch
+++ b/patches/react-native-screens@4.23.0.patch
@@ -1,0 +1,102 @@
+diff --git a/ios/RNSScreenStackHeaderConfig.h b/ios/RNSScreenStackHeaderConfig.h
+index d5ea95f556a55ad2bd68626fc0f653c2d9bc24d4..82566776b4324817e545f22186c62f13a3efcd1b 100644
+--- a/ios/RNSScreenStackHeaderConfig.h
++++ b/ios/RNSScreenStackHeaderConfig.h
+@@ -52,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
+ @property (nonatomic, retain) NSString *largeTitleFontWeight;
+ @property (nonatomic, retain) UIColor *largeTitleBackgroundColor;
+ @property (nonatomic) BOOL largeTitleHideShadow;
++@property (nonatomic) BOOL largeTitleInline;
+ @property (nonatomic, retain) UIColor *largeTitleColor;
+ @property (nonatomic) BOOL hideBackButton;
+ @property (nonatomic) BOOL disableBackButtonMenu;
+diff --git a/ios/RNSScreenStackHeaderConfig.mm b/ios/RNSScreenStackHeaderConfig.mm
+index 3270127a09a05af656566009ee6c4437590bb435..f9e932db9c75badae545096a31c53d7ab1358d17 100644
+--- a/ios/RNSScreenStackHeaderConfig.mm
++++ b/ios/RNSScreenStackHeaderConfig.mm
+@@ -591,8 +591,9 @@ RNS_IGNORE_SUPER_CALL_END
+   if (config.largeTitle) {
+     navctr.navigationBar.prefersLargeTitles = YES;
+   }
+-  navitem.largeTitleDisplayMode =
+-      config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
++  navitem.largeTitleDisplayMode = config.largeTitle
++      ? (config.largeTitleInline ? UINavigationItemLargeTitleDisplayModeNever : UINavigationItemLargeTitleDisplayModeAlways)
++      : UINavigationItemLargeTitleDisplayModeNever;
+ #endif
+ 
+   UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
+@@ -1133,6 +1134,7 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
+   _largeTitleFontWeight = RCTNSStringFromStringNilIfEmpty(newScreenProps.largeTitleFontWeight);
+   _largeTitleFontSize = [self getFontSizePropValue:newScreenProps.largeTitleFontSize];
+   _largeTitleHideShadow = newScreenProps.largeTitleHideShadow;
++  _largeTitleInline = newScreenProps.largeTitleInline;
+   _largeTitleBackgroundColor = RCTUIColorFromSharedColor(newScreenProps.largeTitleBackgroundColor);
+ 
+   _backTitle = RCTNSStringFromStringNilIfEmpty(newScreenProps.backTitle);
+@@ -1292,6 +1294,7 @@ RCT_EXPORT_VIEW_PROPERTY(largeTitleFontWeight, NSString)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleColor, UIColor)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleBackgroundColor, UIColor)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleHideShadow, BOOL)
++RCT_EXPORT_VIEW_PROPERTY(largeTitleInline, BOOL)
+ RCT_EXPORT_VIEW_PROPERTY(hideBackButton, BOOL)
+ RCT_EXPORT_VIEW_PROPERTY(hideShadow, BOOL)
+ RCT_EXPORT_VIEW_PROPERTY(backButtonInCustomView, BOOL)
+diff --git a/lib/typescript/fabric/ScreenStackHeaderConfigNativeComponent.d.ts b/lib/typescript/fabric/ScreenStackHeaderConfigNativeComponent.d.ts
+index 1e40b7044765ef44a4a3c7dd6243b3f2dbcdf496..3e8dc2cd46ae17a3a38338b2091ae3d0e3e105bf 100644
+--- a/lib/typescript/fabric/ScreenStackHeaderConfigNativeComponent.d.ts
++++ b/lib/typescript/fabric/ScreenStackHeaderConfigNativeComponent.d.ts
+@@ -29,6 +29,7 @@ export interface NativeProps extends ViewProps {
+     largeTitleFontWeight?: string;
+     largeTitleBackgroundColor?: ColorValue;
+     largeTitleHideShadow?: boolean;
++    largeTitleInline?: boolean;
+     largeTitleColor?: ColorValue;
+     translucent?: boolean;
+     title?: string;
+diff --git a/lib/typescript/types.d.ts b/lib/typescript/types.d.ts
+index b197c162f00fd78159e4ee715b7740da87ecdf1f..1c3194d7c0913ef240fa56c71672ccdb166b72b5 100644
+--- a/lib/typescript/types.d.ts
++++ b/lib/typescript/types.d.ts
+@@ -683,6 +683,12 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
+      * Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+      */
+     largeTitleHideShadow?: boolean;
++    /**
++     * Boolean indicating whether large title should be displayed inline.
++     *
++     * @platform ios
++     */
++    largeTitleInline?: boolean;
+     /**
+      * Callback which is executed when screen header is attached
+      */
+diff --git a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+index fcbb2683cb438fe433edc7b3261041c75776d479..591c0bac5670251cb65e2a09d96899c1f04194f1 100644
+--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
++++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+@@ -58,6 +58,7 @@ export interface NativeProps extends ViewProps {
+   largeTitleFontWeight?: string;
+   largeTitleBackgroundColor?: ColorValue;
+   largeTitleHideShadow?: boolean;
++  largeTitleInline?: boolean;
+   largeTitleColor?: ColorValue;
+   translucent?: boolean;
+   title?: string;
+diff --git a/src/types.tsx b/src/types.tsx
+index a657c0f69f806e488697334680997507baa36078..ff9c4b0ea454878c87fa436a17193d47d1710f26 100644
+--- a/src/types.tsx
++++ b/src/types.tsx
+@@ -786,6 +786,12 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
+    * Boolean that allows for disabling drop shadow under navigation header when the edge of any scrollable content reaches the matching edge of the navigation bar.
+    */
+   largeTitleHideShadow?: boolean;
++  /**
++   * Boolean indicating whether large title should be displayed inline.
++   *
++   * @platform ios
++   */
++  largeTitleInline?: boolean;
+   /**
+    * Callback which is executed when screen header is attached
+    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,12 @@ overrides:
   '@radix-ui/react-visually-hidden': 1.2.4
 
 patchedDependencies:
+  '@react-navigation/native-stack@7.10.1':
+    hash: y2iizxa2t2taqzgka3v4kmibky
+    path: patches/@react-navigation__native-stack@7.10.1.patch
+  react-native-screens@4.23.0:
+    hash: vtvgp5w6bmoj2zv6lo4wpqycie
+    path: patches/react-native-screens@4.23.0.patch
   xcode@3.0.1:
     hash: kvggi4abfe6iel7wt6iiemonyq
     path: patches/xcode@3.0.1.patch
@@ -713,7 +719,7 @@ importers:
         version: 6.0.0(expo@55.0.0-preview.12)
       expo-router:
         specifier: 'catalog:'
-        version: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+        version: 55.0.0-preview.9(732a7prv3l4isorqeb4cuinj6u)
       expo-secure-store:
         specifier: 'catalog:'
         version: 55.0.7(expo@55.0.0-preview.12)
@@ -806,7 +812,7 @@ importers:
         version: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-screens:
         specifier: 'catalog:'
-        version: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+        version: 4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.3(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -5207,6 +5213,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -12449,7 +12456,7 @@ snapshots:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+      expo-router: 55.0.0-preview.9(732a7prv3l4isorqeb4cuinj6u)
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12787,7 +12794,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      expo-router: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+      expo-router: 55.0.0-preview.9(732a7prv3l4isorqeb4cuinj6u)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -14398,7 +14405,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
     dependencies:
       '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -14406,7 +14413,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -14433,7 +14440,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  '@react-navigation/native-stack@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+  '@react-navigation/native-stack@7.10.1(patch_hash=y2iizxa2t2taqzgka3v4kmibky)(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
     dependencies:
       '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -14441,7 +14448,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -17528,16 +17535,16 @@ snapshots:
       schema-utils: 4.3.3
       sf-symbols-typescript: 2.2.0
 
-  expo-router@55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva):
+  expo-router@55.0.0-preview.9(732a7prv3l4isorqeb4cuinj6u):
     dependencies:
       '@expo/log-box': 55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/schema-utils': 55.0.2
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-tabs': 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      '@react-navigation/native-stack': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native-stack': 7.10.1(patch_hash=y2iizxa2t2taqzgka3v4kmibky)(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
@@ -17557,7 +17564,7 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
@@ -20384,7 +20391,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
 
-  react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+  react-native-screens@4.23.0(patch_hash=vtvgp5w6bmoj2zv6lo4wpqycie)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-freeze: 1.0.4(react@19.2.0)


### PR DESCRIPTION
### Motivation
- Enable showing large navigation titles inline on iOS by exposing a `largeTitleInline` / `headerLargeTitleInline` option and wiring it through JS, types, and native code.

### Description
- Add patches for `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0` and register them in `package.json` and `pnpm-lock.yaml`.
- Expose a new boolean option `headerLargeTitleInline` / `largeTitleInline` in JS/TS APIs and propagate it in `useHeaderConfigProps` to the runtime config as `largeTitleInline`.
- Add TypeScript typings for the new option in `types.d.ts`, `src/types.tsx`, and `lib/typescript` artifacts and update the native component props in `ScreenStackHeaderConfigNativeComponent`.
- Update iOS native header configuration (`RNSScreenStackHeaderConfig.h` / `.mm`) to store and apply `_largeTitleInline` and export the `largeTitleInline` view property, and change `largeTitleDisplayMode` logic to respect the inline flag.

### Testing
- Ran TypeScript type checks with `pnpm -w -s tsc --noEmit`, which succeeded.
- Performed a workspace install and build with `pnpm -w install` and `pnpm -w -s build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94522dd08832a83d841e82c72f326)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for inline large navigation titles on iOS via a new `headerLargeTitleInline`/`largeTitleInline` option. Also applies the option in the Expo app for Feed and Following tabs.

- **New Features**
  - Adds `headerLargeTitleInline` (JS/TS) → propagates as `largeTitleInline` on iOS; updates types and native props.
  - iOS: keeps `prefersLargeTitles`; sets `UINavigationItem.largeTitleDisplayMode` to Never when inline is true (iOS-only mapping).
  - Expo app: enables `headerLargeTitleInline: true` in Feed and Following tab layouts.

- **Dependencies**
  - Patches `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0` and registers them in package files.

<sup>Written for commit 428a314ebe8ac8a2dd12013b16a9d942168f2719. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `headerLargeTitleInline` / `largeTitleInline` support for iOS native stack navigation by shipping two pnpm patches against `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0`. The feature is wired end-to-end: JS/TS types → `useHeaderConfigProps` → Fabric and Paper native props → Objective-C header config, and is immediately consumed in the `feed` and `following` tab layouts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the patches are self-contained, the lock file is consistent, and no regressions are introduced on Android (guarded by Platform.OS === 'ios').

All changes are additive and opt-in. The iOS UIKit logic (largeTitleDisplayMode = Never for inline display) is correct. Both Fabric and Paper native architectures are covered. Default BOOL value of false preserves existing behaviour for screens that don't set the flag. No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patches/react-native-screens@4.23.0.patch | Adds `largeTitleInline` BOOL property to iOS native header config; correctly sets `largeTitleDisplayMode = Never` (inline) when the flag is true, and exports it for both Fabric and Paper architectures. |
| patches/@react-navigation__native-stack@7.10.1.patch | Exposes `headerLargeTitleInline` in JS/TS types and propagates it as `largeTitleInline` (iOS-only guard) through `useHeaderConfigProps` in both source and compiled artifacts. |
| apps/expo/src/app/(tabs)/feed/_layout.tsx | Adds `headerLargeTitleInline: true` to the feed stack screen options alongside the existing `headerLargeTitle: true`. |
| apps/expo/src/app/(tabs)/following/_layout.tsx | Adds `headerLargeTitleInline: true` to the following stack screen options alongside the existing `headerLargeTitle: true`. |
| package.json | Registers the two new patch entries for `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0` under `patchedDependencies`. |
| pnpm-lock.yaml | Lock file updated to include patch hashes for the two new patches and propagated correctly through all dependent snapshot entries. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["headerLargeTitle: true\nheaderLargeTitleInline: true\n(JS/TS — NativeStackNavigationOptions)"] --> B["useHeaderConfigProps\n(patched @react-navigation/native-stack)"]
    B --> C{"Platform.OS === 'ios'\n&& headerLargeTitleInline === true"}
    C -- "true" --> D["largeTitleInline: true\n→ RNSScreenStackHeaderConfig"]
    C -- "false" --> E["largeTitleInline: false\n→ RNSScreenStackHeaderConfig"]
    D --> F{"config.largeTitle?"}
    E --> F
    F -- "true + largeTitleInline=true" --> G["prefersLargeTitles = YES\nlargeTitleDisplayMode = Never\n(inline / standard nav bar title)"]
    F -- "true + largeTitleInline=false" --> H["prefersLargeTitles = YES\nlargeTitleDisplayMode = Always\n(expanded large title)"]
    F -- "false" --> I["largeTitleDisplayMode = Never"]
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): inline all existing headerLa..."](https://github.com/jaronheard/soonlist-turbo/commit/428a314ebe8ac8a2dd12013b16a9d942168f2719) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29366645)</sub>

<!-- /greptile_comment -->