### PR TITLE
Patch native stack + screens to support iOS inline large titles (headerLargeTitleInline)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
       "@radix-ui/react-visually-hidden": "1.2.4"
     },
     "patchedDependencies": {
-      "xcode@3.0.1": "patches/xcode@3.0.1.patch"
+      "xcode@3.0.1": "patches/xcode@3.0.1.patch",
+      "@react-navigation/native-stack@7.10.1": "patches/@react-navigation__native-stack@7.10.1.patch",
+      "react-native-screens@4.23.0": "patches/react-native-screens@4.23.0.patch"
     },
     "onlyBuiltDependencies": [
       "@clerk/shared",

--- a/patches/@react-navigation__native-stack@7.10.1.patch
+++ b/patches/@react-navigation__native-stack@7.10.1.patch
@@ -1,0 +1,95 @@
+diff --git a/lib/module/views/useHeaderConfigProps.js b/lib/module/views/useHeaderConfigProps.js
+index 492390b5fad0e48d8f25f11179935754f8402f75..1e4887b144d669790e505680cf8fbe94b244196b 100644
+--- a/lib/module/views/useHeaderConfigProps.js
++++ b/lib/module/views/useHeaderConfigProps.js
+@@ -125,6 +125,7 @@ export function useHeaderConfigProps({
+   headerLargeStyle,
+   headerLargeTitle: headerLargeTitleDeprecated,
+   headerLargeTitleEnabled = headerLargeTitleDeprecated,
++  headerLargeTitleInline,
+   headerLargeTitleShadowVisible,
+   headerLargeTitleStyle,
+   headerBackground,
+@@ -330,6 +331,7 @@ export function useHeaderConfigProps({
+     hideBackButton: headerBackVisible === false,
+     hideShadow: headerShadowVisible === false || headerBackground != null || headerTransparent && headerShadowVisible !== true,
+     largeTitle: headerLargeTitleEnabled,
++    largeTitleInline: headerLargeTitleInline,
+     largeTitleBackgroundColor,
+     largeTitleColor,
+     largeTitleFontFamily,
+diff --git a/lib/typescript/src/types.d.ts b/lib/typescript/src/types.d.ts
+index 5bbdb198f6392171e42c57ceb7153395477d8c2f..44b8cf5ccf8b34831e97740d95d48eeb5c8f4e51 100644
+--- a/lib/typescript/src/types.d.ts
++++ b/lib/typescript/src/types.d.ts
+@@ -205,6 +205,16 @@ export type NativeStackNavigationOptions = {
+      * @deprecated Use `headerLargeTitleEnabled` instead.
+      */
+     headerLargeTitle?: boolean;
++    /**
++     * Whether to display large titles inline in the navigation bar on iOS 26+.
++     *
++     * This keeps the large title anchored in the toolbar instead of reserving extra space below it.
++     *
++     * Only supported on iOS.
++     *
++     * @platform ios
++     */
++    headerLargeTitleInline?: boolean;
+     /**
+      * Whether drop shadow of header is visible when a large title is shown.
+      *
+diff --git a/lib/typescript/src/views/useHeaderConfigProps.d.ts b/lib/typescript/src/views/useHeaderConfigProps.d.ts
+index 44e9bdd3be5ef4819c3438e5bbf47c0ceac01013..f43a959df4170c3958277b2c2193df8a1b34e8c3 100644
+--- a/lib/typescript/src/views/useHeaderConfigProps.d.ts
++++ b/lib/typescript/src/views/useHeaderConfigProps.d.ts
+@@ -10,6 +10,6 @@ type Props = NativeStackNavigationOptions & {
+     } | undefined;
+     route: Route<string>;
+ };
+-export declare function useHeaderConfigProps({ headerBackIcon, headerBackImageSource, headerBackButtonDisplayMode, headerBackButtonMenuEnabled, headerBackTitle, headerBackTitleStyle, headerBackVisible, headerShadowVisible, headerLargeStyle, headerLargeTitle: headerLargeTitleDeprecated, headerLargeTitleEnabled, headerLargeTitleShadowVisible, headerLargeTitleStyle, headerBackground, headerLeft, headerRight, headerShown, headerStyle, headerBlurEffect, headerTintColor, headerTitle, headerTitleAlign, headerTitleStyle, headerTransparent, headerSearchBarOptions, headerTopInsetEnabled, headerBack, route, title, unstable_headerLeftItems: headerLeftItems, unstable_headerRightItems: headerRightItems, }: Props): ScreenStackHeaderConfigProps;
++export declare function useHeaderConfigProps({ headerBackIcon, headerBackImageSource, headerBackButtonDisplayMode, headerBackButtonMenuEnabled, headerBackTitle, headerBackTitleStyle, headerBackVisible, headerShadowVisible, headerLargeStyle, headerLargeTitle: headerLargeTitleDeprecated, headerLargeTitleEnabled, headerLargeTitleInline, headerLargeTitleShadowVisible, headerLargeTitleStyle, headerBackground, headerLeft, headerRight, headerShown, headerStyle, headerBlurEffect, headerTintColor, headerTitle, headerTitleAlign, headerTitleStyle, headerTransparent, headerSearchBarOptions, headerTopInsetEnabled, headerBack, route, title, unstable_headerLeftItems: headerLeftItems, unstable_headerRightItems: headerRightItems, }: Props): ScreenStackHeaderConfigProps;
+ export {};
+ //# sourceMappingURL=useHeaderConfigProps.d.ts.map
+\ No newline at end of file
+diff --git a/src/types.tsx b/src/types.tsx
+index f01dbddb99c046a50ff6385d02ef55c22502f40d..27702afa2d913c9d30aff80d6ed79bad6a0fbbe0 100644
+--- a/src/types.tsx
++++ b/src/types.tsx
+@@ -249,6 +249,16 @@ export type NativeStackNavigationOptions = {
+    * @deprecated Use `headerLargeTitleEnabled` instead.
+    */
+   headerLargeTitle?: boolean;
++  /**
++   * Whether to display large titles inline in the navigation bar on iOS 26+.
++   *
++   * This keeps the large title anchored in the toolbar instead of reserving extra space below it.
++   *
++   * Only supported on iOS.
++   *
++   * @platform ios
++   */
++  headerLargeTitleInline?: boolean;
+   /**
+    * Whether drop shadow of header is visible when a large title is shown.
+    *
+diff --git a/src/views/useHeaderConfigProps.tsx b/src/views/useHeaderConfigProps.tsx
+index 14a00939c903b735314ea2cc934ed1918f4f87de..bd2f045a2ffc19c47fea55fdb7325177a5fd46a1 100644
+--- a/src/views/useHeaderConfigProps.tsx
++++ b/src/views/useHeaderConfigProps.tsx
+@@ -176,6 +176,7 @@ export function useHeaderConfigProps({
+   headerLargeStyle,
+   headerLargeTitle: headerLargeTitleDeprecated,
+   headerLargeTitleEnabled = headerLargeTitleDeprecated,
++  headerLargeTitleInline,
+   headerLargeTitleShadowVisible,
+   headerLargeTitleStyle,
+   headerBackground,
+@@ -483,6 +484,7 @@ export function useHeaderConfigProps({
+       headerBackground != null ||
+       (headerTransparent && headerShadowVisible !== true),
+     largeTitle: headerLargeTitleEnabled,
++    largeTitleInline: headerLargeTitleInline,
+     largeTitleBackgroundColor,
+     largeTitleColor,
+     largeTitleFontFamily,

--- a/patches/react-native-screens@4.23.0.patch
+++ b/patches/react-native-screens@4.23.0.patch
@@ -1,0 +1,67 @@
+diff --git a/ios/RNSScreenStackHeaderConfig.h b/ios/RNSScreenStackHeaderConfig.h
+index d5ea95f556a55ad2bd68626fc0f653c2d9bc24d4..5937586bd123d6896e17fb898c589a3d3a7fc4d5 100644
+--- a/ios/RNSScreenStackHeaderConfig.h
++++ b/ios/RNSScreenStackHeaderConfig.h
+@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
+ @property (nonatomic, retain) UIColor *backgroundColor;
+ @property (nonatomic, retain) UIColor *color;
+ @property (nonatomic) BOOL largeTitle;
++@property (nonatomic) BOOL largeTitleInline;
+ @property (nonatomic, retain) NSString *largeTitleFontFamily;
+ @property (nonatomic, retain) NSNumber *largeTitleFontSize;
+ @property (nonatomic, retain) NSString *largeTitleFontWeight;
+diff --git a/ios/RNSScreenStackHeaderConfig.mm b/ios/RNSScreenStackHeaderConfig.mm
+index 3270127a09a05af656566009ee6c4437590bb435..86617647ad4fc7706bd6cacea451608f83f53343 100644
+--- a/ios/RNSScreenStackHeaderConfig.mm
++++ b/ios/RNSScreenStackHeaderConfig.mm
+@@ -591,8 +591,20 @@ RNS_IGNORE_SUPER_CALL_END
+   if (config.largeTitle) {
+     navctr.navigationBar.prefersLargeTitles = YES;
+   }
+-  navitem.largeTitleDisplayMode =
+-      config.largeTitle ? UINavigationItemLargeTitleDisplayModeAlways : UINavigationItemLargeTitleDisplayModeNever;
++  if (config.largeTitle) {
++#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
++    if (@available(iOS 26.0, *)) {
++      navitem.largeTitleDisplayMode =
++          config.largeTitleInline ? UINavigationItemLargeTitleDisplayModeInlineLarge : UINavigationItemLargeTitleDisplayModeAlways;
++    } else {
++      navitem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
++    }
++#else
++    navitem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
++#endif
++  } else {
++    navitem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
++  }
+ #endif
+ 
+   UINavigationBarAppearance *appearance = [self buildAppearance:vc withConfig:config];
+@@ -1127,6 +1139,7 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
+   _hideShadow = newScreenProps.hideShadow;
+ 
+   _largeTitle = newScreenProps.largeTitle;
++  _largeTitleInline = newScreenProps.largeTitleInline;
+   if (newScreenProps.largeTitleFontFamily != oldScreenProps.largeTitleFontFamily) {
+     _largeTitleFontFamily = RCTNSStringFromStringNilIfEmpty(newScreenProps.largeTitleFontFamily);
+   }
+@@ -1286,6 +1299,7 @@ RCT_EXPORT_VIEW_PROPERTY(blurEffect, RNSBlurEffectStyle)
+ RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
+ RCT_EXPORT_VIEW_PROPERTY(direction, UISemanticContentAttribute)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitle, BOOL)
++RCT_EXPORT_VIEW_PROPERTY(largeTitleInline, BOOL)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleFontFamily, NSString)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleFontSize, NSNumber)
+ RCT_EXPORT_VIEW_PROPERTY(largeTitleFontWeight, NSString)
+diff --git a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+index fcbb2683cb438fe433edc7b3261041c75776d479..21ff24ec23b2ee8f7dac217a438564eb3595f948 100644
+--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
++++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+@@ -53,6 +53,7 @@ export interface NativeProps extends ViewProps {
+   hidden?: boolean;
+   hideShadow?: boolean;
+   largeTitle?: boolean;
++  largeTitleInline?: boolean;
+   largeTitleFontFamily?: string;
+   largeTitleFontSize?: CT.Int32;
+   largeTitleFontWeight?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,12 @@ overrides:
   '@radix-ui/react-visually-hidden': 1.2.4
 
 patchedDependencies:
+  '@react-navigation/native-stack@7.10.1':
+    hash: ww6kvzu7lvcmp3abvnlavgudba
+    path: patches/@react-navigation__native-stack@7.10.1.patch
+  react-native-screens@4.23.0:
+    hash: oyjxmekeo53d44su5gbrxzr6yi
+    path: patches/react-native-screens@4.23.0.patch
   xcode@3.0.1:
     hash: kvggi4abfe6iel7wt6iiemonyq
     path: patches/xcode@3.0.1.patch
@@ -713,7 +719,7 @@ importers:
         version: 6.0.0(expo@55.0.0-preview.12)
       expo-router:
         specifier: 'catalog:'
-        version: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+        version: 55.0.0-preview.9(ex3t5ipxrzpexhxlb5idqv35ca)
       expo-secure-store:
         specifier: 'catalog:'
         version: 55.0.7(expo@55.0.0-preview.12)
@@ -806,7 +812,7 @@ importers:
         version: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-screens:
         specifier: 'catalog:'
-        version: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+        version: 4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.3(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -5202,11 +5208,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5587,7 +5594,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
@@ -12449,7 +12456,7 @@ snapshots:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+      expo-router: 55.0.0-preview.9(ex3t5ipxrzpexhxlb5idqv35ca)
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12787,7 +12794,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      expo-router: 55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva)
+      expo-router: 55.0.0-preview.9(ex3t5ipxrzpexhxlb5idqv35ca)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -14347,7 +14354,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.83.3
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -14398,7 +14405,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+  '@react-navigation/bottom-tabs@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
     dependencies:
       '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -14406,7 +14413,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
@@ -14433,7 +14440,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
 
-  '@react-navigation/native-stack@7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
+  '@react-navigation/native-stack@7.10.1(patch_hash=ww6kvzu7lvcmp3abvnlavgudba)(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)':
     dependencies:
       '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -14441,7 +14448,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
@@ -17528,16 +17535,16 @@ snapshots:
       schema-utils: 4.3.3
       sf-symbols-typescript: 2.2.0
 
-  expo-router@55.0.0-preview.9(wemhwxreivcbfahvcu5xpeebva):
+  expo-router@55.0.0-preview.9(ex3t5ipxrzpexhxlb5idqv35ca):
     dependencies:
       '@expo/log-box': 55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.0-preview.12)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/schema-utils': 55.0.2
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.0)
       '@radix-ui/react-tabs': 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      '@react-navigation/native-stack': 7.10.1(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native-stack': 7.10.1(patch_hash=ww6kvzu7lvcmp3abvnlavgudba)(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
@@ -17557,7 +17564,7 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       semver: 7.6.3
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
@@ -19118,6 +19125,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.83.3:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-cache: 0.83.3
+      metro-core: 0.83.3
+      metro-runtime: 0.83.3
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   metro-config@0.83.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
@@ -20384,7 +20404,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
 
-  react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
+  react-native-screens@4.23.0(patch_hash=oyjxmekeo53d44su5gbrxzr6yi)(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-freeze: 1.0.4(react@19.2.0)


### PR DESCRIPTION
### Motivation
- Enable the new iOS 26 "inline large title" behavior (Apple's `InlineLarge` title display) for the Expo app by exposing a boolean option that mirrors the iOS API and avoids reserved vertical space below the toolbar. 

### Description
- Added a new screen option `headerLargeTitleInline?: boolean` to `@react-navigation/native-stack` and forwarded it through `useHeaderConfigProps` as `largeTitleInline`. 
- Patched `react-native-screens` to accept a new native header config property `largeTitleInline` (JS/TS and Fabric/native component bindings). 
- Updated iOS native logic in `RNSScreenStackHeaderConfig.mm` to use `UINavigationItemLargeTitleDisplayModeInlineLarge` on iOS 26+ when `largeTitleInline` is enabled, with safe fallbacks to previous behavior on older iOS versions. 
- Registered both patches in `package.json` and the lockfile so `pnpm` applies them via `patchedDependencies` (created `patches/@react-navigation__native-stack@7.10.1.patch` and `patches/react-native-screens@4.23.0.patch`).

### Testing
- Confirmed patch files and registration with `git` commit (created patch files and updated `package.json` / `pnpm-lock.yaml`).
- Verified the patched props exist in installed packages with repository searches (e.g. `rg -n "headerLargeTitleInline|largeTitleInline" node_modules/...`).
- Ran repository checks `pnpm lint:fix && pnpm check`, which aborted with pre-existing lint errors in `apps/expo` unrelated to these patches (so lint/`check` did not pass end-to-end but the patch application and commits succeeded). 
- Executed `pnpm patch-commit` for both packages successfully so the patches will be applied on installs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97e16afd4832ab9462236fa9eda0b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iOS 26 inline large title support to native stack headers via a new `headerLargeTitleInline` option. Large titles can now stay inline in the toolbar without reserving extra vertical space, with safe fallbacks on older iOS.

- **New Features**
  - Adds `headerLargeTitleInline?: boolean` to `@react-navigation/native-stack` and forwards it as `largeTitleInline` to `react-native-screens`.
  - On iOS 26+, sets `UINavigationItemLargeTitleDisplayModeInlineLarge` when enabled; falls back to previous modes on older iOS.
  - Registers patches via `patchedDependencies` for `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0`.

- **Migration**
  - Opt-in per screen: set `headerLargeTitleEnabled: true` and `headerLargeTitleInline: true` (iOS only).

<sup>Written for commit a27d69e0e01a7baa0194209c1ad17f5565f42a0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `headerLargeTitleInline` support for iOS 26's `InlineLarge` title display mode by patching both `@react-navigation/native-stack@7.10.1` and `react-native-screens@4.23.0` via pnpm's `patchedDependencies` mechanism. The JS/TS surface, Fabric component bindings, and native Objective-C logic are all updated in concert, with appropriate compile-time and runtime guards for older SDKs.

- The `#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)` macro must be confirmed to exist in `react-native-screens@4.23.0`'s headers — if it's missing the build will fail at compile time regardless of the runtime `@available` guard.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the RNS_IPHONE_OS_VERSION_AVAILABLE macro availability is confirmed in the 4.23.0 source tree.

The P1 concern around RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) is a compile-time risk: if that macro is not defined in react-native-screens 4.23.0, the iOS build will fail. All other logic is well-structured with correct fallbacks.

patches/react-native-screens@4.23.0.patch — specifically the #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) compile guard.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patches/react-native-screens@4.23.0.patch | Adds largeTitleInline BOOL property to the iOS header config, gated by RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) compile-time macro and @available(iOS 26.0, *) runtime check; also extends Fabric TypeScript interface. |
| patches/@react-navigation__native-stack@7.10.1.patch | Adds headerLargeTitleInline?: boolean to NativeStackNavigationOptions type and threads it through useHeaderConfigProps as largeTitleInline. |
| package.json | Registers the two new patch entries in patchedDependencies alongside the existing xcode@3.0.1 patch. |
| pnpm-lock.yaml | Lockfile updated to reflect patched-dependency hashes and cascading snapshot renames; also picks up minor unrelated changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Screen option\nheaderLargeTitleInline?: boolean"] -->|"useHeaderConfigProps patch"| B["largeTitleInline prop\npassed to native component"]
    B -->|"Fabric codegen"| C["C++ newScreenProps.largeTitleInline"]
    C -->|"_largeTitleInline assignment"| D{"config.largeTitle?"}
    D -- "false" --> E["largeTitleDisplayMode = Never"]
    D -- "true" --> F{"RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) + @available"}
    F -- "iOS 26+ SDK + runtime" --> G{"config.largeTitleInline?"}
    G -- "true" --> H["InlineLarge mode"]
    G -- "false" --> I["Always mode"]
    F -- "older" --> I
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: patches/react-native-screens@4.23.0.patch
Line: 25-36

Comment:
**Verify `RNS_IPHONE_OS_VERSION_AVAILABLE` macro exists in 4.23.0**

The `#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)` compile-time guard assumes this macro is already defined somewhere in `react-native-screens@4.23.0`. If it isn't, the build will fail with a preprocessor error regardless of the `@available(iOS 26.0, *)` runtime check. Worth confirming the macro definition exists (e.g. in `RNSUtils.h` or a shared header) before this patch ships to CI.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: patches/@react-navigation__native-stack@7.10.1.patch
Line: 25-34

Comment:
**Document dependency on `headerLargeTitleEnabled`**

The JSDoc for `headerLargeTitleInline` doesn't mention that it has no effect unless `headerLargeTitleEnabled: true` is also set. In the native layer, `largeTitleInline` is only read inside the `if (config.largeTitle)` branch. A quick note in the description would prevent confusion for callers who set this prop in isolation.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["patch native stack to support iOS inline..."](https://github.com/jaronheard/soonlist-turbo/commit/a27d69e0e01a7baa0194209c1ad17f5565f42a0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29375185)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->