### PR TITLE
Sync event follows with personal lists and add backfill migration

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillFollowedEventsToPersonalLists from "../migrations/backfillFollowedEventsToPersonalLists.js";
 import type * as migrations_backfillListFeeds from "../migrations/backfillListFeeds.js";
 import type * as migrations_backfillSourceListId from "../migrations/backfillSourceListId.js";
 import type * as migrations_backfillUserFeedVisibility from "../migrations/backfillUserFeedVisibility.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillFollowedEventsToPersonalLists": typeof migrations_backfillFollowedEventsToPersonalLists;
   "migrations/backfillListFeeds": typeof migrations_backfillListFeeds;
   "migrations/backfillSourceListId": typeof migrations_backfillSourceListId;
   "migrations/backfillUserFeedVisibility": typeof migrations_backfillUserFeedVisibility;

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -1,0 +1,72 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
+import { getOrCreatePersonalList } from "../lists";
+
+/**
+ * Batch migration: ensure each eventFollow has a matching membership in the
+ * follower's personal list.
+ */
+export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    linked: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("eventFollows")
+      .paginate({ numItems: batchSize, cursor });
+
+    let linked = 0;
+
+    for (const follow of result.page) {
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", follow.eventId))
+        .first();
+
+      if (!event) {
+        continue;
+      }
+
+      const personalList = await getOrCreatePersonalList(ctx, follow.userId);
+      const existingLink = await ctx.db
+        .query("eventToLists")
+        .withIndex("by_event_and_list", (q) =>
+          q.eq("eventId", follow.eventId).eq("listId", personalList.id),
+        )
+        .first();
+
+      if (existingLink) {
+        continue;
+      }
+
+      await ctx.db.insert("eventToLists", {
+        eventId: follow.eventId,
+        listId: personalList.id,
+      });
+      await addEventToListFeedInline(ctx, follow.eventId, personalList.id);
+      await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
+        eventId: follow.eventId,
+        listId: personalList.id,
+      });
+
+      linked++;
+    }
+
+    return {
+      processed: result.page.length,
+      linked,
+      nextCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
+  },
+});

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -54,12 +54,28 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         listId: personalList.id,
       });
       await addEventToListFeedInline(ctx, follow.eventId, personalList.id);
-      await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
-        eventId: follow.eventId,
-        listId: personalList.id,
-      });
+
+      // Schedule feed population in a separate transaction to avoid
+      // hitting transaction limits when there are many followers
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addEventToListFollowersFeeds,
+        {
+          eventId: follow.eventId,
+          listId: personalList.id,
+        },
+      );
 
       linked++;
+    }
+
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfillFollowedEventsToPersonalLists
+          .backfillFollowedEventsToPersonalListsBatch,
+        { cursor: result.continueCursor, batchSize },
+      );
     }
 
     return {
@@ -68,5 +84,25 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
       nextCursor: result.continueCursor,
       isDone: result.isDone,
     };
+  },
+});
+
+/**
+ * Orchestrator: kicks off the batched backfill. Subsequent batches
+ * self-schedule until `isDone`.
+ */
+export const backfillFollowedEventsToPersonalLists = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { batchSize }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.migrations.backfillFollowedEventsToPersonalLists
+        .backfillFollowedEventsToPersonalListsBatch,
+      { cursor: null, batchSize: batchSize ?? 100 },
+    );
+    return null;
   },
 });

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1416,11 +1416,16 @@ export async function addEventToList(
     // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Add event to followers' feeds
-    await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
-      eventId,
-      listId,
-    });
+    // Schedule follower feed fan-out in a separate transaction to avoid
+    // hitting transaction limits when there are many followers.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.feedHelpers.addEventToListFollowersFeeds,
+      {
+        eventId,
+        listId,
+      },
+    );
   }
 }
 
@@ -1485,8 +1490,10 @@ export async function removeEventFromList(
     // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Remove event from followers' feeds
-    await ctx.runMutation(
+    // Schedule follower feed fan-out in a separate transaction to avoid
+    // hitting transaction limits when there are many followers.
+    await ctx.scheduler.runAfter(
+      0,
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
         eventId,

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1259,6 +1259,11 @@ export async function followEvent(
         userId,
         eventId,
       });
+
+      // Keep personal list membership in sync with follows so subscribers of
+      // this user's Soonlist see the same public events.
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await addEventToList(ctx, eventId, personalList.id, userId);
     }
   }
 
@@ -1294,6 +1299,12 @@ export async function unfollowEvent(
       if (isCreator) {
         return await getEventById(ctx, eventId);
       }
+
+      // Remove followed events from the user's personal list so list
+      // subscribers lose this source unless the event still exists in another
+      // followed list.
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await removeEventFromList(ctx, eventId, personalList.id, userId);
 
       const listFollows = await ctx.db
         .query("listFollows")

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1416,16 +1416,11 @@ export async function addEventToList(
     // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Schedule follower feed fan-out in a separate transaction to avoid
-    // hitting transaction limits when there are many followers.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.feedHelpers.addEventToListFollowersFeeds,
-      {
-        eventId,
-        listId,
-      },
-    );
+    // Add event to followers' feeds
+    await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
+      eventId,
+      listId,
+    });
   }
 }
 
@@ -1490,10 +1485,8 @@ export async function removeEventFromList(
     // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Schedule follower feed fan-out in a separate transaction to avoid
-    // hitting transaction limits when there are many followers.
-    await ctx.scheduler.runAfter(
-      0,
+    // Remove event from followers' feeds
+    await ctx.runMutation(
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
         eventId,


### PR DESCRIPTION
### Motivation

- Ensure that when a user follows or unfollows an event their personal list is kept in sync so subscribers to that user's list see the same public events.
- Backfill existing `eventFollows` so each follow has a corresponding membership in the follower's personal list.

### Description

- Added `backfillFollowedEventsToPersonalListsBatch` migration in `migrations/backfillFollowedEventsToPersonalLists.ts` which paginates `eventFollows`, creates or finds the follower's personal list via `getOrCreatePersonalList`, inserts missing `eventToLists` links, and updates feeds via `addEventToListFeedInline` and the `addEventToListFollowersFeeds` mutation.
- Updated `followEvent` in `model/events.ts` to create a personal list membership by calling `getOrCreatePersonalList` and `addEventToList` after adding the follow and user feed entry.
- Updated `unfollowEvent` in `model/events.ts` to remove the personal list membership by calling `getOrCreatePersonalList` and `removeEventFromList` during unfollow processing, preserving existing checks for creator and other followed lists.
- The migration and follow/unfollow changes avoid creating duplicate `eventToLists` entries by checking existing links with indexed queries.

### Testing

- Ran the project's automated backend test suite against these changes and all tests passed.
- Executed the new migration locally on a smaller dataset to validate pagination and linking behavior and observed expected linking results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e974810188832a8e1b790971ef8370)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs event follows/unfollows with each user's personal Soonlist so subscribers see the same public events. Adds a batched, self-scheduling backfill that links existing follows and fans out updates to followers without hitting transaction limits.

- **New Features**
  - Keep personal list in sync on follow/unfollow so Soonlist subscribers see the same public events.

- **Migration**
  - Added backfillFollowedEventsToPersonalListsBatch to paginate eventFollows, link missing eventToLists with indexed checks, and return processed/linked/nextCursor/isDone; idempotent and resumable.
  - Fan-out to followers runs via ctx.scheduler.runAfter per link, and batches self-chain; backfillFollowedEventsToPersonalLists kicks off the first batch.

<sup>Written for commit af2df99f7ab33111ee8b6a7e5d72bc01e7db66df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs direct event follows/unfollows with each user's personal Soonlist so list subscribers see the same public events as the follower, and adds a paginated backfill migration for existing `eventFollows` records.

- **P1 – migration transaction limits**: `ctx.runMutation(addEventToListFollowersFeeds)` is called inside the batch loop, running in the same transaction. Other places in the codebase (e.g. `lists.ts`, `feedHelpers.ts`) explicitly switched to `ctx.scheduler.runAfter(0, ...)` to avoid hitting Convex's per-transaction document limit when a list has many followers. The same issue applies here for every batch iteration.
- **P2 – no self-scheduling**: The migration returns `isDone`/`nextCursor` but doesn't schedule the next page itself, requiring external orchestration to run to completion.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the ctx.runMutation-in-loop issue in the migration, which can cause transaction limit failures for users with many followers.

The follow/unfollow changes in events.ts are correct and follow established patterns. The migration has one P1 issue: using ctx.runMutation instead of ctx.scheduler.runAfter inside the batch loop, which is inconsistent with existing codebase patterns that explicitly work around Convex transaction limits for this same mutation. Fixing this before running the migration on production data is important.

packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts — the ctx.runMutation call inside the loop should be changed to ctx.scheduler.runAfter(0, ...) to avoid transaction limits.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts | New batched migration that links existing eventFollows to personal lists; uses ctx.runMutation in a loop instead of ctx.scheduler.runAfter, risking transaction-limit failures for users with many followers, and lacks self-scheduling to chain batches automatically. |
| packages/backend/convex/model/events.ts | followEvent now adds to personal list via addEventToList (idempotent), and unfollowEvent removes from personal list before the existing list-follow check; both follow established patterns and look correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant FE as followEvent / unfollowEvent
    participant DB as Convex DB
    participant PL as getOrCreatePersonalList
    participant AE as addEventToList / removeEventFromList
    participant FF as addEventToListFollowersFeeds

    note over U,FF: followEvent
    U->>FE: followEvent(userId, eventId)
    FE->>DB: insert eventFollows
    FE->>DB: runMutation addEventToUserFeed
    FE->>PL: getOrCreatePersonalList(userId)
    PL-->>FE: personalList
    FE->>AE: addEventToList(eventId, personalList.id, userId)
    AE->>DB: insert eventToLists (if missing)
    AE->>FF: addEventToListFollowersFeeds

    note over U,FF: unfollowEvent
    U->>FE: unfollowEvent(userId, eventId)
    FE->>DB: delete eventFollows
    FE->>PL: getOrCreatePersonalList(userId)
    PL-->>FE: personalList
    FE->>AE: removeEventFromList(eventId, personalList.id, userId)
    AE->>DB: delete eventToLists
    FE->>DB: query listFollows (by_user)
    alt event in a followed list
        FE-->>U: return (keep user feed)
    else not in any followed list
        FE->>DB: delete userFeeds entry
        FE-->>U: return
    end

    note over U,FF: Backfill migration
    U->>DB: backfillFollowedEventsToPersonalListsBatch(cursor, batchSize)
    DB-->>U: page of eventFollows
    loop for each follow
        U->>PL: getOrCreatePersonalList(follow.userId)
        U->>DB: check eventToLists (by_event_and_list)
        alt no existing link
            U->>DB: insert eventToLists
            U->>FF: ctx.runMutation addEventToListFollowersFeeds
        end
    end
    U-->>U: return {processed, linked, nextCursor, isDone}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
Line: 57-60

Comment:
**`ctx.runMutation` vs `ctx.scheduler.runAfter` inconsistency can hit transaction limits**

`addEventToListFollowersFeeds` is called via `ctx.runMutation` inside a loop, meaning every call runs in the **same** outer mutation transaction. Other places in the codebase explicitly switched to `ctx.scheduler.runAfter(0, ...)` to avoid exceeding Convex's per-transaction document read/write limit when a list has many followers — see `lists.ts:1227–1230` ("hitting transaction limits when there are many followers") and `feedHelpers.ts:925–931`. In the migration, this call happens up to `batchSize` times per batch, multiplying the risk.

Use `ctx.scheduler.runAfter(0, ...)` here, consistent with those other callsites:

```ts
ctx.scheduler.runAfter(
  0,
  internal.feedHelpers.addEventToListFollowersFeeds,
  {
    eventId: follow.eventId,
    listId: personalList.id,
  },
);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
Line: 12-26

Comment:
**No self-scheduling mechanism to chain batches**

The mutation returns `isDone` and `nextCursor` but has no self-scheduling step (e.g. `ctx.scheduler.runAfter(0, ...)`) to automatically kick off the next page when `!isDone`. Without an external runner or a cron that loops until `isDone`, it is easy to run the first batch and forget to continue, leaving the backfill partially complete. Consider adding an internal scheduler call at the end of the handler, or document a required external runner alongside this export.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["add backfill for followed events in pers..."](https://github.com/jaronheard/soonlist-turbo/commit/914cf991a49ed16e7cb212899f738701a2b4158e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29375749)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->