### PR TITLE
fix(expo): use UINavigationItemLargeTitleDisplayModeInline for iOS 26 inline large titles

### DIFF
--- a/patches/react-native-screens@4.23.0.patch
+++ b/patches/react-native-screens@4.23.0.patch
@@ -24,7 +24,7 @@ index 3270127a09a05af656566009ee6c4437590bb435..86617647ad4fc7706bd6cacea451608f
 +#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 +    if (@available(iOS 26.0, *)) {
 +      navitem.largeTitleDisplayMode =
-+          config.largeTitleInline ? UINavigationItemLargeTitleDisplayModeInlineLarge : UINavigationItemLargeTitleDisplayModeAlways;
++          config.largeTitleInline ? UINavigationItemLargeTitleDisplayModeInline : UINavigationItemLargeTitleDisplayModeAlways;
 +    } else {
 +      navitem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeAlways;
 +    }


### PR DESCRIPTION
## Summary
- Fixes EAS Build failure against `iPhoneOS26.2.sdk`: `use of undeclared identifier 'UINavigationItemLargeTitleDisplayModeInlineLarge'; did you mean 'UINavigationItemLargeTitleDisplayModeInline'?`
- The iOS 26 inline large title enum case is `UINavigationItemLargeTitleDisplayModeInline` — the `InlineLarge` spelling used in #1051 does not exist in any iOS SDK.

## Background
#1051 added a patch to `react-native-screens@4.23.0` to expose iOS 26's inline large title mode. It compiled only because no builds against the iOS 26 SDK had run yet; Xcode rejected the hallucinated symbol the moment EAS picked it up.

Greptile's P1 review comment on #1051 correctly sensed there was a compile-time risk here, but attributed it to the `RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)` macro (which actually exists in `ios/utils/RNSDefines.h`). The real problem was two lines down.

## Test plan
- [ ] EAS Build completes (`iPhoneOS26.2.sdk`)
- [ ] On iOS 26 device, `headerLargeTitleEnabled: true` + `headerLargeTitleInline: true` renders inline large title
- [ ] On pre-iOS 26 device, falls back to `...Always` large title

---
_Generated by [Claude Code](https://claude.ai/code/session_018yaqZg3QGQ8DjSP9g7pK6G)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS 26 builds by using the correct enum `UINavigationItemLargeTitleDisplayModeInline` in the `react-native-screens@4.23.0` patch. Restores inline large title behavior on iOS 26 with clean fallback on older iOS versions.

- **Bug Fixes**
  - Replaced `UINavigationItemLargeTitleDisplayModeInlineLarge` with `UINavigationItemLargeTitleDisplayModeInline`.
  - EAS build now succeeds with `iPhoneOS26.2.sdk` (no undeclared identifier error).
  - On iOS 26, `headerLargeTitleEnabled: true` + `headerLargeTitleInline: true` shows inline large titles; older iOS uses `...Always`.

<sup>Written for commit 25f079bc420e535cd5b41145ce638e5e8d84aed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a single-character typo in the `react-native-screens@4.23.0` patch introduced in #1051: the non-existent symbol `UINavigationItemLargeTitleDisplayModeInlineLarge` is replaced with the correct `UINavigationItemLargeTitleDisplayModeInline` (value `3` in the iOS 26.2 SDK), unblocking EAS builds against `iPhoneOS26.2.sdk`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single targeted fix for a compile-time typo with no logic changes.

The change is a one-line correction of a non-existent Objective-C enum name to the confirmed-valid iOS 26.2 SDK symbol. No logic, behaviour, or API surface is altered; the only prior P1 risk (undeclared identifier causing build failure) is directly resolved.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patches/react-native-screens@4.23.0.patch | Replaces undeclared `UINavigationItemLargeTitleDisplayModeInlineLarge` with the correct iOS 26 SDK symbol `UINavigationItemLargeTitleDisplayModeInline`, fixing the EAS Build compile error. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["headerLargeTitleEnabled: true\n+ headerLargeTitleInline: true"] --> B{"iOS 26+?"}
    B -- Yes --> C["UINavigationItemLargeTitleDisplayModeInline\n✅ Inline large title (iOS 26 SDK value 3)"]
    B -- No --> D["UINavigationItemLargeTitleDisplayModeAlways\n✅ Fallback: always-large title"]
    E["❌ Before fix\nUINavigationItemLargeTitleDisplayModeInlineLarge\n(undeclared — EAS build failure)"] -. replaced by .-> C
```

<sub>Reviews (1): Last reviewed commit: ["fix(expo): use UINavigationItemLargeTitl..."](https://github.com/jaronheard/soonlist-turbo/commit/25f079bc420e535cd5b41145ce638e5e8d84aed2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29377628)</sub>

<!-- /greptile_comment -->