### PR TITLE
feat(expo): enable inline large titles on Feed & Following tabs

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/feed/_layout.tsx
@@ -14,6 +14,7 @@ export default function FeedLayout() {
       <Stack
         screenOptions={{
           headerLargeTitle: true,
+          headerLargeTitleInline: true,
           headerLargeTitleStyle: { color: "#5A32FB" },
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,

--- a/apps/expo/src/app/(tabs)/following/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/following/_layout.tsx
@@ -11,6 +11,7 @@ export default function FollowingLayout() {
       <Stack
         screenOptions={{
           headerLargeTitle: true,
+          headerLargeTitleInline: true,
           headerLargeTitleStyle: { color: "#5A32FB" },
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,


### PR DESCRIPTION
## Summary

- Adds `headerLargeTitleInline: true` to the `<Stack>` `screenOptions` for the **My Soonlist** (Feed) and **My Scene** (Following) tabs.
- On iOS 26+, this maps to `UINavigationItemLargeTitleDisplayModeInline` (wired up by #1051 / #1053), so the large title is anchored inside the toolbar and fades on scroll instead of reserving extra vertical space below the nav bar — the same behavior Apple's Wallet app uses on iOS 26.
- On older iOS versions the prop is a no-op and the title keeps falling back to `...DisplayModeAlways`.

## Why

The previous large-title layout left noticeable dead space at the top of these two tabs. Now that the native-stack patch exposes the inline option as a boolean prop, we can just opt in.

## Test plan

- [ ] Build the iOS dev client on an iOS 26 simulator/device.
- [ ] Open the **Feed** tab (My Soonlist): title should sit inline in the toolbar at rest, fade on scroll, and the right-side share + profile items should still be tappable.
- [ ] Open the **Following** tab (My Scene): same inline behavior, profile menu still works.
- [ ] Sanity check on iOS 18 that both titles still render as regular large titles (no regression).
- [ ] Public profile screen (`[username]`) is unchanged — it sets `headerLargeTitle: false`, so no inline opt-in needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `headerLargeTitleInline: true` to the `Stack` `screenOptions` for both the **Feed** (`My Soonlist`) and **Following** (`My Scene`) tab layouts. The change is symmetric, minimal, and correctly scoped — on iOS 26+ it opts into the inline large-title display mode, and on older iOS versions it is a no-op.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two-line change with no logic, data, or security implications.

Both files receive an identical, additive prop that is a no-op on unsupported OS versions. No existing props are removed or altered, and the change is fully symmetric across the two affected tabs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/feed/_layout.tsx | Adds `headerLargeTitleInline: true` to Stack screenOptions; straightforward opt-in to iOS 26 inline large-title behavior, no issues found. |
| apps/expo/src/app/(tabs)/following/_layout.tsx | Same `headerLargeTitleInline: true` addition as feed layout; symmetric and consistent change, no issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stack screenOptions] --> B{iOS version?}
    B -- "iOS 26+" --> C["headerLargeTitleInline: true\n→ UINavigationItemLargeTitleDisplayModeInline\nTitle anchored inline in toolbar, fades on scroll"]
    B -- "iOS < 26" --> D["headerLargeTitleInline ignored\n→ UINavigationItemLargeTitleDisplayModeAlways\nLarge title below nav bar (existing behavior)"]
    C --> E[Feed tab — My Soonlist]
    C --> F[Following tab — My Scene]
    D --> E
    D --> F
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): enable inline large titles o..."](https://github.com/jaronheard/soonlist-turbo/commit/54c4c2179f608ae97c18e2dfe7c3ad735cb9f4b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29382048)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable inline large titles on the Feed (My Soonlist) and Following (My Scene) tabs by setting `headerLargeTitleInline: true`, so on iOS 26 the title sits inside the toolbar and fades on scroll instead of reserving extra space. On older iOS, this is a no-op and the existing large-title behavior remains.

<sup>Written for commit 54c4c2179f608ae97c18e2dfe7c3ad735cb9f4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

