### PR TITLE
chore(backend): strip non-functional comments

### DIFF
--- a/packages/backend/convex/aggregates.ts
+++ b/packages/backend/convex/aggregates.ts
@@ -1,4 +1,3 @@
-
 import { TableAggregate } from "@convex-dev/aggregate";
 
 import type { DataModel } from "./_generated/dataModel";

--- a/packages/backend/convex/aggregates.ts
+++ b/packages/backend/convex/aggregates.ts
@@ -1,24 +1,12 @@
-/**
- * Aggregate definitions for efficient stats calculations
- *
- * This eliminates the need to fetch all user events and follows,
- * providing O(log(n)) lookups instead of O(n).
- */
 
 import { TableAggregate } from "@convex-dev/aggregate";
 
 import type { DataModel } from "./_generated/dataModel";
 import { components } from "./_generated/api";
 
-/**
- * Aggregate for events by creation time
- * Used for: capturesThisWeek, allTimeEvents count
- * Namespace: userId - separate data per user
- * SortKey: created_at timestamp
- */
 export const eventsByCreation = new TableAggregate<{
-  Namespace: string; // userId
-  Key: number; // created_at timestamp in ms
+  Namespace: string;
+  Key: number;
   DataModel: DataModel;
   TableName: "events";
 }>(components.eventsByCreation, {
@@ -26,15 +14,9 @@ export const eventsByCreation = new TableAggregate<{
   sortKey: (doc) => new Date(doc.created_at).getTime(),
 });
 
-/**
- * Aggregate for events by start time
- * Used for: upcomingEvents count
- * Namespace: userId - separate data per user
- * SortKey: startDateTime timestamp
- */
 export const eventsByStartTime = new TableAggregate<{
-  Namespace: string; // userId
-  Key: number; // startDateTime timestamp in ms
+  Namespace: string;
+  Key: number;
   DataModel: DataModel;
   TableName: "events";
 }>(components.eventsByStartTime, {
@@ -42,14 +24,8 @@ export const eventsByStartTime = new TableAggregate<{
   sortKey: (doc) => new Date(doc.startDateTime).getTime(),
 });
 
-/**
- * Aggregate for event follows
- * Used for: total follows count, upcoming followed events
- * Namespace: userId - separate data per user
- * SortKey: null (we only need counts)
- */
 export const eventFollowsAggregate = new TableAggregate<{
-  Namespace: string; // userId
+  Namespace: string;
   Key: null;
   DataModel: DataModel;
   TableName: "eventFollows";
@@ -58,15 +34,9 @@ export const eventFollowsAggregate = new TableAggregate<{
   sortKey: () => null,
 });
 
-/**
- * Aggregate for user feeds
- * Used for: counting upcoming/past events in a user's feed (own + followed)
- * Namespace: feedId - separate data per feed (user_${userId}, discover, etc.)
- * SortKey: hasEnded flag (0 for upcoming/false, 1 for past/true)
- */
 export const userFeedsAggregate = new TableAggregate<{
-  Namespace: string; // feedId (e.g., "user_${userId}")
-  Key: number; // hasEnded flag as number (0 or 1)
+  Namespace: string;
+  Key: number;
   DataModel: DataModel;
   TableName: "userFeeds";
 }>(components.userFeedsAggregate, {
@@ -74,14 +44,8 @@ export const userFeedsAggregate = new TableAggregate<{
   sortKey: (doc) => (doc.hasEnded ? 1 : 0),
 });
 
-/**
- * Aggregate for list follows
- * Used for: efficient follower counts per list
- * Namespace: listId - separate data per list
- * SortKey: null (we only need counts)
- */
 export const listFollowsAggregate = new TableAggregate<{
-  Namespace: string; // listId
+  Namespace: string;
   Key: null;
   DataModel: DataModel;
   TableName: "listFollows";

--- a/packages/backend/convex/ai.ts
+++ b/packages/backend/convex/ai.ts
@@ -10,17 +10,12 @@ import { eventDataValidator } from "./events";
 import * as AI from "./model/ai";
 import { fetchAndProcessEvent, validateJinaResponse } from "./model/aiHelpers";
 
-// Create workflow manager instance
 const workflow = new WorkflowManager(components.workflow);
 
-// Validators for complex types
 const listValidator = v.object({
   value: v.string(),
 });
 
-/**
- * Create event from base64 image using workflow
- */
 export const eventFromImageBase64ThenCreate = mutation({
   args: {
     base64Image: v.string(),
@@ -40,7 +35,6 @@ export const eventFromImageBase64ThenCreate = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start the workflow with onComplete handler
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromImageBase64Workflow,
@@ -61,9 +55,6 @@ export const eventFromImageBase64ThenCreate = mutation({
   },
 });
 
-/**
- * Create event from URL using workflow
- */
 export const eventFromUrlThenCreate = mutation({
   args: {
     url: v.string(),
@@ -83,7 +74,6 @@ export const eventFromUrlThenCreate = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start the URL workflow with onComplete handler for failure notifications
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -104,9 +94,6 @@ export const eventFromUrlThenCreate = mutation({
   },
 });
 
-/**
- * Create event from text using workflow
- */
 export const eventFromTextThenCreate = mutation({
   args: {
     rawText: v.string(),
@@ -126,7 +113,6 @@ export const eventFromTextThenCreate = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start the text workflow with onComplete handler for failure notifications
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromTextWorkflow,
@@ -147,12 +133,7 @@ export const eventFromTextThenCreate = mutation({
   },
 });
 
-// INTERNAL ACTIONS FOR WORKFLOW
-// ============================================================================
 
-/**
- * Extract event data from base64 image using AI
- */
 export const extractEventFromBase64Image = internalAction({
   args: {
     base64Image: v.string(),
@@ -171,7 +152,6 @@ export const extractEventFromBase64Image = internalAction({
       timezone: args.timezone,
     });
 
-    // Strip buttonStyle and options fields that are added by addCommonAddToCalendarProps
     const cleanedEvents = result.events.map((event) => {
       const {
         buttonStyle: _buttonStyle,
@@ -205,7 +185,6 @@ export const extractEventFromUrl = internalAction({
     args,
   ): Promise<{ events: EventWithMetadata[]; response: string }> => {
     try {
-      // Check if the URL is a valid URL
       if (!args.url.startsWith("http")) {
         throw new ConvexError({
           message: "Invalid URL: URL must start with http",
@@ -213,7 +192,6 @@ export const extractEventFromUrl = internalAction({
         });
       }
 
-      // Let Jina API process the URL and get the actual response
       const aiResult = await fetchAndProcessEvent({
         ctx,
         input: {
@@ -223,11 +201,8 @@ export const extractEventFromUrl = internalAction({
         fnName: "eventFromUrlThenCreateThenNotification",
       });
 
-      // Use the new validateJinaResponse helper for content-based validation
       validateJinaResponse(aiResult);
 
-      // Use the enhanced validateEvent function for event-specific validations
-      // The AI returns an array of events, validate each one
       if (!Array.isArray(aiResult.events)) {
         throw new ConvexError({
           message: "Invalid response: expected events array",
@@ -235,12 +210,10 @@ export const extractEventFromUrl = internalAction({
         });
       }
 
-      // Validate each event in the array
       for (const event of aiResult.events) {
         AI.validateEvent(event);
       }
 
-      // Strip buttonStyle and options fields that are added by addCommonAddToCalendarProps
       const cleanedEvents = aiResult.events.map((event) => {
         const {
           buttonStyle: _buttonStyle,
@@ -258,7 +231,6 @@ export const extractEventFromUrl = internalAction({
         response: aiResult.response,
       };
     } catch (error) {
-      // Re-throw ConvexError as-is, wrap other errors
       if (error instanceof ConvexError) {
         throw error;
       }
@@ -295,7 +267,6 @@ export const extractEventFromText = internalAction({
       lists: [],
     });
 
-    // Strip buttonStyle and options fields that are added by addCommonAddToCalendarProps
     const cleanedEvents = result.events.map((event) => {
       const {
         buttonStyle: _buttonStyle,
@@ -315,9 +286,6 @@ export const extractEventFromText = internalAction({
   },
 });
 
-/**
- * Validate first event from an array of events
- */
 export const validateFirstEvent = internalAction({
   args: {
     events: v.array(eventDataValidator),
@@ -341,24 +309,13 @@ export const validateFirstEvent = internalAction({
       });
     }
 
-    // Additional validation can be done here
     AI.validateEvent(firstEvent);
 
-    // The validator ensures all required fields are present
-    // Return the validated event which now has all required fields populated
     return firstEvent;
   },
 });
 
-// NEW DIRECT FUNCTIONS WITHOUT WORKFLOW OVERHEAD
-// ============================================================================
 
-/**
- * Direct event creation from base64 image - no workflow overhead
- */
-/**
- * Process single image - internal action that can be called from mutations
- */
 export const processSingleImage = internalAction({
   args: {
     base64Image: v.string(),
@@ -380,7 +337,6 @@ export const processSingleImage = internalAction({
   }),
   handler: async (ctx, args) => {
     try {
-      // Step 1: Extract event and upload image in parallel
       const [aiResult, uploadedImageUrl]: [
         { events: EventWithMetadata[]; response: string },
         string,
@@ -395,7 +351,6 @@ export const processSingleImage = internalAction({
         }),
       ]);
 
-      // Step 2: Validate first event
       if (aiResult.events.length === 0) {
         throw new ConvexError({
           message: "No events found in image",
@@ -413,7 +368,6 @@ export const processSingleImage = internalAction({
 
       AI.validateEvent(firstEvent);
 
-      // Step 3: Insert event into database
       const eventArgs = {
         comment: args.comment,
         lists: args.lists,
@@ -448,9 +402,6 @@ export const processSingleImage = internalAction({
   },
 });
 
-/**
- * Direct event creation from base64 image - no workflow overhead
- */
 export const eventFromImageBase64Direct = mutation({
   args: {
     base64Image: v.string(),
@@ -471,7 +422,6 @@ export const eventFromImageBase64Direct = mutation({
     error: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    // Schedule the processing as an action (this allows parallel execution)
     const jobId: string = await ctx.scheduler.runAfter(
       0,
       internal.ai.processSingleImageWithNotification,
@@ -488,7 +438,6 @@ export const eventFromImageBase64Direct = mutation({
       },
     );
 
-    // Return immediately with a job ID for tracking
     return {
       success: true,
       jobId: jobId,
@@ -497,9 +446,6 @@ export const eventFromImageBase64Direct = mutation({
   },
 });
 
-/**
- * Add images to an existing batch
- */
 export const addImagesToBatch = mutation({
   args: {
     batchId: v.string(),
@@ -514,7 +460,6 @@ export const addImagesToBatch = mutation({
     added: v.number(),
   }),
   handler: async (ctx, args) => {
-    // Get the batch to verify it exists and belongs to the user
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       throw new ConvexError("Not authenticated");
@@ -533,7 +478,6 @@ export const addImagesToBatch = mutation({
       throw new ConvexError("Unauthorized");
     }
 
-    // Schedule processing for these new images
     const _jobId: string = await ctx.scheduler.runAfter(
       0,
       internal.ai.processAdditionalBatchImages,
@@ -550,9 +494,6 @@ export const addImagesToBatch = mutation({
   },
 });
 
-/**
- * Batch event creation from multiple base64 images
- */
 export const createEventBatch = mutation({
   args: {
     batchId: v.string(),
@@ -584,7 +525,6 @@ export const createEventBatch = mutation({
     totalImages: number;
     jobId?: string;
   }> => {
-    // Create batch tracking record
     await ctx.runMutation(internal.eventBatches.createBatch, {
       batchId: args.batchId,
       userId: args.userId,
@@ -592,7 +532,6 @@ export const createEventBatch = mutation({
       timezone: args.timezone,
     });
 
-    // Only schedule processing if we have images
     let jobId: string | undefined;
     if (args.images.length > 0) {
       jobId = await ctx.scheduler.runAfter(0, internal.ai.processBatchImages, {
@@ -616,9 +555,6 @@ export const createEventBatch = mutation({
   },
 });
 
-/**
- * Process single image with notification - internal action
- */
 export const processSingleImageWithNotification = internalAction({
   args: {
     base64Image: v.string(),
@@ -665,9 +601,6 @@ export const processSingleImageWithNotification = internalAction({
   },
 });
 
-/**
- * Process additional images for an existing batch
- */
 export const processAdditionalBatchImages = internalAction({
   args: {
     batchId: v.string(),
@@ -680,7 +613,6 @@ export const processAdditionalBatchImages = internalAction({
     userId: v.string(),
   },
   handler: async (ctx, args) => {
-    // Get the batch info to get the other parameters
     const batch = await ctx.runQuery(internal.eventBatches.getBatchInfo, {
       batchId: args.batchId,
     });
@@ -689,7 +621,6 @@ export const processAdditionalBatchImages = internalAction({
       throw new ConvexError("Batch not found");
     }
 
-    // Process these images using the same logic as processBatchImages
     const results: {
       tempId: string;
       success: boolean;
@@ -697,7 +628,6 @@ export const processAdditionalBatchImages = internalAction({
       error?: string;
     }[] = [];
 
-    // Process images (reusing the chunk logic)
     const CHUNK_SIZE = 5;
     const chunks: (typeof args.images)[] = [];
 
@@ -705,7 +635,7 @@ export const processAdditionalBatchImages = internalAction({
       chunks.push(args.images.slice(i, i + CHUNK_SIZE));
     }
 
-    const timezone = batch.timezone ?? DEFAULT_TIMEZONE; // Default fallback
+    const timezone = batch.timezone ?? DEFAULT_TIMEZONE;
 
     for (const [_chunkIndex, chunk] of chunks.entries()) {
       const chunkResults = await Promise.allSettled(
@@ -728,7 +658,6 @@ export const processAdditionalBatchImages = internalAction({
         }),
       );
 
-      // Convert Promise.allSettled results
       for (let i = 0; i < chunkResults.length; i++) {
         const result = chunkResults[i];
         const image = chunk[i];
@@ -749,7 +678,6 @@ export const processAdditionalBatchImages = internalAction({
       }
     }
 
-    // Update batch progress
     const successCount = results.filter((r) => r.success).length;
     const failureCount = results.filter((r) => !r.success).length;
 
@@ -763,9 +691,6 @@ export const processAdditionalBatchImages = internalAction({
   },
 });
 
-/**
- * Process batch of images - internal action
- */
 export const processBatchImages = internalAction({
   args: {
     batchId: v.string(),
@@ -784,7 +709,6 @@ export const processBatchImages = internalAction({
     sendNotification: v.boolean(),
   },
   handler: async (ctx, args) => {
-    // Process in chunks to avoid overwhelming the system
     const CHUNK_SIZE = 5;
     const chunks: (typeof args.images)[] = [];
 
@@ -799,7 +723,6 @@ export const processBatchImages = internalAction({
       error?: string;
     }[] = [];
 
-    // Process chunks sequentially, items within chunks in parallel
     for (const [chunkIndex, chunk] of chunks.entries()) {
       const chunkResults = await Promise.allSettled(
         chunk.map(async (image) => {
@@ -821,7 +744,6 @@ export const processBatchImages = internalAction({
         }),
       );
 
-      // Convert Promise.allSettled results for this chunk
       for (let i = 0; i < chunkResults.length; i++) {
         const result = chunkResults[i];
         const image = chunk[i];
@@ -849,11 +771,9 @@ export const processBatchImages = internalAction({
       }
     }
 
-    // Count successes and failures
     const successCount = allResults.filter((r) => r.success).length;
     const failureCount = allResults.filter((r) => !r.success).length;
 
-    // Update batch status
     await ctx.runMutation(internal.eventBatches.updateBatchStatus, {
       batchId: args.batchId,
       successCount,
@@ -861,9 +781,7 @@ export const processBatchImages = internalAction({
       status: "completed",
     });
 
-    // Send batch notification if enabled
     if (args.sendNotification) {
-      // Collect failed image details for better error reporting
       const failedImages = allResults
         .filter((r) => !r.success)
         .map((r) => ({

--- a/packages/backend/convex/ai.ts
+++ b/packages/backend/convex/ai.ts
@@ -133,7 +133,6 @@ export const eventFromTextThenCreate = mutation({
   },
 });
 
-
 export const extractEventFromBase64Image = internalAction({
   args: {
     base64Image: v.string(),
@@ -314,7 +313,6 @@ export const validateFirstEvent = internalAction({
     return firstEvent;
   },
 });
-
 
 export const processSingleImage = internalAction({
   args: {

--- a/packages/backend/convex/codes.ts
+++ b/packages/backend/convex/codes.ts
@@ -2,10 +2,6 @@ import { v } from "convex/values";
 
 import { action } from "./_generated/server";
 
-/**
- * Redeem a code to enable discover access
- * This action updates the user's public metadata via Clerk
- */
 export const redeemCode = action({
   args: {
     code: v.string(),
@@ -17,11 +13,8 @@ export const redeemCode = action({
   handler: async (ctx, { code }) => {
     const normalized = code.trim().toUpperCase();
     const validCode = "DISCOVER";
-    // Check if user is authenticated
     const identity = await ctx.auth.getUserIdentity();
 
-    // For anonymous users: validation only. The client persists the code
-    // (e.g., AsyncStorage) and redeems post-auth.
     if (!identity) {
       if (normalized === validCode) {
         return { success: true };
@@ -30,9 +23,7 @@ export const redeemCode = action({
       }
     }
 
-    // For authenticated users, update their Clerk metadata directly
     try {
-      // Make HTTP request to update Clerk user metadata
       const clerkEndpoint =
         process.env.CLERK_API_ENDPOINT || "https://api.clerk.dev/v1";
       const secretKey = process.env.CLERK_SECRET_KEY;
@@ -42,12 +33,10 @@ export const redeemCode = action({
         return { success: false, error: "Configuration error" };
       }
 
-      // Only support the "DISCOVER" code
       if (normalized !== validCode) {
         return { success: false, error: "Invalid code" };
       }
 
-      // Update user's public metadata
       const response = await fetch(
         `${clerkEndpoint}/users/${identity.subject}`,
         {

--- a/packages/backend/convex/constants.ts
+++ b/packages/backend/convex/constants.ts
@@ -1,9 +1,4 @@
-/**
- * Default values used throughout the application
- */
 
-// Default timezone for events
 export const DEFAULT_TIMEZONE = "America/Los_Angeles";
 
-// Default visibility setting for new events
 export const DEFAULT_VISIBILITY = "private" as const;

--- a/packages/backend/convex/constants.ts
+++ b/packages/backend/convex/constants.ts
@@ -1,4 +1,3 @@
-
 export const DEFAULT_TIMEZONE = "America/Los_Angeles";
 
 export const DEFAULT_VISIBILITY = "private" as const;

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -1,4 +1,3 @@
-// convex/convex.config.ts
 import aggregate from "@convex-dev/aggregate/convex.config";
 import migrations from "@convex-dev/migrations/convex.config";
 import workflow from "@convex-dev/workflow/convex.config";
@@ -10,11 +9,10 @@ app.use(workflow);
 app.use(workpool, { name: "eventIngestionWorkpool" });
 app.use(migrations);
 
-// Aggregates for efficient stats calculations
-app.use(aggregate, { name: "eventsByCreation" }); // For capturesThisWeek
-app.use(aggregate, { name: "eventsByStartTime" }); // For upcomingEvents (own only)
-app.use(aggregate, { name: "eventFollowsAggregate" }); // For follow counts
-app.use(aggregate, { name: "userFeedsAggregate" }); // For upcoming events (own + followed)
-app.use(aggregate, { name: "listFollowsAggregate" }); // For list follower counts
+app.use(aggregate, { name: "eventsByCreation" });
+app.use(aggregate, { name: "eventsByStartTime" });
+app.use(aggregate, { name: "eventFollowsAggregate" });
+app.use(aggregate, { name: "userFeedsAggregate" });
+app.use(aggregate, { name: "listFollowsAggregate" });
 
 export default app;

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -4,15 +4,7 @@ import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-// Send weekly notifications every Sunday at 9 AM
-// crons.cron(
-//   "weekly notifications",
-//   "0 9 * * 0", // Every Sunday at 9:00 AM
-//   internal.notifications.sendWeeklyNotifications,
-//   {},
-// );
 
-// Send trial expiration reminders daily at 10 AM
 crons.cron(
   "trial expiration reminders",
   "0 10 * * *", // Every day at 10:00 AM
@@ -20,10 +12,7 @@ crons.cron(
   {},
 );
 
-// Marketing notification cron removed — the launch-specific message was stale.
-// Re-add with evergreen copy if an annual notification is desired.
 
-// Sync user properties to PostHog daily at 6 AM UTC
 crons.cron(
   "posthog user sync",
   "0 6 * * *", // Every day at 6:00 AM UTC
@@ -31,7 +20,6 @@ crons.cron(
   {},
 );
 
-// Update hasEnded flags for userFeeds every 15 minutes
 crons.cron(
   "update hasEnded flags",
   "*/15 * * * *", // Every 15 minutes
@@ -39,7 +27,6 @@ crons.cron(
   {},
 );
 
-// Update hasEnded flags for userFeedGroups every 15 minutes
 crons.cron(
   "update grouped hasEnded flags",
   "*/15 * * * *", // Every 15 minutes

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -4,14 +4,12 @@ import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-
 crons.cron(
   "trial expiration reminders",
   "0 10 * * *", // Every day at 10:00 AM
   internal.notifications.sendTrialExpirationReminders,
   {},
 );
-
 
 crons.cron(
   "posthog user sync",

--- a/packages/backend/convex/eventBatches.ts
+++ b/packages/backend/convex/eventBatches.ts
@@ -11,16 +11,12 @@ import {
 import { DEFAULT_TIMEZONE, DEFAULT_VISIBILITY } from "./constants";
 import { getNotificationContent } from "./model/notificationHelpers";
 
-// Batch tracking schema
 export const batchStatusValidator = v.union(
   v.literal("processing"),
   v.literal("completed"),
   v.literal("failed"),
 );
 
-/**
- * Create a new batch tracking record
- */
 export const createBatch = internalMutation({
   args: {
     batchId: v.string(),
@@ -29,18 +25,15 @@ export const createBatch = internalMutation({
     timezone: v.string(),
   },
   handler: async (ctx, args) => {
-    // Validate timezone
     if (!args.timezone || args.timezone.trim() === "") {
       throw new ConvexError("Timezone is required");
     }
 
-    // Check if timezone is supported (using a simple check)
     try {
       new Intl.DateTimeFormat("en-US", { timeZone: args.timezone });
     } catch {
       throw new ConvexError(`Invalid timezone: ${args.timezone}`);
     }
-    // Get username from user record
     const user = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", args.userId))
@@ -61,9 +54,6 @@ export const createBatch = internalMutation({
   },
 });
 
-/**
- * Update batch status after processing
- */
 export const updateBatchStatus = internalMutation({
   args: {
     batchId: v.string(),
@@ -93,9 +83,6 @@ export const updateBatchStatus = internalMutation({
   },
 });
 
-/**
- * Send appropriate notification based on batch size
- */
 export const sendBatchNotificationWithErrors = internalAction({
   args: {
     batchId: v.string(),
@@ -113,7 +100,6 @@ export const sendBatchNotificationWithErrors = internalAction({
   },
   handler: async (ctx, args) => {
     try {
-      // Call the original sendBatchNotification logic but with enhanced error details
       return await sendBatchNotificationHandler(ctx, args);
     } catch (error) {
       console.error("Error in sendBatchNotificationWithErrors:", error);
@@ -122,9 +108,6 @@ export const sendBatchNotificationWithErrors = internalAction({
   },
 });
 
-/**
- * Get batch info for processing additional images
- */
 export const getBatchInfo = internalQuery({
   args: {
     batchId: v.string(),
@@ -148,9 +131,6 @@ export const getBatchInfo = internalQuery({
   },
 });
 
-/**
- * Increment batch progress as images are processed
- */
 export const incrementBatchProgress = internalMutation({
   args: {
     batchId: v.string(),
@@ -178,13 +158,10 @@ export const incrementBatchProgress = internalMutation({
       successCount: newSuccessCount,
       failureCount: newFailureCount,
       progress: newProgress,
-      // Update status if all images are processed
       status: newProgress >= 1 ? "completed" : "processing",
     });
 
-    // Check if we should send the batch notification
     if (newProgress >= 1) {
-      // Get the full batch details for notification
       const updatedBatch = await ctx.db.get(batch._id);
       if (updatedBatch) {
         await ctx.scheduler.runAfter(
@@ -205,7 +182,6 @@ export const incrementBatchProgress = internalMutation({
   },
 });
 
-// Keep the original for backward compatibility
 export const sendBatchNotification = internalAction({
   args: {
     batchId: v.string(),
@@ -216,7 +192,6 @@ export const sendBatchNotification = internalAction({
     failureCount: v.number(),
   },
   handler: async (ctx, args) => {
-    // Call the handler with empty failed images array
     return await sendBatchNotificationHandler(ctx, {
       ...args,
       failedImages: [],
@@ -224,7 +199,6 @@ export const sendBatchNotification = internalAction({
   },
 });
 
-// Shared handler function
 async function sendBatchNotificationHandler(
   ctx: ActionCtx,
   args: {
@@ -238,15 +212,11 @@ async function sendBatchNotificationHandler(
   },
 ) {
   try {
-    // Get the created events for this batch
     const events = await ctx.runQuery(internal.eventBatches.getEventsForBatch, {
       batchId: args.batchId,
     });
 
-    // Determine notification strategy
     if (args.totalCount <= 3) {
-      // Send individual notifications for each successful event
-      // Pass explicit position to ensure accurate count
       const results = [];
       for (let i = 0; i < events.length; i++) {
         const event = events[i];
@@ -254,9 +224,8 @@ async function sendBatchNotificationHandler(
           console.error(`Event at index ${i} is undefined`);
           continue;
         }
-        const position = i + 1; // 1-based position
+        const position = i + 1;
         try {
-          // Add a small delay between notifications to ensure they arrive in order
           if (i > 0) {
             await new Promise((resolve) => setTimeout(resolve, 300));
           }
@@ -274,22 +243,19 @@ async function sendBatchNotificationHandler(
             `Failed to send notification for event ${event.id}:`,
             error,
           );
-          // Don't throw - we want to continue sending other notifications
           results.push({ success: false, error: String(error) });
         }
       }
     } else {
-      // Build enhanced message with error details
       let message: string;
       if (args.failureCount === 0) {
         message = `Successfully captured ${args.successCount} events`;
       } else {
         message = `Captured ${args.successCount} of ${args.totalCount} events`;
 
-        // Add specific error details if available
         if (args.failedImages && args.failedImages.length > 0) {
           const errorSummary = args.failedImages
-            .slice(0, 3) // Show first 3 errors
+            .slice(0, 3)
             .map((img, idx) => `${idx + 1}. ${img.error}`)
             .join("\n");
 
@@ -321,9 +287,6 @@ async function sendBatchNotificationHandler(
   }
 }
 
-/**
- * Get events created in a batch
- */
 export const getEventsForBatch = internalQuery({
   args: {
     batchId: v.string(),
@@ -338,14 +301,12 @@ export const getEventsForBatch = internalQuery({
   },
 });
 
-// Notification content for individual events in a batch
 const notificationContentValidator = v.object({
   title: v.string(),
   subtitle: v.string(),
   body: v.string(),
 });
 
-// Event info for banners
 const eventInfoValidator = v.object({
   id: v.string(),
   name: v.string(),
@@ -358,10 +319,6 @@ const eventInfoValidator = v.object({
   notificationContent: notificationContentValidator,
 });
 
-/**
- * Get batch status for client polling
- * Includes notification content for completion feedback
- */
 export const getBatchStatus = query({
   args: {
     batchId: v.string(),
@@ -374,9 +331,7 @@ export const getBatchStatus = query({
     failureCount: v.number(),
     progress: v.number(),
     firstEventId: v.union(v.string(), v.null()),
-    // Events with notification content for banners (only when completed)
     events: v.array(eventInfoValidator),
-    // Summary content for batch summary banner (2+ events)
     batchSummaryContent: v.union(
       v.object({
         title: v.string(),
@@ -405,7 +360,6 @@ export const getBatchStatus = query({
         ? Math.round((processedCount / batch.totalCount) * 100)
         : 0;
 
-    // Get the first event ID if there's exactly one successful event
     let firstEventId: string | null = null;
     if (batch.successCount === 1) {
       const firstEvent = await ctx.db
@@ -415,7 +369,6 @@ export const getBatchStatus = query({
       firstEventId = firstEvent?.id ?? null;
     }
 
-    // Get events with notification content when batch is completed
     let events: {
       id: string;
       name: string;
@@ -434,15 +387,11 @@ export const getBatchStatus = query({
     } | null = null;
 
     if (batch.status === "completed" || batch.status === "failed") {
-      // Get events for this batch
       const batchEvents = await ctx.db
         .query("events")
         .withIndex("by_batch_id", (q) => q.eq("batchId", args.batchId))
         .collect();
 
-      // Get today's event count for this user (for notification content).
-      // Compute day boundaries in the batch's timezone so daily counts
-      // are accurate regardless of where the server is located.
       const tz = batch.timezone ?? DEFAULT_TIMEZONE;
       const { startOfDay, endOfDay } = getDayBoundsForTimezone(tz);
 
@@ -459,9 +408,7 @@ export const getBatchStatus = query({
 
       const totalTodayCount = todayEvents.length;
 
-      // For 1 event, provide individual event info with notification content
       if (batch.totalCount <= 1) {
-        // Calculate position for each event
         const countBeforeBatch = Math.max(
           0,
           totalTodayCount - batchEvents.length,
@@ -470,7 +417,6 @@ export const getBatchStatus = query({
         events = batchEvents.map((event, index) => {
           const position = countBeforeBatch + index + 1;
           const content = getNotificationContent(event.name ?? "", position);
-          // Extract event data safely - the event field contains the calendar event JSON
           const eventData = event.event as
             | {
                 startDate?: string;
@@ -493,7 +439,6 @@ export const getBatchStatus = query({
           };
         });
       } else {
-        // For 4+ events, provide batch summary content
         if (batch.failureCount === 0) {
           batchSummaryContent = {
             title: "Events captured ✨",
@@ -531,23 +476,12 @@ export const getBatchStatus = query({
   },
 });
 
-/**
- * Get the start and end of "today" as Date objects in UTC,
- * where "today" is determined by the given IANA timezone.
- *
- * For example, at 2024-03-15T02:00:00Z:
- * - In "America/New_York" (UTC-4), it's still March 14, so this returns
- *   March 14 00:00 ET -> March 14 04:00 UTC  to  March 14 23:59:59.999 ET -> March 15 03:59:59.999 UTC
- * - In "Asia/Tokyo" (UTC+9), it's already March 15, so this returns
- *   March 15 00:00 JST -> March 14 15:00 UTC  to  March 15 23:59:59.999 JST -> March 15 14:59:59.999 UTC
- */
 function getDayBoundsForTimezone(tz: string): {
   startOfDay: Date;
   endOfDay: Date;
 } {
   const now = new Date();
 
-  // Use Intl to get the current date parts in the target timezone
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
     year: "numeric",
@@ -563,19 +497,15 @@ function getDayBoundsForTimezone(tz: string): {
     Number(parts.find((p) => p.type === type)?.value ?? 0);
 
   const year = get("year");
-  const month = get("month"); // 1-based
+  const month = get("month");
   const day = get("day");
   const hour = get("hour");
   const minute = get("minute");
   const second = get("second");
 
-  // Compute the UTC offset for this timezone at this instant.
-  // We build a Date from the wall-clock parts (interpreted as UTC) and
-  // compare it to the real UTC instant (`now`).
   const wallAsUtc = Date.UTC(year, month - 1, day, hour, minute, second);
   const offsetMs = wallAsUtc - now.getTime();
 
-  // Build midnight and end-of-day in the target timezone as UTC timestamps
   const midnightWallUtc = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
   const endWallUtc = Date.UTC(year, month - 1, day, 23, 59, 59, 999);
 

--- a/packages/backend/convex/events.ts
+++ b/packages/backend/convex/events.ts
@@ -11,7 +11,6 @@ import * as Events from "./model/events";
 import { enrichEventsAndFilterNulls } from "./model/events";
 import { getViewableListIds } from "./model/lists";
 
-// Validators for complex types
 const eventMetadataValidator = v.optional(
   v.object({
     accessibility: v.optional(v.array(v.string())),
@@ -47,19 +46,14 @@ const listValidator = v.object({
   value: v.string(),
 });
 
-/**
- * Get events by batch ID
- */
 export const getEventsByBatchId = query({
   args: { batchId: v.string() },
   handler: async (ctx, args) => {
-    // Enforce authentication
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       throw new ConvexError("Authentication required");
     }
 
-    // Verify batch ownership
     const batch = await ctx.db
       .query("eventBatches")
       .withIndex("by_batch_id", (q) => q.eq("batchId", args.batchId))
@@ -74,14 +68,10 @@ export const getEventsByBatchId = query({
       .order("desc")
       .collect();
 
-    // Enrich events with user data, comments, and follows
     return await enrichEventsAndFilterNulls(ctx, events);
   },
 });
 
-/**
- * Get saved event IDs for a user
- */
 export const getSavedIdsForUser = query({
   args: { userName: v.string() },
   handler: async (ctx, args) => {
@@ -89,18 +79,12 @@ export const getSavedIdsForUser = query({
   },
 });
 
-/**
- * Get a single event by ID
- */
 export const get = query({
   args: { eventId: v.string() },
   handler: async (ctx, args) => {
     const event = await Events.getEventById(ctx, args.eventId);
     if (!event) return null;
 
-    // Strip lists the viewer can't see so the event-detail attribution
-    // (AttributionGrid / SavedByModal) doesn't leak private list
-    // names or slugs to non-members.
     const identity = await ctx.auth.getUserIdentity();
     const viewerId = identity?.subject ?? null;
     const viewableListIds = await getViewableListIds(
@@ -113,9 +97,6 @@ export const get = query({
   },
 });
 
-/**
- * Get discover events with Convex pagination
- */
 export const getDiscoverPaginated = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -125,14 +106,11 @@ export const getDiscoverPaginated = query({
     const identity = await ctx.auth.getUserIdentity();
     const { beforeThisDateTime } = args;
 
-    // Get all events that are upcoming and public
     const result = await ctx.db
       .query("events")
       .filter((q) => {
-        // Always filter for public events
         let baseFilter = q.eq(q.field("visibility"), "public");
 
-        // If authenticated, exclude user's own events
         if (identity) {
           baseFilter = q.and(
             baseFilter,
@@ -140,7 +118,6 @@ export const getDiscoverPaginated = query({
           );
         }
 
-        // Apply date filter only if beforeThisDateTime is provided
         if (beforeThisDateTime) {
           return q.and(
             baseFilter,
@@ -153,7 +130,6 @@ export const getDiscoverPaginated = query({
       .order("asc")
       .paginate(args.paginationOpts);
 
-    // Enrich events with user data, comments, and follows
     const enrichedEvents = await enrichEventsAndFilterNulls(ctx, result.page);
 
     return {
@@ -163,10 +139,6 @@ export const getDiscoverPaginated = query({
   },
 });
 
-/**
- * Get events for user with Convex pagination (upcoming or past)
- * This efficiently queries both owned and followed events in a single operation
- */
 export const getEventsForUserPaginated = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -189,7 +161,6 @@ export const getEventsForUserPaginated = query({
       });
     }
 
-    // Get followed event IDs efficiently
     const eventFollows = await ctx.db
       .query("eventFollows")
       .withIndex("by_user", (q) => q.eq("userId", user.id))
@@ -197,16 +168,10 @@ export const getEventsForUserPaginated = query({
 
     const followedEventIds = new Set(eventFollows.map((ef) => ef.eventId));
 
-    // Create a single query that filters for events that are either:
-    // 1. Created by the user, OR
-    // 2. Followed by the user
-    // AND optionally match the date filter
     const eventsQuery = ctx.db.query("events").filter((q) => {
       const userFilter = q.eq(q.field("userId"), user.id);
 
-      // If there are no followed events, just filter by user
       if (followedEventIds.size === 0) {
-        // Apply date filter only if beforeThisDateTime is provided
         if (beforeThisDateTime) {
           const dateFilter =
             filter === "upcoming"
@@ -217,14 +182,12 @@ export const getEventsForUserPaginated = query({
         return userFilter;
       }
 
-      // Create OR conditions for followed events
       const followedEventFilters = Array.from(followedEventIds).map((eventId) =>
         q.eq(q.field("id"), eventId),
       );
 
       const eventFilter = q.or(userFilter, ...followedEventFilters);
 
-      // Apply date filter only if beforeThisDateTime is provided
       if (beforeThisDateTime) {
         const dateFilter =
           filter === "upcoming"
@@ -236,7 +199,6 @@ export const getEventsForUserPaginated = query({
       return eventFilter;
     });
 
-    // Apply ordering and pagination
     const orderedQuery =
       filter === "upcoming"
         ? eventsQuery.order("asc")
@@ -244,7 +206,6 @@ export const getEventsForUserPaginated = query({
 
     const result = await orderedQuery.paginate(args.paginationOpts);
 
-    // Enrich events with user data, comments, and follows
     const enrichedEvents = await enrichEventsAndFilterNulls(ctx, result.page);
 
     return {
@@ -254,9 +215,6 @@ export const getEventsForUserPaginated = query({
   },
 });
 
-/**
- * Get user stats
- */
 export const getStats = query({
   args: { userName: v.string() },
   handler: async (ctx, args) => {
@@ -264,9 +222,6 @@ export const getStats = query({
   },
 });
 
-/**
- * Create a new event
- */
 export const create = mutation({
   args: {
     event: eventDataValidator,
@@ -284,7 +239,6 @@ export const create = mutation({
       });
     }
 
-    // Get user info
     const user = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", identity.subject))
@@ -310,9 +264,6 @@ export const create = mutation({
   },
 });
 
-/**
- * Update an existing event
- */
 export const update = mutation({
   args: {
     id: v.string(),
@@ -331,7 +282,6 @@ export const update = mutation({
       });
     }
 
-    // Check if user is admin
     const isAdmin = isUserAdmin(identity);
 
     return await Events.updateEvent(
@@ -348,9 +298,6 @@ export const update = mutation({
   },
 });
 
-/**
- * Delete an event
- */
 export const deleteEvent = mutation({
   args: { id: v.string() },
   handler: async (ctx, args) => {
@@ -362,16 +309,12 @@ export const deleteEvent = mutation({
       });
     }
 
-    // Check if user is admin
     const isAdmin = isUserAdmin(identity);
 
     return await Events.deleteEvent(ctx, identity.subject, args.id, isAdmin);
   },
 });
 
-/**
- * Follow an event
- */
 export const follow = mutation({
   args: { id: v.string() },
   handler: async (ctx, args) => {
@@ -387,9 +330,6 @@ export const follow = mutation({
   },
 });
 
-/**
- * Unfollow an event
- */
 export const unfollow = mutation({
   args: { id: v.string() },
   handler: async (ctx, args) => {
@@ -405,9 +345,6 @@ export const unfollow = mutation({
   },
 });
 
-/**
- * Toggle event visibility
- */
 export const toggleVisibility = mutation({
   args: {
     id: v.string(),
@@ -431,27 +368,8 @@ export const toggleVisibility = mutation({
   },
 });
 
-// ============================================================================
-// ADMIN HELPERS
-// ============================================================================
 
-/**
- * ADMIN ROLE SETUP:
- *
- * To use the admin functionality, you need to configure roles in Clerk:
- *
- * 1. In your Clerk Dashboard, go to JWT Templates
- * 2. Edit your Convex template (or create custom claims)
- * 3. Add roles to the JWT claims, mapping to unsafe_metadata:
- *    - Add a "roles" claim that maps to user.unsafe_metadata.roles
- *
- * The admin check will look for "admin" in the roles array from the
- * unsafe_metadata property in the JWT identity object.
- */
 
-/**
- * Helper function to safely extract roles from an object
- */
 function extractRolesFromObject(obj: unknown): string[] {
   if (!obj || typeof obj !== "object") {
     return [];
@@ -467,9 +385,6 @@ function extractRolesFromObject(obj: unknown): string[] {
   return [];
 }
 
-/**
- * Check if the current user is an admin based on their Clerk session claims
- */
 function isUserAdmin(identity: Record<string, unknown> | null): boolean {
   try {
     if (!identity) {
@@ -494,13 +409,7 @@ function isUserAdmin(identity: Record<string, unknown> | null): boolean {
   }
 }
 
-// ============================================================================
-// INTERNAL ACTIONS FOR WORKFLOW
-// ============================================================================
 
-/**
- * Insert event into database
- */
 export const insertEvent = internalMutation({
   args: {
     firstEvent: eventDataValidator,
@@ -524,10 +433,8 @@ export const insertEvent = internalMutation({
       batchId,
     } = args;
 
-    // Extract eventMetadata from firstEvent before creating eventData
     const { eventMetadata, ...eventDataWithoutMetadata } = firstEvent;
 
-    // Add uploaded image to event if available
     const eventData = {
       ...eventDataWithoutMetadata,
       ...(uploadedImageUrl && {
@@ -556,9 +463,6 @@ export const insertEvent = internalMutation({
   },
 });
 
-/**
- * Internal mutation to create an event (called from workflow)
- */
 export const createEvent = internalMutation({
   args: {
     userId: v.string(),
@@ -584,9 +488,6 @@ export const createEvent = internalMutation({
   },
 });
 
-/**
- * Internal query to get an event by ID (called from workflow)
- */
 export const getEventById = internalQuery({
   args: { eventId: v.string() },
   returns: v.union(v.object({ name: v.string() }), v.null()),
@@ -599,9 +500,6 @@ export const getEventById = internalQuery({
   },
 });
 
-/**
- * Internal query to get today's events count for a user (called from workflow)
- */
 export const getTodayEventsCount = internalQuery({
   args: { userId: v.string() },
   returns: v.array(v.object({ id: v.string() })),

--- a/packages/backend/convex/events.ts
+++ b/packages/backend/convex/events.ts
@@ -368,8 +368,6 @@ export const toggleVisibility = mutation({
   },
 });
 
-
-
 function extractRolesFromObject(obj: unknown): string[] {
   if (!obj || typeof obj !== "object") {
     return [];
@@ -408,7 +406,6 @@ function isUserAdmin(identity: Record<string, unknown> | null): boolean {
     return false;
   }
 }
-
 
 export const insertEvent = internalMutation({
   args: {

--- a/packages/backend/convex/feedGroupHelpers.ts
+++ b/packages/backend/convex/feedGroupHelpers.ts
@@ -141,7 +141,6 @@ export async function syncGroupedFeedEntriesForEventInternal(
   }
 }
 
-
 export const upsertGroupedFeedEntry = internalMutation({
   args: {
     feedId: v.string(),

--- a/packages/backend/convex/feedGroupHelpers.ts
+++ b/packages/backend/convex/feedGroupHelpers.ts
@@ -7,23 +7,17 @@ import {
   selectPrimaryEventForFeed,
 } from "./model/similarityHelpers";
 
-/**
- * Upsert a grouped feed entry from userFeeds membership
- * This derives the userFeedGroups entry from the source of truth (userFeeds)
- */
 export async function upsertGroupedFeedEntryFromMembershipInternal(
   ctx: MutationCtx,
   args: { feedId: string; similarityGroupId: string },
 ): Promise<void> {
   const { feedId, similarityGroupId } = args;
 
-  // Get member count from userFeeds
   const memberCount = await getGroupMemberCount(ctx, {
     feedId,
     similarityGroupId,
   });
 
-  // If no members, remove the grouped entry
   if (memberCount === 0) {
     await removeGroupedFeedEntryIfNoMembersInternal(ctx, {
       feedId,
@@ -32,14 +26,12 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
     return;
   }
 
-  // Select primary event for this feed+group
   const primaryEvent = await selectPrimaryEventForFeed(ctx, {
     feedId,
     similarityGroupId,
   });
 
   if (!primaryEvent) {
-    // No valid events in the group, remove the entry
     await removeGroupedFeedEntryIfNoMembersInternal(ctx, {
       feedId,
       similarityGroupId,
@@ -47,7 +39,6 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
     return;
   }
 
-  // Get the min addedAt from membership entries for stable ordering
   const membershipEntries = await ctx.db
     .query("userFeeds")
     .withIndex("by_feed_group", (q) =>
@@ -57,14 +48,12 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
 
   const minAddedAt = Math.min(...membershipEntries.map((e) => e.addedAt));
 
-  // Calculate times from primary event
   const eventStartTime = new Date(primaryEvent.startDateTime).getTime();
   const eventEndTime = new Date(primaryEvent.endDateTime).getTime();
   const currentTime = Date.now();
   const hasEnded = eventEndTime < currentTime;
   const similarEventsCount = Math.max(0, memberCount - 1);
 
-  // Check if entry already exists
   const existingEntry = await ctx.db
     .query("userFeedGroups")
     .withIndex("by_feed_group", (q) =>
@@ -73,7 +62,6 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
     .first();
 
   if (existingEntry) {
-    // Update existing entry
     await ctx.db.patch(existingEntry._id, {
       primaryEventId: primaryEvent.id,
       eventStartTime,
@@ -83,7 +71,6 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
       similarEventsCount,
     });
   } else {
-    // Insert new entry
     await ctx.db.insert("userFeedGroups", {
       feedId,
       similarityGroupId,
@@ -97,9 +84,6 @@ export async function upsertGroupedFeedEntryFromMembershipInternal(
   }
 }
 
-/**
- * Remove a grouped feed entry if no members remain
- */
 export async function removeGroupedFeedEntryIfNoMembersInternal(
   ctx: MutationCtx,
   args: { feedId: string; similarityGroupId: string },
@@ -118,23 +102,17 @@ export async function removeGroupedFeedEntryIfNoMembersInternal(
   }
 }
 
-/**
- * Sync all grouped feed entries for an event
- * Call this when an event's userFeeds entries change
- */
 export async function syncGroupedFeedEntriesForEventInternal(
   ctx: MutationCtx,
   args: { eventId: string; similarityGroupId: string },
 ): Promise<void> {
   const { eventId, similarityGroupId } = args;
 
-  // Find all userFeeds entries for this event
   const feedEntries = await ctx.db
     .query("userFeeds")
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
     .collect();
 
-  // Get unique (feedId, similarityGroupId) pairs
   const feedGroupPairs = new Set<string>();
 
   for (const entry of feedEntries) {
@@ -143,8 +121,6 @@ export async function syncGroupedFeedEntriesForEventInternal(
     }
   }
 
-  // Also need to check if this event was the primary for any feed groups
-  // and update those groups (in case the primary needs to change)
   const affectedGroups = await ctx.db
     .query("userFeedGroups")
     .withIndex("by_group", (q) => q.eq("similarityGroupId", similarityGroupId))
@@ -154,7 +130,6 @@ export async function syncGroupedFeedEntriesForEventInternal(
     feedGroupPairs.add(`${group.feedId}:${group.similarityGroupId}`);
   }
 
-  // Update each affected feed+group
   for (const pair of feedGroupPairs) {
     const [feedId, groupId] = pair.split(":");
     if (feedId && groupId) {
@@ -166,7 +141,6 @@ export async function syncGroupedFeedEntriesForEventInternal(
   }
 }
 
-// Exposed internal mutations for calling from other modules
 
 export const upsertGroupedFeedEntry = internalMutation({
   args: {

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -5,7 +5,6 @@ import { internal } from "./_generated/api";
 import { internalAction, internalMutation } from "./_generated/server";
 import { userFeedsAggregate } from "./aggregates";
 
-// Helper to add an event to feeds when it's created or updated
 export const updateEventInFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -36,7 +35,6 @@ export const updateEventInFeeds = internalMutation({
     const eventEndTime = new Date(endDateTime).getTime();
     const currentTime = Date.now();
 
-    // 1. Always add to creator's personal feed
     const creatorFeedId = `user_${userId}`;
     await upsertFeedEntry(
       ctx,
@@ -98,14 +96,12 @@ export const updateEventInFeeds = internalMutation({
   },
 });
 
-// Helper to add event to a user's feed when they follow it
 export const addEventToUserFeed = internalMutation({
   args: {
     userId: v.string(),
     eventId: v.string(),
   },
   handler: async (ctx, { userId, eventId }) => {
-    // Get the event to get its start time and similarityGroupId
     const event = await ctx.db
       .query("events")
       .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -121,7 +117,6 @@ export const addEventToUserFeed = internalMutation({
     const currentTime = Date.now();
     const similarityGroupId = event.similarityGroupId;
 
-    // Check if already in feed
     const existing = await ctx.db
       .query("userFeeds")
       .withIndex("by_feed_event", (q) =>
@@ -144,7 +139,6 @@ export const addEventToUserFeed = internalMutation({
       const insertedDoc = (await ctx.db.get(id))!;
       await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
 
-      // Update grouped feed entry if similarityGroupId exists
       if (similarityGroupId) {
         await ctx.runMutation(
           internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -155,7 +149,6 @@ export const addEventToUserFeed = internalMutation({
   },
 });
 
-// Helper to update event visibility across all feed entries for an event
 export const updateEventVisibilityInFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -168,7 +161,6 @@ export const updateEventVisibilityInFeeds = internalMutation({
       .withIndex("by_event", (q) => q.eq("eventId", eventId))
       .collect();
 
-    // Track affected (feedId, similarityGroupId) pairs for grouped feed updates
     const affectedGroups: { feedId: string; similarityGroupId: string }[] = [];
 
     for (const entry of feedEntries) {
@@ -178,7 +170,6 @@ export const updateEventVisibilityInFeeds = internalMutation({
         const updatedDoc = { ...entry, eventVisibility: visibility };
         await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
 
-        // Track the group for later update
         if (entry.similarityGroupId) {
           affectedGroups.push({
             feedId: entry.feedId,
@@ -188,7 +179,6 @@ export const updateEventVisibilityInFeeds = internalMutation({
       }
     }
 
-    // Update grouped feed entries for affected groups
     for (const { feedId, similarityGroupId } of affectedGroups) {
       await ctx.runMutation(internal.feedGroupHelpers.upsertGroupedFeedEntry, {
         feedId,
@@ -200,7 +190,6 @@ export const updateEventVisibilityInFeeds = internalMutation({
   },
 });
 
-// Helper to remove event from feeds (e.g., when visibility changes to private)
 export const removeEventFromFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -211,13 +200,11 @@ export const removeEventFromFeeds = internalMutation({
     ctx,
     { eventId, keepCreatorFeed = true, keepListFeeds = true },
   ) => {
-    // Get all feed entries for this event
     const feedEntries = await ctx.db
       .query("userFeeds")
       .withIndex("by_event", (q) => q.eq("eventId", eventId))
       .collect();
 
-    // Fetch the event once if we need to check creator
     let event = null;
     if (keepCreatorFeed) {
       event = await ctx.db
@@ -226,26 +213,17 @@ export const removeEventFromFeeds = internalMutation({
         .first();
     }
 
-    // Track affected (feedId, similarityGroupId) pairs for grouped feed updates
     const affectedGroups: { feedId: string; similarityGroupId: string }[] = [];
 
     for (const entry of feedEntries) {
-      // If keepCreatorFeed is true, skip only the creator's feed
       if (keepCreatorFeed && event && entry.feedId === `user_${event.userId}`) {
         continue;
       }
 
-      // List-detail feeds (`list_${listId}`) are persistent membership records,
-      // not fan-out targets — they live as long as the eventToLists junction
-      // does. Removing them here would lose membership across visibility
-      // toggles (private→public), since the restore path doesn't recreate
-      // them. getEventsForList filters by eventVisibility="public", so private
-      // events stay invisible without needing to delete the entry.
       if (keepListFeeds && entry.feedId.startsWith("list_")) {
         continue;
       }
 
-      // Track the group for later update
       if (entry.similarityGroupId) {
         affectedGroups.push({
           feedId: entry.feedId,
@@ -253,12 +231,10 @@ export const removeEventFromFeeds = internalMutation({
         });
       }
 
-      // Delete all other entries (including discover and other user feeds)
       await userFeedsAggregate.deleteIfExists(ctx, entry);
       await ctx.db.delete(entry._id);
     }
 
-    // Update grouped feed entries for affected groups
     for (const group of affectedGroups) {
       await ctx.runMutation(
         internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -268,7 +244,6 @@ export const removeEventFromFeeds = internalMutation({
   },
 });
 
-// Helper to update event times across all feed entries for an event
 export const updateEventTimesInAllFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -293,7 +268,6 @@ export const updateEventTimesInAllFeeds = internalMutation({
       .withIndex("by_event", (q) => q.eq("eventId", eventId))
       .collect();
 
-    // Track affected (feedId, similarityGroupId) pairs for grouped feed updates
     const affectedGroups = new Set<string>();
 
     for (const entry of feedEntries) {
@@ -306,13 +280,11 @@ export const updateEventTimesInAllFeeds = internalMutation({
       const updatedDoc = { ...entry, eventStartTime, eventEndTime, hasEnded };
       await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
 
-      // Track the group for later update
       if (entry.similarityGroupId) {
         affectedGroups.add(`${entry.feedId}:${entry.similarityGroupId}`);
       }
     }
 
-    // Update grouped feed entries for affected groups
     for (const pair of affectedGroups) {
       const [feedId, similarityGroupId] = pair.split(":");
       if (feedId && similarityGroupId) {
@@ -356,7 +328,6 @@ async function canUserViewListForFeed(
   return !!membership;
 }
 
-// Helper to upsert a feed entry (insert if missing, update timestamps if exists)
 export async function upsertFeedEntry(
   ctx: MutationCtx,
   feedId: string,
@@ -391,11 +362,9 @@ export async function upsertFeedEntry(
       sourceListId,
     };
     const id = await ctx.db.insert("userFeeds", doc);
-    // Read back to get _id and _creationTime needed by aggregate
     const insertedDoc = (await ctx.db.get(id))!;
     await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
 
-    // Update grouped feed entry if similarityGroupId exists
     if (similarityGroupId) {
       await ctx.runMutation(internal.feedGroupHelpers.upsertGroupedFeedEntry, {
         feedId,
@@ -404,8 +373,6 @@ export async function upsertFeedEntry(
     }
   } else {
     const oldDoc = existingEntry;
-    // Also update similarityGroupId and eventVisibility if provided (for migration scenarios)
-    // Don't overwrite sourceListId — first source wins
     const patchFields = {
       eventStartTime,
       eventEndTime,
@@ -418,7 +385,6 @@ export async function upsertFeedEntry(
     const updatedDoc = { ...existingEntry, ...patchFields };
     await userFeedsAggregate.replaceOrInsert(ctx, oldDoc, updatedDoc);
 
-    // Update grouped feed entry if similarityGroupId exists
     const effectiveGroupId =
       similarityGroupId || existingEntry.similarityGroupId;
     if (effectiveGroupId) {
@@ -430,7 +396,6 @@ export async function upsertFeedEntry(
   }
 }
 
-// Helper to add all events from a list to a user's followedLists feed
 export const addListEventsToUserFeed = internalMutation({
   args: {
     userId: v.string(),
@@ -468,7 +433,6 @@ export const addListEventsToUserFeed = internalMutation({
       const eventEndTime = new Date(event.endDateTime).getTime();
       const similarityGroupId = event.similarityGroupId;
 
-      // Upsert into followedLists feed
       await upsertFeedEntry(
         ctx,
         followedListsFeedId,
@@ -484,7 +448,6 @@ export const addListEventsToUserFeed = internalMutation({
   },
 });
 
-// Helper to remove all events from a list from a user's followedLists feed
 export const removeListEventsFromUserFeed = internalMutation({
   args: {
     userId: v.string(),
@@ -498,18 +461,14 @@ export const removeListEventsFromUserFeed = internalMutation({
 
     const followedListsFeedId = `followedLists_${userId}`;
 
-    // Get all lists the user follows (excluding the one being unfollowed)
-    // This is used to check if events are in other followed lists
     const userListFollows = await ctx.db
       .query("listFollows")
       .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
 
     const followedListIds = new Set(userListFollows.map((f) => f.listId));
-    followedListIds.delete(listId); // Exclude the list being unfollowed
+    followedListIds.delete(listId);
 
-    // Cache the first replacement list per event during this scan so the
-    // sourceListId reattribution below is a map lookup instead of a re-query.
     const eventIdsInThisList = new Set(eventToLists.map((etl) => etl.eventId));
     const eventsInOtherFollowedLists = new Set<string>();
     const eventToReplacementList = new Map<string, string>();
@@ -533,7 +492,6 @@ export const removeListEventsFromUserFeed = internalMutation({
     }
 
     for (const etl of eventToLists) {
-      // Check if event is in another list the user follows (using precomputed set)
       const isInOtherFollowedList = eventsInOtherFollowedLists.has(etl.eventId);
 
       const existingFollowedListsEntry = await ctx.db
@@ -547,7 +505,6 @@ export const removeListEventsFromUserFeed = internalMutation({
         continue;
       }
 
-      // Remove from followedLists feed only if event is not in any other followed list
       if (!isInOtherFollowedList) {
         const similarityGroupId = existingFollowedListsEntry.similarityGroupId;
         await userFeedsAggregate.deleteIfExists(
@@ -556,7 +513,6 @@ export const removeListEventsFromUserFeed = internalMutation({
         );
         await ctx.db.delete(existingFollowedListsEntry._id);
 
-        // Update grouped feed entry
         if (similarityGroupId) {
           await ctx.runMutation(
             internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -564,8 +520,6 @@ export const removeListEventsFromUserFeed = internalMutation({
           );
         }
       } else if (existingFollowedListsEntry.sourceListId === listId) {
-        // Keep the entry but update sourceListId to a different followed list
-        // that also contains this event so the source attribution doesn't go stale.
         const newSourceListId = eventToReplacementList.get(etl.eventId);
         if (newSourceListId) {
           const oldDoc = existingFollowedListsEntry;
@@ -582,7 +536,6 @@ export const removeListEventsFromUserFeed = internalMutation({
   },
 });
 
-// Helper to add an event to all followers' followedLists feeds when added to a list
 export const addEventToListFollowersFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -620,7 +573,6 @@ export const addEventToListFollowersFeeds = internalMutation({
 
       const followedListsFeedId = `followedLists_${follow.userId}`;
 
-      // Upsert into followedLists feed
       await upsertFeedEntry(
         ctx,
         followedListsFeedId,
@@ -636,7 +588,6 @@ export const addEventToListFollowersFeeds = internalMutation({
   },
 });
 
-// Helper to remove an event from all followers' followedLists feeds when removed from a list
 export const removeEventFromListFollowersFeeds = internalMutation({
   args: {
     eventId: v.string(),
@@ -659,19 +610,16 @@ export const removeEventFromListFollowersFeeds = internalMutation({
       return;
     }
 
-    // Hoist eventToLists query outside the loop — the event's list memberships
-    // are the same regardless of which follower we're processing
     const eventListMemberships = await ctx.db
       .query("eventToLists")
       .withIndex("by_event", (q) => q.eq("eventId", eventId))
       .collect();
     const eventListIds = new Set(eventListMemberships.map((etl) => etl.listId));
-    eventListIds.delete(listId); // Exclude the list being removed from
+    eventListIds.delete(listId);
 
     for (const follow of listFollows) {
       const followedListsFeedId = `followedLists_${follow.userId}`;
 
-      // Check if event is in another list this user follows
       const userListFollows = await ctx.db
         .query("listFollows")
         .withIndex("by_user", (q) => q.eq("userId", follow.userId))
@@ -679,12 +627,10 @@ export const removeEventFromListFollowersFeeds = internalMutation({
 
       const followedListIds = new Set(userListFollows.map((f) => f.listId));
 
-      // Check intersection of user's followed lists with event's other lists
       const isInOtherFollowedList = [...eventListIds].some((lid) =>
         followedListIds.has(lid),
       );
 
-      // Remove from followedLists feed only if event is not in any other followed list
       if (!isInOtherFollowedList) {
         const existingFollowedListsEntry = await ctx.db
           .query("userFeeds")
@@ -702,7 +648,6 @@ export const removeEventFromListFollowersFeeds = internalMutation({
           );
           await ctx.db.delete(existingFollowedListsEntry._id);
 
-          // Update grouped feed entry
           if (similarityGroupId) {
             await ctx.runMutation(
               internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -715,8 +660,6 @@ export const removeEventFromListFollowersFeeds = internalMutation({
   },
 });
 
-// Helper to add all public upcoming events from a followed user to the follower's "Following" feed
-// This is the batch mutation that processes a page of events at a time
 export const addUserEventsToUserFeedBatch = internalMutation({
   args: {
     userId: v.string(),
@@ -734,7 +677,6 @@ export const addUserEventsToUserFeedBatch = internalMutation({
     const currentTime = Date.now();
     const followedUsersFeedId = `followedUsers_${userId}`;
 
-    // Query events with pagination
     const result = await ctx.db
       .query("events")
       .withIndex("by_user", (q) => q.eq("userId", followedUserId))
@@ -743,7 +685,6 @@ export const addUserEventsToUserFeedBatch = internalMutation({
     let added = 0;
 
     for (const event of result.page) {
-      // Only add public upcoming events
       if (event.visibility !== "public") {
         continue;
       }
@@ -751,14 +692,12 @@ export const addUserEventsToUserFeedBatch = internalMutation({
       const eventStartTime = new Date(event.startDateTime).getTime();
       const eventEndTime = new Date(event.endDateTime).getTime();
 
-      // Skip past events (endDateTime < now)
       if (eventEndTime < currentTime) {
         continue;
       }
 
       const similarityGroupId = event.similarityGroupId;
 
-      // Check if already in feed
       const existing = await ctx.db
         .query("userFeeds")
         .withIndex("by_feed_event", (q) =>
@@ -781,7 +720,6 @@ export const addUserEventsToUserFeedBatch = internalMutation({
         const insertedDoc = (await ctx.db.get(id))!;
         await userFeedsAggregate.replaceOrInsert(ctx, insertedDoc, insertedDoc);
 
-        // Update grouped feed entry if similarityGroupId exists
         if (similarityGroupId) {
           await ctx.runMutation(
             internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -801,7 +739,6 @@ export const addUserEventsToUserFeedBatch = internalMutation({
   },
 });
 
-// Action to orchestrate adding user events to feed in batches
 export const addUserEventsToUserFeedAction = internalAction({
   args: {
     userId: v.string(),
@@ -815,9 +752,8 @@ export const addUserEventsToUserFeedAction = internalAction({
     let totalProcessed = 0;
     let totalAdded = 0;
     let cursor: string | null = null;
-    const batchSize = 100; // Process 100 events per batch
+    const batchSize = 100;
 
-    // Process batches until no more data
     while (true) {
       const result: {
         processed: number;
@@ -854,7 +790,6 @@ export const addUserEventsToUserFeedAction = internalAction({
   },
 });
 
-// Legacy mutation kept for backwards compatibility - schedules the action
 export const addUserEventsToUserFeed = internalMutation({
   args: {
     userId: v.string(),
@@ -862,7 +797,6 @@ export const addUserEventsToUserFeed = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, { userId, followedUserId }) => {
-    // Schedule the action to run immediately
     await ctx.scheduler.runAfter(
       0,
       internal.feedHelpers.addUserEventsToUserFeedAction,
@@ -916,13 +850,8 @@ export const addEventToContributorLists = internalMutation({
           listId: membership.listId,
         });
 
-        // Maintain the list's own feed (list_${listId}) alongside the
-        // eventToLists insert so getEventsForList stays consistent.
         await addEventToListFeedInline(ctx, eventId, membership.listId);
 
-        // Schedule follower feed fan-out atomically with the insert.
-        // Both the insert and this schedule commit in the same transaction,
-        // matching the pattern in backfillContributorEventsBatch (lists.ts).
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.addEventToListFollowersFeeds,
@@ -938,7 +867,6 @@ export const addEventToContributorLists = internalMutation({
   },
 });
 
-// Helper to remove all events from an unfollowed user from the follower's "Following" feed
 export const removeUserEventsFromUserFeed = internalMutation({
   args: {
     userId: v.string(),
@@ -946,7 +874,6 @@ export const removeUserEventsFromUserFeed = internalMutation({
   },
   returns: v.null(),
   handler: async (ctx, { userId, unfollowedUserId }) => {
-    // Get all events from the unfollowed user
     const events = await ctx.db
       .query("events")
       .withIndex("by_user", (q) => q.eq("userId", unfollowedUserId))
@@ -955,7 +882,6 @@ export const removeUserEventsFromUserFeed = internalMutation({
     const followedUsersFeedId = `followedUsers_${userId}`;
 
     for (const event of events) {
-      // Remove from followedUsers feed (Following tab only)
       const existingEntry = await ctx.db
         .query("userFeeds")
         .withIndex("by_feed_event", (q) =>
@@ -968,7 +894,6 @@ export const removeUserEventsFromUserFeed = internalMutation({
         await userFeedsAggregate.deleteIfExists(ctx, existingEntry);
         await ctx.db.delete(existingEntry._id);
 
-        // Update grouped feed entry
         if (similarityGroupId) {
           await ctx.runMutation(
             internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -982,23 +907,6 @@ export const removeUserEventsFromUserFeed = internalMutation({
   },
 });
 
-/**
- * List detail feed: `list_${listId}`
- *
- * Every list has a feed mirroring its eventToLists membership so the list
- * detail query can paginate directly off `userFeeds.by_feed_visibility_hasEnded_startTime`,
- * matching how `getPublicUserFeed` reads `user_${userId}`. This avoids the
- * sparse-page problem where paginating `eventToLists` and filtering after
- * produced partial pages on large lists with many past or private events.
- *
- * Write-path rules:
- * - Added on `addEventToList` / `addEventToContributorLists` / `backfillContributorEventsBatch`.
- * - Removed on `removeEventFromList` / `removeContributorEventsBatch` and when a list is deleted.
- * - Time/visibility/deletion of the underlying event are already fanned out
- *   across every `userFeeds` entry by `updateEventTimesInAllFeeds`,
- *   `updateEventVisibilityInFeeds`, and `removeEventFromFeeds`, so no extra
- *   wiring is needed there.
- */
 export function listFeedId(listId: string): string {
   return `list_${listId}`;
 }
@@ -1061,13 +969,6 @@ export async function removeEventFromListFeedInline(
   }
 }
 
-/**
- * Batch-delete up to `batchSize` `list_${listId}` feed entries. Used by the
- * user-deletion cascade. Uses `.take()` rather than `.paginate()` because
- * we delete every row we pull on the index prefix — a paginate cursor
- * would point at a deleted document in the next transaction, which is
- * unsafe. The caller loops until `processed === 0`.
- */
 export const removeListFeedBatch = internalMutation({
   args: {
     listId: v.string(),
@@ -1110,17 +1011,10 @@ export const removeListFeedBatch = internalMutation({
   },
 });
 
-/**
- * Orchestrator for `removeListFeedBatch`. Called by the user-deletion cascade
- * where we don't want the caller to block waiting for many batches.
- */
 export const removeListFeedAction = internalAction({
   args: { listId: v.string() },
   returns: v.null(),
   handler: async (ctx, { listId }) => {
-    // take()/delete-everything pattern: loop until the batch returns zero
-    // rows. No cursor to track because each batch re-queries from the
-    // start of the index prefix.
     while (true) {
       const result: {
         processed: number;

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -14,7 +14,6 @@ import { userFeedsAggregate } from "./aggregates";
 import { getEventById } from "./model/events";
 import { getViewableListIds } from "./model/lists";
 
-// Helper function to get the current user ID from auth
 async function getUserId(ctx: QueryCtx): Promise<string | null> {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
@@ -23,8 +22,6 @@ async function getUserId(ctx: QueryCtx): Promise<string | null> {
   return identity.subject;
 }
 
-// Helper to batch-resolve sourceListId → list details (name, slug, and
-// visibility metadata used to gate attribution).
 async function resolveSourceListDetails(
   ctx: QueryCtx,
   feedEntries: { sourceListId?: string }[],
@@ -67,14 +64,12 @@ async function resolveSourceListDetails(
   return map;
 }
 
-// Helper function to query feed with common logic
 async function queryFeed(
   ctx: QueryCtx,
   feedId: string,
   paginationOpts: PaginationOptions,
   filter: "upcoming" | "past" = "upcoming",
 ) {
-  // Use the new index for efficient filtering
   const hasEnded = filter === "past";
   const order = filter === "upcoming" ? "asc" : "desc";
 
@@ -85,43 +80,29 @@ async function queryFeed(
     )
     .order(order);
 
-  // Paginate
   const feedResults = await feedQuery.paginate(paginationOpts);
 
-  // Resolve source list details and capture viewer for visibility checks
   const viewerId = await getUserId(ctx);
   const sourceListDetailsMap = await resolveSourceListDetails(
     ctx,
     feedResults.page,
   );
 
-  // Map feed entries to full events with users and eventFollows, preserving order
   const events = await Promise.all(
     feedResults.page.map(async (feedEntry) => {
       const event = await getEventById(ctx, feedEntry.eventId);
       if (!event) return null;
 
-      // Filter the event's lists down to ones the viewer can actually see
-      // before attributing them. Hidden private lists must not contribute to
-      // the +N badge or leak their existence (or name) to non-members.
       const viewableListIds = await getViewableListIds(
         ctx,
         event.lists ?? [],
         viewerId,
       );
 
-      // Strip private-unviewable lists from `event.lists` before sending to
-      // the client. The "Saved by" modal (SavedByModal) renders this array
-      // directly, so any private list that leaks here leaks its name/slug to
-      // viewers who can see the event but not the list. System/personal
-      // lists are left in place — those are hidden client-side and are not a
-      // privacy concern; they can still be useful for other consumers.
       const viewerFilteredLists = (event.lists ?? []).filter((l) =>
         viewableListIds.has(l.id),
       );
 
-      // Gate the primary attribution: if the viewer cannot see the source
-      // list, drop its name/slug so we don't leak metadata.
       const sourceListDetails = feedEntry.sourceListId
         ? sourceListDetailsMap.get(feedEntry.sourceListId)
         : undefined;
@@ -130,13 +111,6 @@ async function queryFeed(
         !!feedEntry.sourceListId &&
         viewableListIds.has(feedEntry.sourceListId);
 
-      // Count non-system lists this event belongs to BEYOND the source list
-      // (the source is already shown inline on the card as "via [List]", so
-      // the badge is intentionally labeled "+N additional"). The modal
-      // itself is a complete "Saved by" view and renders ALL non-system
-      // lists — including the source list — so modal length = N + 1 by
-      // design. Don't change this invariant without updating SavedByModal's
-      // `visibleLists` and the "+" prefix on the card badge together.
       const additionalSourceCount = viewerFilteredLists.filter(
         (l) => !l.isSystemList && l.id !== feedEntry.sourceListId,
       ).length;
@@ -151,7 +125,6 @@ async function queryFeed(
     }),
   );
 
-  // Filter out null events (should be rare)
   const validEvents = events.filter((event) => event !== null);
 
   return {
@@ -160,7 +133,6 @@ async function queryFeed(
   };
 }
 
-// Helper function to query grouped feed using userFeedGroups table
 async function queryGroupedFeed(
   ctx: QueryCtx,
   feedId: string,
@@ -170,7 +142,6 @@ async function queryGroupedFeed(
   const hasEnded = filter === "past";
   const order = filter === "upcoming" ? "asc" : "desc";
 
-  // Query from the grouped feed table
   const groupedQuery = ctx.db
     .query("userFeedGroups")
     .withIndex("by_feed_hasEnded_startTime", (q) =>
@@ -178,10 +149,8 @@ async function queryGroupedFeed(
     )
     .order(order);
 
-  // Paginate
   const groupedResults = await groupedQuery.paginate(paginationOpts);
 
-  // For each group entry, look up the primary event's feed entry for sourceListId
   const primaryFeedEntries = await Promise.all(
     groupedResults.page.map((groupEntry) =>
       ctx.db
@@ -193,7 +162,6 @@ async function queryGroupedFeed(
     ),
   );
 
-  // Resolve source list details and capture viewer for visibility checks
   const viewerId = await getUserId(ctx);
   const sourceEntries = primaryFeedEntries
     .filter((e): e is NonNullable<typeof e> => e !== null)
@@ -203,10 +171,8 @@ async function queryGroupedFeed(
     sourceEntries,
   );
 
-  // Enrich each group entry with the primary event data
   const enrichedGroups = await Promise.all(
     groupedResults.page.map(async (groupEntry, idx) => {
-      // Get the primary event with full enrichment
       const event = await getEventById(ctx, groupEntry.primaryEventId);
 
       if (!event) {
@@ -216,25 +182,16 @@ async function queryGroupedFeed(
       const feedEntry = primaryFeedEntries[idx];
       const sourceListId = feedEntry?.sourceListId;
 
-      // Filter the event's lists down to ones the viewer can actually see
-      // before attributing them. Hidden private lists must not contribute to
-      // the +N badge or leak their existence (or name) to non-members.
       const viewableListIds = await getViewableListIds(
         ctx,
         event.lists ?? [],
         viewerId,
       );
 
-      // Strip private-unviewable lists from `event.lists` before sending to
-      // the client. See matching note in queryFeed — both the "Saved by"
-      // modal and the +N badge operate on this single pre-filtered set, so
-      // they can never disagree.
       const viewerFilteredLists = (event.lists ?? []).filter((l) =>
         viewableListIds.has(l.id),
       );
 
-      // Gate the primary attribution: if the viewer cannot see the source
-      // list, drop its name/slug so we don't leak metadata.
       const sourceListDetails = sourceListId
         ? sourceListDetailsMap.get(sourceListId)
         : undefined;
@@ -243,10 +200,6 @@ async function queryGroupedFeed(
         !!sourceListId &&
         viewableListIds.has(sourceListId);
 
-      // Count non-system lists beyond the source list. See the matching note
-      // in `queryFeed` — the badge reads "+N additional" (source is shown
-      // inline on the card) and the modal renders the full set including
-      // the source, so modal length = N + 1 by design.
       const additionalSourceCount = viewerFilteredLists.filter(
         (l) => !l.isSystemList && l.id !== sourceListId,
       ).length;
@@ -263,7 +216,6 @@ async function queryGroupedFeed(
     }),
   );
 
-  // Filter out null entries (in case primary event was deleted)
   const validGroups = enrichedGroups.filter((group) => group !== null);
 
   return {
@@ -272,7 +224,6 @@ async function queryGroupedFeed(
   };
 }
 
-// Main feed query that uses proper hasEnded-based filtering
 export const getFeed = query({
   args: {
     feedId: v.string(),
@@ -280,28 +231,23 @@ export const getFeed = query({
     filter: v.union(v.literal("upcoming"), v.literal("past")),
   },
   handler: async (ctx, { feedId, paginationOpts, filter }) => {
-    // For personal feeds, verify access
     if (feedId.startsWith("user_")) {
       const requestedUserId = feedId.replace("user_", "");
       const currentUserId = await getUserId(ctx);
 
-      // Require authentication for user feeds
       if (!currentUserId) {
         throw new ConvexError("Authentication required to access user feeds");
       }
 
-      // Only allow access to own feed
       if (requestedUserId !== currentUserId) {
         throw new ConvexError("Unauthorized access to user feed");
       }
     }
 
-    // Use the common query function
     return queryFeed(ctx, feedId, paginationOpts, filter);
   },
 });
 
-// Helper query to get user's personal feed
 export const getMyFeed = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -315,12 +261,10 @@ export const getMyFeed = query({
 
     const feedId = `user_${userId}`;
 
-    // Use the common query function
     return queryFeed(ctx, feedId, paginationOpts, filter);
   },
 });
 
-// Helper query to get user's personal feed with grouped similar events
 export const getMyFeedGrouped = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -334,12 +278,10 @@ export const getMyFeedGrouped = query({
 
     const feedId = `user_${userId}`;
 
-    // Use the grouped query function
     return queryGroupedFeed(ctx, feedId, paginationOpts, filter);
   },
 });
 
-// Helper query to get followed lists feed
 export const getFollowedListsFeed = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -353,12 +295,10 @@ export const getFollowedListsFeed = query({
 
     const feedId = `followedLists_${userId}`;
 
-    // Use the common query function
     return queryFeed(ctx, feedId, paginationOpts, filter);
   },
 });
 
-// Helper query to get followed users feed (events from users you follow)
 export const getFollowedUsersFeed = query({
   args: {
     paginationOpts: paginationOptsValidator,
@@ -372,7 +312,6 @@ export const getFollowedUsersFeed = query({
 
     const feedId = `followedUsers_${userId}`;
 
-    // Use the common query function
     return queryFeed(ctx, feedId, paginationOpts, filter);
   },
 });
@@ -388,8 +327,6 @@ export const getDiscoverFeed = query({
   },
 });
 
-// Helper query to get a user's public feed (when publicListEnabled is true)
-// Uses the visibility index to filter at database level BEFORE pagination
 export const getPublicUserFeed = query({
   args: {
     username: v.string(),
@@ -397,7 +334,6 @@ export const getPublicUserFeed = query({
     filter: v.optional(v.union(v.literal("upcoming"), v.literal("past"))),
   },
   handler: async (ctx, { username, paginationOpts, filter = "upcoming" }) => {
-    // Get the user by username
     const user = await ctx.db
       .query("users")
       .withIndex("by_username", (q) => q.eq("username", username))
@@ -411,7 +347,6 @@ export const getPublicUserFeed = query({
     const hasEnded = filter === "past";
     const order = filter === "upcoming" ? "asc" : "desc";
 
-    // Filter visibility at index level BEFORE pagination
     const feedQuery = ctx.db
       .query("userFeeds")
       .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
@@ -424,7 +359,6 @@ export const getPublicUserFeed = query({
 
     const feedResults = await feedQuery.paginate(paginationOpts);
 
-    // Map feed entries to full events with users and eventFollows
     const events = await Promise.all(
       feedResults.page.map((entry) => getEventById(ctx, entry.eventId)),
     );
@@ -433,10 +367,6 @@ export const getPublicUserFeed = query({
   },
 });
 
-/**
- * Bound the scan for "last updated" — we only need the max `addedAt` across a
- * recent window per bucket, not every historical feed entry.
- */
 const PUBLIC_FEED_LAST_UPDATED_TAKE = 100;
 
 async function sampleMaxAddedAt(
@@ -444,11 +374,6 @@ async function sampleMaxAddedAt(
   feedId: string,
   hasEnded: boolean,
 ): Promise<number> {
-  // The index is ordered by startTime, not addedAt. We don't have a recency
-  // index on addedAt, so we sample the slice most likely to contain recent
-  // additions: near-term upcoming (asc) or most-recent past (desc). A new
-  // event added far from "now" in startTime can still be missed, but most
-  // recent activity clusters here so the "Last updated" label stays fresh.
   const order = hasEnded ? "desc" : "asc";
   const rows = await ctx.db
     .query("userFeeds")
@@ -523,7 +448,6 @@ export const getPublicListFeedLastUpdated = query({
   },
 });
 
-// Internal mutation to update hasEndedFlags for a batch of userFeeds entries
 export const updateHasEndedFlagsBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -539,13 +463,11 @@ export const updateHasEndedFlagsBatch = internalMutation({
     const currentTime = Date.now();
     let updated = 0;
 
-    // Get a single batch with the provided cursor
     const result = await ctx.db
       .query("userFeeds")
       .order("asc")
       .paginate({ numItems: batchSize, cursor });
 
-    // Process each entry in the batch
     for (const entry of result.page) {
       const shouldHaveEnded = entry.eventEndTime < currentTime;
 
@@ -569,7 +491,6 @@ export const updateHasEndedFlagsBatch = internalMutation({
   },
 });
 
-// Internal query to get discover feed events without pagination (for external integrations)
 export const getDiscoverEventsForIntegration = internalQuery({
   args: {
     limit: v.optional(v.number()),
@@ -620,12 +541,10 @@ export const getDiscoverEventsForIntegration = internalQuery({
       }),
     );
 
-    // Filter out null events and return valid events
     return events.filter((event) => event !== null);
   },
 });
 
-// Internal action to orchestrate updating hasEnded flags across all userFeeds
 export const updateHasEndedFlagsAction = internalAction({
   args: {},
   returns: v.object({
@@ -638,7 +557,6 @@ export const updateHasEndedFlagsAction = internalAction({
     let cursor: string | null = null;
     const batchSize = 2048;
 
-    // Process batches until no more data
     while (true) {
       const result: {
         processed: number;
@@ -670,7 +588,6 @@ export const updateHasEndedFlagsAction = internalAction({
   },
 });
 
-// Internal mutation to update hasEndedFlags for a batch of userFeedGroups entries
 export const updateGroupedHasEndedFlagsBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -686,13 +603,11 @@ export const updateGroupedHasEndedFlagsBatch = internalMutation({
     const currentTime = Date.now();
     let updated = 0;
 
-    // Get a single batch with the provided cursor
     const result = await ctx.db
       .query("userFeedGroups")
       .order("asc")
       .paginate({ numItems: batchSize, cursor });
 
-    // Process each entry in the batch
     for (const entry of result.page) {
       const shouldHaveEnded = entry.eventEndTime < currentTime;
 
@@ -713,7 +628,6 @@ export const updateGroupedHasEndedFlagsBatch = internalMutation({
   },
 });
 
-// Internal action to orchestrate updating hasEnded flags across all userFeedGroups
 export const updateGroupedHasEndedFlagsAction = internalAction({
   args: {},
   returns: v.object({
@@ -726,7 +640,6 @@ export const updateGroupedHasEndedFlagsAction = internalAction({
     let cursor: string | null = null;
     const batchSize = 2048;
 
-    // Process batches until no more data
     while (true) {
       const result: {
         processed: number;

--- a/packages/backend/convex/files.ts
+++ b/packages/backend/convex/files.ts
@@ -3,9 +3,6 @@ import { ConvexError, v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import * as Files from "./model/files";
 
-/**
- * Upload base64 image to CDN
- */
 export const uploadImage = internalAction({
   args: {
     base64Image: v.string(),

--- a/packages/backend/convex/guestOnboarding.ts
+++ b/packages/backend/convex/guestOnboarding.ts
@@ -4,9 +4,6 @@ import { internal } from "./_generated/api";
 import { internalMutation, mutation } from "./_generated/server";
 import { onboardingDataValidator } from "./schema";
 
-/**
- * Save onboarding data for a guest user
- */
 export const saveGuestOnboardingData = mutation({
   args: {
     guestUserId: v.string(),
@@ -16,20 +13,17 @@ export const saveGuestOnboardingData = mutation({
   handler: async (ctx, args) => {
     const { guestUserId, data } = args;
 
-    // Check if we already have onboarding data for this guest
     const existing = await ctx.db
       .query("guestOnboardingData")
       .withIndex("by_owner", (q) => q.eq("ownerToken", guestUserId))
       .first();
 
     if (existing) {
-      // Update existing data
       await ctx.db.patch(existing._id, {
         data: { ...existing.data, ...data },
         updatedAt: new Date().toISOString(),
       });
     } else {
-      // Create new onboarding data
       await ctx.db.insert("guestOnboardingData", {
         ownerToken: guestUserId,
         isGuest: true,
@@ -43,9 +37,6 @@ export const saveGuestOnboardingData = mutation({
   },
 });
 
-/**
- * Transfer guest onboarding data to authenticated user
- */
 export const transferGuestOnboardingData = mutation({
   args: {
     guestUserId: v.string(),
@@ -60,7 +51,6 @@ export const transferGuestOnboardingData = mutation({
       });
     }
 
-    // Find guest onboarding data
     const guestData = await ctx.db
       .query("guestOnboardingData")
       .withIndex("by_owner", (q) => q.eq("ownerToken", args.guestUserId))
@@ -70,16 +60,12 @@ export const transferGuestOnboardingData = mutation({
       return { transferred: false };
     }
 
-    // Get the user
     const user = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", identity.subject))
       .unique();
 
     if (!user) {
-      // User hasn't been created by Clerk webhook yet
-      // This can happen due to race conditions during signup
-      // Schedule a retry for 5 seconds later
       console.log("User not found yet, scheduling retry", {
         userId: identity.subject,
         guestUserId: args.guestUserId,
@@ -98,23 +84,17 @@ export const transferGuestOnboardingData = mutation({
       return { transferred: false };
     }
 
-    // Update user with onboarding data
     await ctx.db.patch(user._id, {
       onboardingData: guestData.data,
       onboardingCompletedAt: guestData.data.completedAt || null,
     });
 
-    // Delete guest data
     await ctx.db.delete(guestData._id);
 
     return { transferred: true };
   },
 });
 
-/**
- * Internal mutation to retry guest data transfer
- * This is called by the scheduler when initial transfer fails due to race conditions
- */
 export const retryTransfer = internalMutation({
   args: {
     userId: v.string(),
@@ -125,7 +105,6 @@ export const retryTransfer = internalMutation({
   handler: async (ctx, args) => {
     const maxAttempts = 3;
 
-    // Find guest onboarding data
     const guestData = await ctx.db
       .query("guestOnboardingData")
       .withIndex("by_owner", (q) => q.eq("ownerToken", args.guestUserId))
@@ -138,7 +117,6 @@ export const retryTransfer = internalMutation({
       return;
     }
 
-    // Get the user
     const user = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", args.userId))
@@ -154,8 +132,7 @@ export const retryTransfer = internalMutation({
         return;
       }
 
-      // Schedule another retry with exponential backoff
-      const delayMs = Math.min(5000 * Math.pow(2, args.attemptCount), 30000); // Max 30 seconds
+      const delayMs = Math.min(5000 * Math.pow(2, args.attemptCount), 30000);
       console.log("User still not found, scheduling another retry", {
         userId: args.userId,
         guestUserId: args.guestUserId,
@@ -175,20 +152,17 @@ export const retryTransfer = internalMutation({
       return;
     }
 
-    // User exists! Transfer the data
     console.log("Retrying guest data transfer - user now exists", {
       userId: args.userId,
       guestUserId: args.guestUserId,
       attemptCount: args.attemptCount,
     });
 
-    // Update user with onboarding data
     await ctx.db.patch(user._id, {
       onboardingData: guestData.data,
       onboardingCompletedAt: guestData.data.completedAt || null,
     });
 
-    // Delete guest data
     await ctx.db.delete(guestData._id);
 
     console.log("Guest data successfully transferred on retry", {

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -22,7 +22,6 @@ interface ClerkWebhookEvent {
 
 const http = httpRouter();
 
-// Helpers for JSON parsing, data URL handling, format validation, and size limits
 const ALLOWED_FORMATS = ["image/webp", "image/jpeg"] as const;
 type AllowedFormat = (typeof ALLOWED_FORMATS)[number];
 
@@ -60,16 +59,14 @@ function validateFormat(format: string | undefined): format is AllowedFormat {
   return !!format && (ALLOWED_FORMATS as readonly string[]).includes(format);
 }
 
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB limit
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
 function isTooLargeBase64(base64: string): boolean {
   const compact = base64.replace(/\s+/g, "");
-  // Base64 encoding increases size by ~33%, +2 for padding
   const maxChars = Math.ceil(MAX_IMAGE_BYTES / 3) * 4 + 2;
   return compact.length > maxChars;
 }
 
-// Helper function for classifying database constraint errors
 function isUniqueConstraintError(error: unknown): boolean {
   const msg =
     error instanceof Error
@@ -139,7 +136,6 @@ http.route({
   }),
 });
 
-// Share extension capture endpoint
 http.route({
   path: "/share/v1/capture",
   method: "POST",
@@ -156,7 +152,6 @@ http.route({
         );
       }
 
-      // Resolve token → user
       let resolved;
       try {
         resolved = await ctx.runQuery(internal.shareTokens.resolveShareToken, {
@@ -189,7 +184,6 @@ http.route({
         );
       }
 
-      // Parse body using helper
       const parsedJson = await parseJsonOr400(request);
       if (!parsedJson.ok) return parsedJson.response;
       const body = parsedJson.body as {
@@ -216,7 +210,6 @@ http.route({
       const lists = Array.isArray(body.lists) ? body.lists : [];
       const visibility = body.visibility ?? "private";
 
-      // Validate format
       const providedFormat = body.format;
       if (providedFormat && !validateFormat(providedFormat)) {
         return new Response(
@@ -230,7 +223,6 @@ http.route({
           ? providedFormat
           : undefined;
 
-      // Enforce maximum size using character-bound check
       if (isTooLargeBase64(base64)) {
         return new Response(
           JSON.stringify({ ok: false, error: "Payload too large" }),
@@ -238,7 +230,6 @@ http.route({
         );
       }
 
-      // Schedule processing
       const result = await ctx.runMutation(api.ai.eventFromImageBase64Direct, {
         base64Image: base64,
         timezone,
@@ -328,13 +319,11 @@ function parseVenueFromLocation(location: string | undefined): {
   };
 }
 
-// FreakScene integration endpoint
 http.route({
   path: "/api/freakscene",
   method: "GET",
   handler: httpAction(async (ctx) => {
     try {
-      // Get discover feed events
       const events = await ctx.runQuery(
         internal.feeds.getDiscoverEventsForIntegration,
         { limit: 500 },
@@ -381,7 +370,6 @@ http.route({
   }),
 });
 
-// Health check endpoint
 http.route({
   path: "/sync/health",
   method: "GET",

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -24,7 +24,6 @@ type EnrichedEvent = Awaited<
   ReturnType<typeof enrichEventsAndFilterNulls>
 >[number];
 
-// Helper function to get the current user ID from auth
 async function getUserId(ctx: QueryCtx): Promise<string | null> {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
@@ -33,14 +32,11 @@ async function getUserId(ctx: QueryCtx): Promise<string | null> {
   return identity.subject;
 }
 
-// Result type for list access check
 type ListAccessResult =
   | { status: "notFound" }
   | { status: "forbidden" }
   | { status: "ok"; list: Doc<"lists"> };
 
-// Helper function to check if user can view a list
-// Returns a discriminated union to distinguish "not found" from "access denied"
 async function checkListAccess(
   ctx: QueryCtx,
   listId: string,
@@ -55,24 +51,19 @@ async function checkListAccess(
     return { status: "notFound" };
   }
 
-  // Public and unlisted lists are viewable by anyone
   if (list.visibility === "public" || list.visibility === "unlisted") {
     return { status: "ok", list };
   }
 
-  // Private lists are only viewable by owner or members
   if (!userId) {
     return { status: "forbidden" };
   }
 
-  // At this point, userId is guaranteed to be a string
   const userIdString = userId;
 
-  // Owner can always view
   if (list.userId === userIdString) {
     return { status: "ok", list };
   }
-  // Check if user is a member
   const membership = await ctx.db
     .query("listMembers")
     .withIndex("by_list_and_user", (q) =>
@@ -87,8 +78,6 @@ async function checkListAccess(
   return { status: "forbidden" };
 }
 
-// Helper function to check if user can view a list (backward compatibility)
-// Returns boolean for cases where we don't need to distinguish error types
 async function canUserViewList(
   ctx: QueryCtx,
   listId: string,
@@ -107,7 +96,6 @@ async function _canUserContributeToList(
     return false;
   }
 
-  // At this point, userId is guaranteed to be a string
   const userIdString = userId;
 
   const list = await ctx.db
@@ -119,19 +107,16 @@ async function _canUserContributeToList(
     return false;
   }
 
-  // Owner can always contribute
   if (list.userId === userIdString) {
     return true;
   }
 
   const contribution = list.contribution ?? "open";
 
-  // Open contribution mode: anyone who can view can contribute
   if (contribution === "open") {
     return canUserViewList(ctx, listId, userIdString);
   }
 
-  // Restricted and owner modes: only members can contribute
   const membership = await ctx.db
     .query("listMembers")
     .withIndex("by_list_and_user", (q) =>
@@ -141,15 +126,10 @@ async function _canUserContributeToList(
   return !!membership;
 }
 
-/**
- * Internal helper: get or create a user's personal Soonlist.
- * Used during event creation and user signup.
- */
 export async function getOrCreatePersonalList(
   ctx: MutationCtx,
   userId: string,
 ): Promise<Doc<"lists">> {
-  // Look up existing personal list
   const existing = await ctx.db
     .query("lists")
     .withIndex("by_user_and_isSystemList_and_systemListType", (q) =>
@@ -164,7 +144,6 @@ export async function getOrCreatePersonalList(
     return existing;
   }
 
-  // Look up user for display name
   const user = await ctx.db
     .query("users")
     .withIndex("by_custom_id", (q) => q.eq("id", userId))
@@ -185,18 +164,12 @@ export async function getOrCreatePersonalList(
     slug: `user-${username}`,
     created_at: new Date().toISOString(),
     updatedAt: null,
-    // New lists never need the backfill fallback — the write path
-    // (addEventToList → addEventToListFeedInline) keeps the list feed in
-    // lockstep with eventToLists from day one.
     feedBackfilledAt: new Date().toISOString(),
   });
 
   return (await ctx.db.get(docId))!;
 }
 
-/**
- * Get the personal list for a user (public query)
- */
 export const getPersonalListForUser = query({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {
@@ -228,25 +201,18 @@ export const getPersonalListForUser = query({
   },
 });
 
-/**
- * Get all public/unlisted lists for a user (personal list first), plus contributed lists.
- * Includes follower count per list.
- */
 export const getListsForUser = query({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {
-    // Get user's own lists
     const ownedLists = await ctx.db
       .query("lists")
       .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
 
-    // Filter to public/unlisted only
     const visibleOwned = ownedLists.filter(
       (l) => l.visibility === "public" || l.visibility === "unlisted",
     );
 
-    // Get lists where user is a member (contributor)
     const memberships = await ctx.db
       .query("listMembers")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -269,17 +235,14 @@ export const getListsForUser = query({
         l.userId !== userId, // Exclude owned lists (already in visibleOwned)
     );
 
-    // Combine and deduplicate
     const allLists = [...visibleOwned, ...visibleContributed];
 
-    // Sort: personal list first, then by name
     allLists.sort((a, b) => {
       if (a.isSystemList && a.systemListType === "personal") return -1;
       if (b.isSystemList && b.systemListType === "personal") return 1;
       return a.name.localeCompare(b.name);
     });
 
-    // Add follower count per list (O(log n) via aggregate)
     const listsWithCounts = await Promise.all(
       allLists.map(async (list) => {
         const followerCount = await listFollowsAggregate.count(ctx, {
@@ -294,9 +257,6 @@ export const getListsForUser = query({
   },
 });
 
-/**
- * Get lists where the current user is a listMember (contributing to)
- */
 export const getContributingLists = query({
   args: {},
   handler: async (ctx) => {
@@ -324,9 +284,6 @@ export const getContributingLists = query({
   },
 });
 
-/**
- * Follow a list
- */
 export const followList = mutation({
   args: {
     listId: v.string(),
@@ -345,7 +302,6 @@ export const followList = mutation({
       throw new ConvexError("Cannot follow this list: access denied");
     }
 
-    // accessResult.status === "ok", and we have the list
     const existingFollow = await ctx.db
       .query("listFollows")
       .withIndex("by_user_and_list", (q) =>
@@ -373,10 +329,6 @@ export const followList = mutation({
   },
 });
 
-/**
- * Follow a user's personal list by username.
- * Encapsulates user lookup, personal list lookup, and follow in one server-side call.
- */
 export const followUserByUsername = mutation({
   args: { username: v.string() },
   handler: async (ctx, { username }) => {
@@ -385,7 +337,6 @@ export const followUserByUsername = mutation({
       throw new ConvexError("Authentication required");
     }
 
-    // Look up target user by username
     const targetUser = await ctx.db
       .query("users")
       .withIndex("by_username", (q) => q.eq("username", username))
@@ -395,7 +346,6 @@ export const followUserByUsername = mutation({
       return { success: false as const, reason: "User not found" };
     }
 
-    // Get their personal list
     const personalList = await ctx.db
       .query("lists")
       .withIndex("by_user_and_isSystemList_and_systemListType", (q) =>
@@ -420,7 +370,6 @@ export const followUserByUsername = mutation({
       };
     }
 
-    // Check if already following
     const existingFollow = await ctx.db
       .query("listFollows")
       .withIndex("by_user_and_list", (q) =>
@@ -448,9 +397,6 @@ export const followUserByUsername = mutation({
   },
 });
 
-/**
- * Unfollow a list
- */
 export const unfollowList = mutation({
   args: {
     listId: v.string(),
@@ -481,9 +427,6 @@ export const unfollowList = mutation({
   },
 });
 
-/**
- * Get all lists a user follows
- */
 export const getFollowedLists = query({
   args: {},
   handler: async (ctx) => {
@@ -523,9 +466,6 @@ export const getFollowedLists = query({
   },
 });
 
-/**
- * Get all users following a list
- */
 export const getListFollowers = query({
   args: {
     listId: v.string(),
@@ -544,7 +484,6 @@ export const getListFollowers = query({
       throw new ConvexError("Cannot view this list: access denied");
     }
 
-    // accessResult.status === "ok"
     const follows = await ctx.db
       .query("listFollows")
       .withIndex("by_list", (q) => q.eq("listId", listId))
@@ -554,9 +493,6 @@ export const getListFollowers = query({
   },
 });
 
-/**
- * Check if user follows a specific list
- */
 export const isFollowingList = query({
   args: {
     listId: v.string(),
@@ -578,9 +514,6 @@ export const isFollowingList = query({
   },
 });
 
-/**
- * Add a member to a list (for restricted/owner contribution modes)
- */
 export const addListMember = mutation({
   args: {
     listId: v.string(),
@@ -592,7 +525,6 @@ export const addListMember = mutation({
       throw new ConvexError("Authentication required");
     }
 
-    // At this point, userId is guaranteed to be a string
     const userIdString = userId;
 
     const list = await ctx.db
@@ -628,9 +560,6 @@ export const addListMember = mutation({
   },
 });
 
-/**
- * Remove a member from a list
- */
 export const removeListMember = mutation({
   args: {
     listId: v.string(),
@@ -642,7 +571,6 @@ export const removeListMember = mutation({
       throw new ConvexError("Authentication required");
     }
 
-    // At this point, userId is guaranteed to be a string
     const userIdString = userId;
 
     const list = await ctx.db
@@ -673,15 +601,6 @@ export const removeListMember = mutation({
   },
 });
 
-/**
- * Get a list by its slug.
- *
- * Returns a discriminated union so callers can distinguish
- * "not found" from "exists but private":
- *   { status: "ok", list }       — public/unlisted or viewer has access
- *   { status: "private", owner } — list exists but viewer cannot see contents
- *   { status: "notFound" }       — no list with this slug
- */
 const listOwnerValidator = v.union(
   v.object({
     _id: v.id("users"),
@@ -782,9 +701,6 @@ export const getBySlug = query({
         }
       : null;
 
-    // Use the same access rules as the rest of the backend so owners and
-    // members of a private list can still resolve its detail page (used by
-    // the saver-attribution flow which deep-links to `/list/[slug]`).
     const viewerId = await getUserId(ctx);
     const accessResult = await checkListAccess(ctx, list.id, viewerId);
 
@@ -819,16 +735,6 @@ export const getBySlug = query({
   },
 });
 
-/**
- * Get contributors (non-owner members with role="contributor") for a list.
- *
- * Used by the list detail hero to show who has captured events into the list,
- * mirroring the "From these Soonlists" attribution on event detail (owner is
- * the creator-equivalent, contributors are the savers-equivalent).
- *
- * Returns a bounded slice of UserForDisplay-shaped users. Respects list
- * access rules — private lists only yield contributors to authorized viewers.
- */
 export const getContributorsForList = query({
   args: {
     slug: v.string(),
@@ -886,9 +792,6 @@ export const getContributorsForList = query({
   },
 });
 
-/**
- * Get all system lists
- */
 export const getSystemLists = query({
   args: {},
   returns: v.array(
@@ -929,9 +832,6 @@ export const getSystemLists = query({
   },
 });
 
-/**
- * Add a contributor to a contributor list
- */
 export const addContributor = mutation({
   args: {
     listId: v.string(),
@@ -1007,9 +907,6 @@ export const addContributor = mutation({
   },
 });
 
-/**
- * Remove a contributor from a contributor list
- */
 export const removeContributor = mutation({
   args: {
     listId: v.string(),
@@ -1065,9 +962,6 @@ export const removeContributor = mutation({
   },
 });
 
-/**
- * Internal: Remove a contributor's events from a list (one batch/page)
- */
 export const removeContributorEventsBatch = internalMutation({
   args: {
     listId: v.string(),
@@ -1097,12 +991,8 @@ export const removeContributorEventsBatch = internalMutation({
       if (event?.userId === contributorUserId) {
         await ctx.db.delete(entry._id);
 
-        // Keep the list's own feed (list_${listId}) in sync with eventToLists.
         await removeEventFromListFeedInline(ctx, entry.eventId, listId);
 
-        // Schedule feed cleanup in a separate transaction to reduce bandwidth
-        // of this batch mutation — removeEventFromListFollowersFeeds does
-        // multiple queries per follower
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.removeEventFromListFollowersFeeds,
@@ -1124,10 +1014,6 @@ export const removeContributorEventsBatch = internalMutation({
   },
 });
 
-/**
- * Internal: Remove a contributor's events from a list.
- * Orchestrates batch processing to avoid transaction limits.
- */
 export const removeContributorEventsAction = internalAction({
   args: {
     listId: v.string(),
@@ -1176,9 +1062,6 @@ export const removeContributorEventsAction = internalAction({
   },
 });
 
-/**
- * Internal: Backfill a contributor's existing public events into a list (one batch/page)
- */
 export const backfillContributorEventsBatch = internalMutation({
   args: {
     listId: v.string(),
@@ -1218,13 +1101,8 @@ export const backfillContributorEventsBatch = internalMutation({
           listId,
         });
 
-        // Maintain the list's own feed (list_${listId}) inline in this
-        // batch — addEventToListFeedInline is a single upsert on userFeeds
-        // and stays well within the per-mutation transaction budget.
         await addEventToListFeedInline(ctx, event.id, listId);
 
-        // Schedule feed population in a separate transaction to avoid
-        // hitting transaction limits when there are many followers
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.addEventToListFollowersFeeds,
@@ -1246,11 +1124,6 @@ export const backfillContributorEventsBatch = internalMutation({
   },
 });
 
-/**
- * Enrich a page of raw event docs with user / follows / lists data and
- * strip lists the viewer can't see — shared by both the feed-backed path
- * and the backfill-window fallback so they return the same shape.
- */
 async function enrichListEventsForViewer(
   ctx: QueryCtx,
   events: Doc<"events">[],
@@ -1258,12 +1131,6 @@ async function enrichListEventsForViewer(
 ) {
   const enrichedEvents = await enrichEventsAndFilterNulls(ctx, events);
 
-  // Strip private-unviewable lists from each event.lists before returning.
-  // enrichEventsAndFilterNulls hydrates event.lists with ALL lists the
-  // event belongs to, including ones this viewer can't see. The client
-  // (SavedByModal) trusts the server's filtering, so we must enforce
-  // visibility here — same contract as queryFeed/queryGroupedFeed in
-  // feeds.ts.
   const allListsAcrossEvents = enrichedEvents.flatMap((e) => e.lists ?? []);
   const viewableListIds = await getViewableListIds(
     ctx,
@@ -1276,30 +1143,12 @@ async function enrichListEventsForViewer(
   }));
 }
 
-/**
- * Continuation cursors emitted by the backfill-window fallback are tagged
- * with this prefix so the next paginate call routes back to the fallback
- * path. Without it, page 2 would feed an `eventToLists` cursor into the
- * `userFeeds` index — Convex would reject it as an invalid cursor.
- */
 const FALLBACK_CURSOR_PREFIX = "etl:";
 
 function isFallbackCursor(cursor: string | null): cursor is string {
   return cursor?.startsWith(FALLBACK_CURSOR_PREFIX) ?? false;
 }
 
-/**
- * Backfill-window fallback: paginate `eventToLists` directly and filter
- * events in memory. Reproduces the pre-feed behavior — sparse pages and
- * all — but only fires when `list_${listId}` has zero `userFeeds` entries
- * for a list that still has membership rows. The migration drains this
- * branch into the feed; once it completes for a list the dense feed path
- * takes over.
- *
- * Once a request enters this path, every subsequent page must stay on it —
- * the returned `continueCursor` is wrapped with `FALLBACK_CURSOR_PREFIX`
- * and the main handler re-routes wrapped cursors back here.
- */
 async function getEventsForListBackfillFallback(
   ctx: QueryCtx,
   listId: string,
@@ -1333,8 +1182,6 @@ async function getEventsForListBackfillFallback(
 
   return {
     ...eventToLists,
-    // Tag the cursor only when there's more data to fetch; once isDone the
-    // client won't call back, so leave the original (possibly empty) value.
     continueCursor: eventToLists.isDone
       ? eventToLists.continueCursor
       : `${FALLBACK_CURSOR_PREFIX}${eventToLists.continueCursor}`,
@@ -1342,20 +1189,6 @@ async function getEventsForListBackfillFallback(
   };
 }
 
-/**
- * Get events for a list by slug.
- *
- * Paginates the list's dedicated feed (`list_${listId}`) in `userFeeds` so
- * every page comes back densely filled with matching events — previously we
- * paginated the `eventToLists` junction and then discarded past/private
- * events, which produced sparse pages on large lists.
- *
- * Write-path wiring that keeps the feed in sync lives in `feedHelpers.ts`
- * (`addEventToListFeedInline` / `removeEventFromListFeedInline` /
- * `removeListFeedAction`). Existing `eventToLists` rows are backfilled by
- * `migrations/backfillListFeeds.ts`; lists not yet reached by the migration
- * fall back to a legacy scan so the deploy window doesn't show empty lists.
- */
 export const getEventsForList = query({
   args: {
     slug: v.string(),
@@ -1364,10 +1197,6 @@ export const getEventsForList = query({
   },
   handler: async (ctx, { slug, paginationOpts, filter = "upcoming" }) => {
     const emptyResults = async () => {
-      // Pass a null cursor rather than the incoming one: the page is empty
-      // anyway (isDone=true), and a tagged fallback cursor (`etl:...`) or
-      // any stale cursor from a deleted/inaccessible list would otherwise
-      // be rejected by `userFeeds.paginate` as invalid.
       const emptyPage = await ctx.db
         .query("userFeeds")
         .withIndex("by_feed_hasEnded_startTime", (q) =>
@@ -1380,7 +1209,6 @@ export const getEventsForList = query({
       };
     };
 
-    // Find the list by slug
     const list = await ctx.db
       .query("lists")
       .withIndex("by_slug", (q) => q.eq("slug", slug))
@@ -1390,17 +1218,12 @@ export const getEventsForList = query({
       return emptyResults();
     }
 
-    // Private lists are still viewable by their owner or members — mirror
-    // getBySlug / checkListAccess so authorized viewers see the events.
     const viewerId = await getUserId(ctx);
     const accessResult = await checkListAccess(ctx, list.id, viewerId);
     if (accessResult.status !== "ok") {
       return emptyResults();
     }
 
-    // If the previous page came from the backfill fallback, its cursor is
-    // tagged so we stay on the same path — feeding an `eventToLists`
-    // cursor into the `userFeeds` index would fail.
     if (isFallbackCursor(paginationOpts.cursor)) {
       return getEventsForListBackfillFallback(
         ctx,
@@ -1414,17 +1237,6 @@ export const getEventsForList = query({
       );
     }
 
-    // Backfill-window safety: a list is only known to have its `list_*`
-    // feed fully mirrored from `eventToLists` once `list.feedBackfilledAt`
-    // is populated. New lists set this at creation; pre-existing lists get
-    // it set by `migrations/backfillListFeeds.runBackfillListFeeds`. When
-    // the marker is absent we fall back to the junction scan unconditionally
-    // — the feed may already have some entries (partial migration) but we
-    // can't trust that they're complete, so returning a partial first page
-    // would silently hide unmigrated events.
-    //
-    // Gated on cursor=null because subsequent pages within a fallback run
-    // already route via `isFallbackCursor` above.
     if (paginationOpts.cursor === null && !list.feedBackfilledAt) {
       return getEventsForListBackfillFallback(
         ctx,
@@ -1439,10 +1251,6 @@ export const getEventsForList = query({
     const hasEnded = filter === "past";
     const order = filter === "upcoming" ? "asc" : "desc";
 
-    // Filter + sort at the index BEFORE paginating so every page is densely
-    // populated with matching events (no sparse pages from post-filtering).
-    // `eventVisibility` is pinned to "public" to mirror the previous
-    // behavior of dropping private events from list detail views.
     const feedResults = await ctx.db
       .query("userFeeds")
       .withIndex("by_feed_visibility_hasEnded_startTime", (q) =>
@@ -1474,10 +1282,6 @@ export const getEventsForList = query({
   },
 });
 
-/**
- * Internal: Backfill a contributor's existing public events into a list.
- * Orchestrates batch processing to avoid transaction limits.
- */
 export const backfillContributorEvents = internalAction({
   args: {
     listId: v.string(),
@@ -1526,11 +1330,6 @@ export const backfillContributorEvents = internalAction({
   },
 });
 
-// Only return images hosted on our Bytescale account. @vercel/og (satori)
-// only decodes PNG/JPEG, and the OG route relies on Bytescale's `/image/`
-// processor with `f=jpg` to transcode WebP origin bytes — a trick that only
-// works for URLs on our account. External WebP URLs (scraped from other
-// CDNs) would fail satori's image fetch and crash the entire render.
 const OUR_BYTESCALE_URL_PREFIX = "https://upcdn.io/12a1yek/";
 function isRenderableEventImage(value: unknown): value is string {
   return (
@@ -1538,18 +1337,6 @@ function isRenderableEventImage(value: unknown): value is string {
   );
 }
 
-/**
- * Get the minimal data needed to render an OpenGraph preview image for a list.
- *
- * Separate from `getBySlug` so the OG-specific shape can evolve independently.
- * This query runs unauthenticated at crawl time, so private lists intentionally
- * return `status: "private"` — never leak member-only content to crawlers.
- *
- * Returns one of:
- *   { status: "ok", list, owner, upcomingEvents }  — 0–3 upcoming events, chronological
- *   { status: "private" }
- *   { status: "notFound" }
- */
 export const getOgData = query({
   args: { slug: v.string() },
   returns: v.union(
@@ -1595,15 +1382,6 @@ export const getOgData = query({
       return { status: "private" as const };
     }
 
-    // Bounded per Convex's `.take()`-over-`.collect()` rule (see
-    // packages/backend/.cursor/rules/convex_rules.mdc). `.order("desc")` scans
-    // the most-recently-added memberships first — upcoming events are far
-    // more likely to be in the tail of the insertion order than the head, so
-    // this prevents older-only lists from falling back to the branded
-    // default. The pill count below is still derived from this slice, so
-    // lists with >500 upcoming-public events show an approximate count; a
-    // denormalized counter updated by list mutations would be the rigorous
-    // fix if/when that becomes visible.
     const OG_EVENT_SCAN_LIMIT = 500;
     const [owner, eventToLists] = await Promise.all([
       ctx.db
@@ -1631,8 +1409,6 @@ export const getOgData = query({
       ),
     );
 
-    // Pill count reports the *upcoming* count so it aligns with what the
-    // preview promises (the screenshots are upcoming events).
     const upcomingPublic = events
       .filter((e): e is NonNullable<typeof e> => e !== null)
       .filter((e) => e.visibility !== "private")

--- a/packages/backend/convex/migrations/backfillListFeeds.ts
+++ b/packages/backend/convex/migrations/backfillListFeeds.ts
@@ -4,21 +4,6 @@ import { internal } from "../_generated/api";
 import { internalAction, internalMutation } from "../_generated/server";
 import { addEventToListFeedInline } from "../feedHelpers";
 
-/**
- * Backfill `list_${listId}` userFeeds entries from the current `eventToLists`
- * junction so the list-detail query can paginate efficiently on the
- * `by_feed_visibility_hasEnded_startTime` index.
- *
- * Must be run once after deploying the write-path changes in
- * `addEventToList` / `removeEventFromList` / `addEventToContributorLists` /
- * `backfillContributorEventsBatch` / `removeContributorEventsBatch`. New
- * writes after those changes maintain the feed themselves; this only catches
- * up existing data.
- *
- * Idempotent: `addEventToListFeedInline` upserts via `by_feed_event`, so
- * re-running the migration just refreshes timestamps on already-populated
- * entries.
- */
 export const backfillListFeedsBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -40,10 +25,6 @@ export const backfillListFeedsBatch = internalMutation({
     let skipped = 0;
 
     for (const etl of result.page) {
-      // addEventToListFeedInline returns false when the event row is
-      // missing — eventToLists can outlive its event during cascades or
-      // partial cleanups. Track those separately so the orchestrator log
-      // distinguishes real upserts from dangling-junction skips.
       const didUpsert = await addEventToListFeedInline(
         ctx,
         etl.eventId,
@@ -66,12 +47,6 @@ export const backfillListFeedsBatch = internalMutation({
   },
 });
 
-/**
- * Phase 2: once the feed entries are populated, mark every list so
- * `getEventsForList` can trust the feed directly (O(1) field check)
- * instead of falling back to a junction scan. Idempotent: only lists
- * missing `feedBackfilledAt` get patched.
- */
 export const markListsBackfilledBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -110,8 +85,6 @@ export const runBackfillListFeeds = internalAction({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
-    // Phase 1: mirror every eventToLists row into a `list_${listId}` feed
-    // entry. Safe to re-run; upserts are keyed on (feedId, eventId).
     let totalProcessed = 0;
     let totalUpserted = 0;
     let totalSkipped = 0;
@@ -136,12 +109,6 @@ export const runBackfillListFeeds = internalAction({
 
       if (result.isDone) break;
       if (result.nextCursor === cursor) {
-        // Throwing instead of breaking: stalling here means phase 1 only
-        // partially populated the feed. If we fell through to phase 2 we'd
-        // stamp `feedBackfilledAt` on every list, silencing the
-        // getEventsForList fallback even though many list_* feeds are
-        // still incomplete. Fail loud so an operator can investigate and
-        // re-run rather than leave users with quietly-wrong lists.
         throw new Error(
           `Cursor stalled in backfillListFeeds after ${totalProcessed} rows — phase 2 not run`,
         );
@@ -153,10 +120,6 @@ export const runBackfillListFeeds = internalAction({
       `list feed backfill phase 1: ${totalProcessed} eventToLists processed, ${totalUpserted} feed entries upserted, ${totalSkipped} skipped (missing event)`,
     );
 
-    // Phase 2: stamp every list with `feedBackfilledAt`. Once phase 1
-    // committed its last row, this marker is safe — it tells
-    // getEventsForList that the feed is authoritative for this list and
-    // the junction-scan fallback can be skipped.
     let totalListsProcessed = 0;
     let totalMarked = 0;
     let listCursor: string | null = null;

--- a/packages/backend/convex/migrations/backfillSourceListId.ts
+++ b/packages/backend/convex/migrations/backfillSourceListId.ts
@@ -3,12 +3,6 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalAction, internalMutation } from "../_generated/server";
 
-/**
- * Batch mutation: backfill sourceListId for followedLists_ feed entries that lack it.
- * Caches listFollows per userId within a batch to avoid re-reading them
- * for every entry, and uses a conservative batch size to stay under
- * Convex transaction limits.
- */
 export const backfillSourceListIdBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -26,17 +20,13 @@ export const backfillSourceListIdBatch = internalMutation({
       .paginate({ numItems: batchSize, cursor });
 
     let updated = 0;
-    // Cache a user's followed-list ids within this batch so we only query
-    // listFollows once per user per batch.
     const followedListsByUser = new Map<string, Set<string>>();
 
     for (const entry of result.page) {
-      // Only process followedLists_ entries that lack sourceListId
       if (!entry.feedId.startsWith("followedLists_") || entry.sourceListId) {
         continue;
       }
 
-      // Extract userId from feedId
       const userId = entry.feedId.replace("followedLists_", "");
 
       let followedListIds = followedListsByUser.get(userId);
@@ -53,9 +43,6 @@ export const backfillSourceListIdBatch = internalMutation({
         continue;
       }
 
-      // Find which list (that the user follows) the event is in.
-      // Query per-followed-list instead of fetching all eventToLists for the
-      // event, so we stay bounded by the user's follow set.
       let matchingListId: string | undefined = undefined;
       for (const listId of followedListIds) {
         const etl = await ctx.db
@@ -87,9 +74,6 @@ export const backfillSourceListIdBatch = internalMutation({
   },
 });
 
-/**
- * Action: orchestrate backfill of sourceListId
- */
 export const runBackfillSourceListId = internalAction({
   args: {},
   returns: v.null(),

--- a/packages/backend/convex/migrations/backfillUserFeedVisibility.ts
+++ b/packages/backend/convex/migrations/backfillUserFeedVisibility.ts
@@ -6,21 +6,15 @@ import { userFeedsAggregate } from "../aggregates.js";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
-/**
- * Backfill eventVisibility in userFeeds table
- * Copies the visibility from the event to each userFeeds entry
- */
 export const backfillUserFeedVisibility = migrations.define({
   table: "userFeeds",
   batchSize: 100,
   migrateOne: async (ctx, feedEntry) => {
-    // Skip if already has eventVisibility
     if (feedEntry.eventVisibility) {
       return;
     }
 
     try {
-      // Get the event to fetch its visibility
       const event = await ctx.db
         .query("events")
         .withIndex("by_custom_id", (q) => q.eq("id", feedEntry.eventId))

--- a/packages/backend/convex/migrations/fix2027Dates.ts
+++ b/packages/backend/convex/migrations/fix2027Dates.ts
@@ -2,7 +2,6 @@ import { v } from "convex/values";
 
 import { internalMutation, internalQuery } from "../_generated/server";
 
-
 function fixYear(dateStr: string): string {
   return dateStr.replace(/2027/g, "2026");
 }

--- a/packages/backend/convex/migrations/fix2027Dates.ts
+++ b/packages/backend/convex/migrations/fix2027Dates.ts
@@ -2,18 +2,7 @@ import { v } from "convex/values";
 
 import { internalMutation, internalQuery } from "../_generated/server";
 
-/**
- * Migration to fix events that incorrectly have 2027 dates instead of 2026.
- *
- * Usage:
- * 1. Run dry run first to review changes:
- *    npx convex run migrations/fix2027Dates:dryRun
- *
- * 2. After reviewing, run the actual migration:
- *    npx convex run migrations/fix2027Dates:migrate
- */
 
-// Helper to replace 2027 with 2026 in date strings
 function fixYear(dateStr: string): string {
   return dateStr.replace(/2027/g, "2026");
 }
@@ -26,7 +15,6 @@ function fixYearOptional(dateStr: string | undefined): string | undefined {
 export const dryRun = internalQuery({
   args: {},
   handler: async (ctx) => {
-    // Find all events with 2027 in their dates (ISO strings, so range query works)
     const affectedEvents = await ctx.db
       .query("events")
       .filter((q) =>
@@ -78,7 +66,6 @@ export const migrate = internalMutation({
   handler: async (ctx, args) => {
     const isDryRun = args.dryRun ?? false;
 
-    // Find all events with 2027 in their dates (ISO strings, so range query works)
     const affectedEvents = await ctx.db
       .query("events")
       .filter((q) =>
@@ -113,7 +100,6 @@ export const migrate = internalMutation({
         updates.endDate = fixYearOptional(event.endDate);
       }
 
-      // Also fix the nested event object if it exists
       if (event.event && typeof event.event === "object") {
         const eventStr = JSON.stringify(event.event);
         if (eventStr.includes("2027")) {

--- a/packages/backend/convex/migrations/fix2027FeedDates.ts
+++ b/packages/backend/convex/migrations/fix2027FeedDates.ts
@@ -8,14 +8,12 @@ import {
 } from "../_generated/server";
 import { userFeedsAggregate } from "../aggregates";
 
-
 const YEAR_2027_START_MS = new Date("2027-01-01T00:00:00.000Z").getTime();
 const YEAR_2028_START_MS = new Date("2028-01-01T00:00:00.000Z").getTime();
 
 function isIn2027(timestamp: number): boolean {
   return timestamp >= YEAR_2027_START_MS && timestamp < YEAR_2028_START_MS;
 }
-
 
 export const migrateFeedsBatch = internalMutation({
   args: {
@@ -148,7 +146,6 @@ export const migrateGroupsBatch = internalMutation({
   },
 });
 
-
 export const dryRunFeedsBatch = internalQuery({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -264,7 +261,6 @@ export const dryRunGroupsBatch = internalQuery({
     };
   },
 });
-
 
 const BATCH_SIZE = 2048;
 

--- a/packages/backend/convex/migrations/fix2027FeedDates.ts
+++ b/packages/backend/convex/migrations/fix2027FeedDates.ts
@@ -8,19 +8,6 @@ import {
 } from "../_generated/server";
 import { userFeedsAggregate } from "../aggregates";
 
-/**
- * Migration to fix userFeeds and userFeedGroups entries that have incorrect 2027 timestamps.
- *
- * The events table has already been fixed, but the feed tables still have wrong timestamps.
- * This migration uses cursor-based pagination to avoid the 32k document scan limit.
- *
- * Usage:
- * 1. Run dry run first to review changes:
- *    npx convex run migrations/fix2027FeedDates:dryRunFix2027FeedDates --prod
- *
- * 2. After reviewing, run the actual migration:
- *    npx convex run migrations/fix2027FeedDates:fix2027FeedDates --prod
- */
 
 const YEAR_2027_START_MS = new Date("2027-01-01T00:00:00.000Z").getTime();
 const YEAR_2028_START_MS = new Date("2028-01-01T00:00:00.000Z").getTime();
@@ -29,7 +16,6 @@ function isIn2027(timestamp: number): boolean {
   return timestamp >= YEAR_2027_START_MS && timestamp < YEAR_2028_START_MS;
 }
 
-// --- Batched mutations ---
 
 export const migrateFeedsBatch = internalMutation({
   args: {
@@ -162,7 +148,6 @@ export const migrateGroupsBatch = internalMutation({
   },
 });
 
-// --- Batched queries (dry run) ---
 
 export const dryRunFeedsBatch = internalQuery({
   args: {
@@ -280,7 +265,6 @@ export const dryRunGroupsBatch = internalQuery({
   },
 });
 
-// --- Orchestrating actions ---
 
 const BATCH_SIZE = 2048;
 
@@ -299,7 +283,6 @@ export const fix2027FeedDates = internalAction({
     }),
   }),
   handler: async (ctx) => {
-    // Migrate userFeeds
     let feedsProcessed = 0;
     let feedsUpdated = 0;
     let feedsSkipped = 0;
@@ -329,7 +312,6 @@ export const fix2027FeedDates = internalAction({
       `userFeeds: ${feedsUpdated} updated, ${feedsSkipped} skipped (event not found), ${feedsProcessed} total scanned`,
     );
 
-    // Migrate userFeedGroups
     let groupsProcessed = 0;
     let groupsUpdated = 0;
     let groupsSkipped = 0;
@@ -389,7 +371,6 @@ export const dryRunFix2027FeedDates = internalAction({
     }),
   }),
   handler: async (ctx) => {
-    // Dry run userFeeds
     let feedsProcessed = 0;
     let feedsAffected = 0;
     let feedsSkipped = 0;
@@ -419,7 +400,6 @@ export const dryRunFix2027FeedDates = internalAction({
       `[DRY RUN] userFeeds: ${feedsAffected} would update, ${feedsSkipped} missing events, ${feedsProcessed} total scanned`,
     );
 
-    // Dry run userFeedGroups
     let groupsProcessed = 0;
     let groupsAffected = 0;
     let groupsSkipped = 0;

--- a/packages/backend/convex/migrations/initializeAggregates.ts
+++ b/packages/backend/convex/migrations/initializeAggregates.ts
@@ -1,9 +1,3 @@
-/**
- * Migration to initialize aggregates for existing events and eventFollows
- *
- * Run this once after deploying the aggregate changes to populate the
- * aggregates with existing data.
- */
 
 import { v } from "convex/values";
 
@@ -18,9 +12,6 @@ import {
 
 const BATCH_SIZE = 100;
 
-/**
- * Initialize aggregates for a batch of events
- */
 export const initializeEventAggregatesBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -43,7 +34,6 @@ export const initializeEventAggregatesBatch = internalMutation({
       await eventsByStartTime.replaceOrInsert(ctx, event, event);
     }
 
-    // If there are more pages, schedule the next batch
     if (!result.isDone) {
       await ctx.scheduler.runAfter(
         0,
@@ -60,16 +50,12 @@ export const initializeEventAggregatesBatch = internalMutation({
   },
 });
 
-/**
- * Initialize aggregates for all existing events (orchestrator)
- */
 export const initializeEventAggregates = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
     console.log("Starting event aggregates initialization...");
 
-    // Kick off the first batch; subsequent batches self-schedule
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeAggregates.initializeEventAggregatesBatch,
@@ -79,9 +65,6 @@ export const initializeEventAggregates = internalMutation({
   },
 });
 
-/**
- * Initialize aggregates for a batch of eventFollows
- */
 export const initializeEventFollowsAggregatesBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -103,7 +86,6 @@ export const initializeEventFollowsAggregatesBatch = internalMutation({
       await eventFollowsAggregate.replaceOrInsert(ctx, follow, follow);
     }
 
-    // If there are more pages, schedule the next batch
     if (!result.isDone) {
       await ctx.scheduler.runAfter(
         0,
@@ -121,16 +103,12 @@ export const initializeEventFollowsAggregatesBatch = internalMutation({
   },
 });
 
-/**
- * Initialize aggregates for all existing eventFollows (orchestrator)
- */
 export const initializeEventFollowsAggregates = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
     console.log("Starting eventFollows aggregates initialization...");
 
-    // Kick off the first batch; subsequent batches self-schedule
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeAggregates
@@ -141,9 +119,6 @@ export const initializeEventFollowsAggregates = internalMutation({
   },
 });
 
-/**
- * Initialize aggregates for a batch of listFollows
- */
 export const initializeListFollowsAggregatesBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -165,7 +140,6 @@ export const initializeListFollowsAggregatesBatch = internalMutation({
       await listFollowsAggregate.replaceOrInsert(ctx, follow, follow);
     }
 
-    // If there are more pages, schedule the next batch
     if (!result.isDone) {
       await ctx.scheduler.runAfter(
         0,
@@ -183,16 +157,12 @@ export const initializeListFollowsAggregatesBatch = internalMutation({
   },
 });
 
-/**
- * Initialize aggregates for all existing listFollows (orchestrator)
- */
 export const initializeListFollowsAggregates = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
     console.log("Starting listFollows aggregates initialization...");
 
-    // Kick off the first batch; subsequent batches self-schedule
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeAggregates
@@ -203,14 +173,10 @@ export const initializeListFollowsAggregates = internalMutation({
   },
 });
 
-/**
- * Run all aggregate initializations
- */
 export const initializeAllAggregates = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
-    // Clear all namespaces once at the very beginning
     await ctx.runMutation(components.eventsByCreation.public.clear, {});
     await ctx.runMutation(components.eventsByStartTime.public.clear, {});
     await ctx.runMutation(components.eventFollowsAggregate.public.clear, {});

--- a/packages/backend/convex/migrations/initializeAggregates.ts
+++ b/packages/backend/convex/migrations/initializeAggregates.ts
@@ -1,4 +1,3 @@
-
 import { v } from "convex/values";
 
 import { components, internal } from "../_generated/api";

--- a/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
+++ b/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
@@ -1,4 +1,3 @@
-
 import { v } from "convex/values";
 
 import { internal } from "../_generated/api";

--- a/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
+++ b/packages/backend/convex/migrations/initializeUserFeedsAggregate.ts
@@ -1,9 +1,3 @@
-/**
- * Migration to initialize userFeeds aggregate for existing userFeeds entries
- *
- * Run this once after deploying the aggregate changes to populate the
- * aggregate with existing data.
- */
 
 import { v } from "convex/values";
 
@@ -13,9 +7,6 @@ import { userFeedsAggregate } from "../aggregates";
 
 const BATCH_SIZE = 100;
 
-/**
- * Initialize aggregate for a batch of userFeeds entries
- */
 export const initializeUserFeedsAggregateBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -39,7 +30,6 @@ export const initializeUserFeedsAggregateBatch = internalMutation({
       await userFeedsAggregate.replaceOrInsert(ctx, feedEntry, feedEntry);
     }
 
-    // If there are more pages, schedule the next batch
     if (!result.isDone) {
       await ctx.scheduler.runAfter(
         0,
@@ -57,15 +47,11 @@ export const initializeUserFeedsAggregateBatch = internalMutation({
   },
 });
 
-/**
- * Initialize aggregate for all existing userFeeds entries (orchestrator)
- */
 export const initializeUserFeedsAggregate = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
     console.log("Starting userFeeds aggregate initialization...");
-    // Kick off the first batch; subsequent batches self-schedule
     await ctx.scheduler.runAfter(
       0,
       internal.migrations.initializeUserFeedsAggregate

--- a/packages/backend/convex/migrations/personalListMigration.ts
+++ b/packages/backend/convex/migrations/personalListMigration.ts
@@ -7,11 +7,6 @@ import { getOrCreatePersonalList } from "../lists";
 
 const EVENTS_PER_BATCH = 100;
 
-/**
- * Batch mutation: create personal lists for a page of users.
- * Event backfill is scheduled as separate bounded mutations to avoid
- * exceeding Convex transaction document-read limits for power users.
- */
 export const personalListBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -31,10 +26,8 @@ export const personalListBatch = internalMutation({
     let created = 0;
 
     for (const user of result.page) {
-      // Create personal list (idempotent)
       const personalList = await getOrCreatePersonalList(ctx, user.id);
 
-      // Check if any events are already linked
       const existingLink = await ctx.db
         .query("eventToLists")
         .withIndex("by_list", (q) => q.eq("listId", personalList.id))
@@ -44,8 +37,6 @@ export const personalListBatch = internalMutation({
         created++;
       }
 
-      // Schedule per-user backfill as a separate transaction so a single
-      // power user's events never blow the batch-level read budget.
       await ctx.scheduler.runAfter(
         0,
         internal.migrations.personalListMigration.backfillUserEventsBatch,
@@ -66,10 +57,6 @@ export const personalListBatch = internalMutation({
   },
 });
 
-/**
- * Paginated backfill of a single user's events → personal list.
- * Self-schedules the next page to stay under transaction limits.
- */
 export const backfillUserEventsBatch = internalMutation({
   args: {
     userId: v.string(),
@@ -101,11 +88,6 @@ export const backfillUserEventsBatch = internalMutation({
           eventId: event.id,
           listId,
         });
-        // Keep the list's `list_${listId}` feed in lockstep with the
-        // junction. `getOrCreatePersonalList` stamps `feedBackfilledAt`
-        // at creation, so `getEventsForList` trusts the feed for these
-        // lists — skipping this call would leave migrated personal lists
-        // with an empty feed and return empty pages to users.
         await addEventToListFeedInline(ctx, event.id, listId);
         linked++;
       }
@@ -131,9 +113,6 @@ export const backfillUserEventsBatch = internalMutation({
   },
 });
 
-/**
- * Action: orchestrate batch processing for personal list migration
- */
 export const runPersonalListMigration = internalAction({
   args: {},
   returns: v.null(),

--- a/packages/backend/convex/migrations/similarityGroupMigration.ts
+++ b/packages/backend/convex/migrations/similarityGroupMigration.ts
@@ -7,28 +7,20 @@ import { generatePublicId } from "../utils.js";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
-/**
- * Phase 1: Backfill events.similarityGroupId
- * Groups events by similarity, assigning the same group ID to similar events
- */
 export const backfillEventSimilarityGroups = migrations.define({
   table: "events",
   batchSize: 50,
   migrateOne: async (ctx, event) => {
-    // Skip if already has a similarity group
     if (event.similarityGroupId) {
       return;
     }
 
     try {
-      // Search window: events within ±2 hours of the start time
       const startDateTime = new Date(event.startDateTime);
       const windowMs = 2 * 60 * 60 * 1000;
       const lowerBound = new Date(startDateTime.getTime() - windowMs);
       const upperBound = new Date(startDateTime.getTime() + windowMs);
 
-      // Query events within the time window that were created before this event
-      // and already have a similarity group
       const candidateEvents = await ctx.db
         .query("events")
         .withIndex("by_startDateTime", (q) =>
@@ -44,7 +36,6 @@ export const backfillEventSimilarityGroups = migrations.define({
         )
         .collect();
 
-      // Check each candidate for similarity
       let foundGroupId: string | null = null;
 
       for (const candidate of candidateEvents) {
@@ -73,7 +64,6 @@ export const backfillEventSimilarityGroups = migrations.define({
         }
       }
 
-      // Assign group: found similar event's group or create new
       const similarityGroupId = foundGroupId || `sg_${generatePublicId()}`;
 
       await ctx.db.patch(event._id, {
@@ -97,21 +87,15 @@ export const runBackfillEventSimilarityGroups = migrations.runner(
   internal.migrations.similarityGroupMigration.backfillEventSimilarityGroups,
 );
 
-/**
- * Phase 2: Backfill userFeeds.similarityGroupId from events
- * Copies the similarityGroupId from the event to each userFeeds entry
- */
 export const backfillUserFeedsSimilarityGroups = migrations.define({
   table: "userFeeds",
   batchSize: 100,
   migrateOne: async (ctx, feedEntry) => {
-    // Skip if already has a similarity group
     if (feedEntry.similarityGroupId) {
       return;
     }
 
     try {
-      // Get the event to fetch its similarity group
       const event = await ctx.db
         .query("events")
         .withIndex("by_custom_id", (q) => q.eq("id", feedEntry.eventId))
@@ -151,15 +135,10 @@ export const runBackfillUserFeedsSimilarityGroups = migrations.runner(
     .backfillUserFeedsSimilarityGroups,
 );
 
-/**
- * Phase 3: Derive userFeedGroups from userFeeds
- * Creates grouped feed entries from the userFeeds table
- */
 export const deriveUserFeedGroups = migrations.define({
   table: "userFeeds",
   batchSize: 100,
   migrateOne: async (ctx, feedEntry) => {
-    // Skip entries without a similarity group
     if (!feedEntry.similarityGroupId) {
       return;
     }
@@ -168,7 +147,6 @@ export const deriveUserFeedGroups = migrations.define({
       const feedId = feedEntry.feedId;
       const similarityGroupId = feedEntry.similarityGroupId;
 
-      // Check if a grouped entry already exists
       const existingGroupEntry = await ctx.db
         .query("userFeedGroups")
         .withIndex("by_feed_group", (q) =>
@@ -177,11 +155,9 @@ export const deriveUserFeedGroups = migrations.define({
         .first();
 
       if (existingGroupEntry) {
-        // Already exists, skip
         return;
       }
 
-      // Get all members of this group in this feed
       const members = await ctx.db
         .query("userFeeds")
         .withIndex("by_feed_group", (q) =>
@@ -193,7 +169,6 @@ export const deriveUserFeedGroups = migrations.define({
         return;
       }
 
-      // Fetch all member events to select primary
       const memberEvents = await Promise.all(
         members.map(async (m) => {
           return await ctx.db
@@ -211,7 +186,6 @@ export const deriveUserFeedGroups = migrations.define({
         return;
       }
 
-      // Priority 1: If this is a user feed, prefer that user's own event
       const feedUserId = feedId.startsWith("user_")
         ? feedId.replace("user_", "")
         : null;
@@ -221,7 +195,6 @@ export const deriveUserFeedGroups = migrations.define({
         primaryEvent = validEvents.find((e) => e.userId === feedUserId) || null;
       }
 
-      // Priority 2: earliest by created_at
       if (!primaryEvent) {
         primaryEvent = validEvents.sort(
           (a, b) =>
@@ -233,7 +206,6 @@ export const deriveUserFeedGroups = migrations.define({
         return;
       }
 
-      // Calculate times and counts
       const eventStartTime = new Date(primaryEvent.startDateTime).getTime();
       const eventEndTime = new Date(primaryEvent.endDateTime).getTime();
       const currentTime = Date.now();
@@ -241,7 +213,6 @@ export const deriveUserFeedGroups = migrations.define({
       const minAddedAt = Math.min(...members.map((m) => m.addedAt));
       const similarEventsCount = Math.max(0, members.length - 1);
 
-      // Insert the grouped entry
       await ctx.db.insert("userFeedGroups", {
         feedId,
         similarityGroupId,

--- a/packages/backend/convex/migrations/userFeedsMigration.ts
+++ b/packages/backend/convex/migrations/userFeedsMigration.ts
@@ -5,7 +5,6 @@ import { components, internal } from "../_generated/api.js";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
-// Migration to populate user feeds from existing events
 export const populateUserFeeds = migrations.define({
   table: "events",
   batchSize: 100,
@@ -16,7 +15,6 @@ export const populateUserFeeds = migrations.define({
       const currentTime = Date.now();
       let addedCount = 0;
 
-      // 1. Add to creator's personal feed
       const creatorFeedId = `user_${event.userId}`;
       try {
         const existingCreatorEntry = await ctx.db
@@ -45,7 +43,6 @@ export const populateUserFeeds = migrations.define({
         throw error;
       }
 
-      // 2. Add to discover feed if public
       if (event.visibility === "public") {
         const discoverFeedId = "discover";
         try {
@@ -76,7 +73,6 @@ export const populateUserFeeds = migrations.define({
         }
       }
 
-      // 3. Add to feeds of users who follow this event
       try {
         const eventFollows = await ctx.db
           .query("eventFollows")
@@ -109,7 +105,6 @@ export const populateUserFeeds = migrations.define({
               `Failed to add event ${event.id} to follower feed ${followerFeedId}:`,
               error,
             );
-            // Continue with other followers rather than failing the entire migration
             continue;
           }
         }
@@ -131,18 +126,15 @@ export const populateUserFeeds = migrations.define({
   },
 });
 
-// Specific runner for the populateUserFeeds migration
 export const runPopulateUserFeeds = migrations.runner(
   internal.migrations.userFeedsMigration.populateUserFeeds,
 );
 
-// Optional: cleanup migration for orphaned entries
 export const cleanupOrphanedFeedEntries = migrations.define({
   table: "userFeeds",
   batchSize: 50,
   migrateOne: async (ctx, feedEntry) => {
     try {
-      // Check if event exists by querying with the custom id
       const event = await ctx.db
         .query("events")
         .withIndex("by_custom_id", (q) => q.eq("id", feedEntry.eventId))

--- a/packages/backend/convex/migrations/userFollowsToListFollows.ts
+++ b/packages/backend/convex/migrations/userFollowsToListFollows.ts
@@ -5,9 +5,6 @@ import { internalAction, internalMutation } from "../_generated/server";
 import { listFollowsAggregate } from "../aggregates";
 import { getOrCreatePersonalList } from "../lists";
 
-/**
- * Batch mutation: convert userFollows to listFollows by following the target user's personal list
- */
 export const userFollowsToListFollowsBatch = internalMutation({
   args: {
     cursor: v.union(v.string(), v.null()),
@@ -27,13 +24,11 @@ export const userFollowsToListFollowsBatch = internalMutation({
     let migrated = 0;
 
     for (const userFollow of result.page) {
-      // Get or create the followed user's personal list
       const personalList = await getOrCreatePersonalList(
         ctx,
         userFollow.followingId,
       );
 
-      // Check if listFollow already exists
       const existingListFollow = await ctx.db
         .query("listFollows")
         .withIndex("by_user_and_list", (q) =>
@@ -49,7 +44,6 @@ export const userFollowsToListFollowsBatch = internalMutation({
         const followDoc = (await ctx.db.get(followId))!;
         await listFollowsAggregate.insert(ctx, followDoc);
 
-        // Schedule feed population
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.addListEventsToUserFeed,
@@ -72,9 +66,6 @@ export const userFollowsToListFollowsBatch = internalMutation({
   },
 });
 
-/**
- * Action: orchestrate migration of userFollows → listFollows
- */
 export const runUserFollowsToListFollows = internalAction({
   args: {},
   returns: v.null(),

--- a/packages/backend/convex/model/ai.ts
+++ b/packages/backend/convex/model/ai.ts
@@ -39,9 +39,6 @@ export interface AIErrorResponse {
   error?: string;
 }
 
-/**
- * Generate text using Anthropic's Claude model via direct API call
- */
 export async function generateText({
   prompt,
   temperature = 0,
@@ -99,10 +96,6 @@ export async function generateText({
   }
 }
 
-/**
- * Generate structured event data from base64 image using AI
- * Extracted from eventFromImageBase64ThenCreate in ai router
- */
 
 export async function processEventFromBase64Image(
   ctx: ActionCtx,
@@ -123,7 +116,7 @@ export async function processEventFromBase64Image(
 
     return aiResult;
   } catch (error) {
-    console.error("Error in processEventFromBase64Image:", error); // Log the actual error
+    console.error("Error in processEventFromBase64Image:", error);
     throw new ConvexError({
       message:
         error instanceof Error
@@ -133,10 +126,6 @@ export async function processEventFromBase64Image(
     });
   }
 }
-/**
- * Generate structured event data from URL using AI
- * Extracted from eventFromUrlThenCreateThenNotification in ai router
- */
 
 export async function processEventFromUrl(
   ctx: ActionCtx,
@@ -161,7 +150,6 @@ export async function processEventFromUrl(
       fnName: "eventFromUrlThenCreateThenNotification",
     });
 
-    // Validate that we have at least one event
     if (events.length === 0) {
       throw new ConvexError({
         message: "No events found in response",
@@ -176,7 +164,7 @@ export async function processEventFromUrl(
       validatedEvent,
     };
   } catch (error) {
-    console.error("Error in processEventFromUrl:", error); // Log the actual error
+    console.error("Error in processEventFromUrl:", error);
     throw new ConvexError({
       message:
         error instanceof Error
@@ -186,10 +174,6 @@ export async function processEventFromUrl(
     });
   }
 }
-/**
- * Generate structured event data from raw text using AI
- * Extracted from eventFromRawTextThenCreateThenNotification in ai router
- */
 
 export async function processEventFromText(
   ctx: ActionCtx,
@@ -215,7 +199,6 @@ export async function processEventFromText(
       fnName: "eventFromRawTextThenCreateThenNotification",
     });
 
-    // Validate that we have at least one event
     if (events.length === 0) {
       throw new ConvexError({
         message: "No events found in response",
@@ -231,7 +214,7 @@ export async function processEventFromText(
       response,
     };
   } catch (error) {
-    console.error("Error in processEventFromText:", error); // Log the actual error
+    console.error("Error in processEventFromText:", error);
     throw new ConvexError({
       message:
         error instanceof Error
@@ -256,9 +239,7 @@ export function validateEvent(event: unknown) {
   try {
     validatedEvent = EventWithMetadataSchema.parse(event);
   } catch (e) {
-    // If Zod parsing fails, it's invalid event data
     if (e instanceof Error) {
-      // You could log e.message here if more detail is needed for debugging
       console.error("Zod validation failed:", e.message);
     }
 
@@ -274,7 +255,6 @@ export function validateEvent(event: unknown) {
     });
   }
 
-  // 1. Check if event has proper date/time information
   if (
     !validatedEvent.startDate ||
     validatedEvent.startDate === "TBD" ||
@@ -290,11 +270,9 @@ export function validateEvent(event: unknown) {
     });
   }
 
-  // 2. Check for extremely generic event names that suggest hallucination
   const name = validatedEvent.name.toLowerCase() || "";
   const description = validatedEvent.description.toLowerCase() || "";
 
-  // Invalid names - only reject if the entire name is one of these generic placeholders
   const invalidNames = [
     "title",
     "name",
@@ -306,7 +284,6 @@ export function validateEvent(event: unknown) {
     "new event",
   ];
 
-  // Very specific patterns that indicate the AI made something up from error/test content
   const invalidPatterns = [
     "paramvalidationerror",
     "domain resolution error",
@@ -323,7 +300,6 @@ export function validateEvent(event: unknown) {
     "http error",
   ];
 
-  // Use exact match (after trimming) instead of partial matching
   const isInvalidName = invalidNames.some((invalid) => name.trim() === invalid);
 
   const isInvalidPattern = invalidPatterns.some(
@@ -342,6 +318,5 @@ export function validateEvent(event: unknown) {
     });
   }
 
-  // If all checks pass, return the Zod-validated event
   return validatedEvent;
 }

--- a/packages/backend/convex/model/ai.ts
+++ b/packages/backend/convex/model/ai.ts
@@ -96,7 +96,6 @@ export async function generateText({
   }
 }
 
-
 export async function processEventFromBase64Image(
   ctx: ActionCtx,
   input: {

--- a/packages/backend/convex/model/aiHelpers.ts
+++ b/packages/backend/convex/model/aiHelpers.ts
@@ -332,7 +332,6 @@ function constructMessagesBase64Image({
 function validateUrl(url: string): void {
   let parsedUrl: URL;
 
-  // Check if URL is well-formed
   try {
     parsedUrl = new URL(url);
   } catch (error) {
@@ -345,7 +344,6 @@ function validateUrl(url: string): void {
     });
   }
 
-  // Only allow http and https protocols
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new ConvexError({
       message: "Only HTTP and HTTPS protocols are allowed",
@@ -355,7 +353,6 @@ function validateUrl(url: string): void {
 
   const hostname = parsedUrl.hostname.toLowerCase();
 
-  // Prevent localhost access
   if (
     hostname === "localhost" ||
     hostname === "127.0.0.1" ||
@@ -367,7 +364,6 @@ function validateUrl(url: string): void {
     });
   }
 
-  // Prevent access to private IP ranges
   const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
   const ipv4Match = ipv4Regex.exec(hostname);
 
@@ -381,17 +377,11 @@ function validateUrl(url: string): void {
     ];
     const [, a, b, _c, _d] = octetsAsTuple;
 
-    // Check for private IP ranges
     if (
-      // 10.0.0.0/8
       a === 10 ||
-      // 172.16.0.0/12
       (a === 172 && b >= 16 && b <= 31) ||
-      // 192.168.0.0/16
       (a === 192 && b === 168) ||
-      // 169.254.0.0/16 (link-local)
       (a === 169 && b === 254) ||
-      // 127.0.0.0/8 (additional loopback check)
       a === 127
     ) {
       throw new ConvexError({
@@ -401,7 +391,6 @@ function validateUrl(url: string): void {
     }
   }
 
-  // Prevent access to common cloud metadata endpoints
   const blockedHosts = [
     "metadata.google.internal",
     "169.254.169.254", // AWS/Azure/GCP metadata
@@ -494,7 +483,6 @@ export async function fetchAndProcessEvent({
     });
   } else if (input.url) {
     try {
-      // Validate URL to prevent SSRF attacks
       validateUrl(input.url);
 
       const jinaReader = await fetch(`https://r.jina.ai/${input.url}`, {
@@ -531,12 +519,10 @@ export async function fetchAndProcessEvent({
         rawText: rawText,
       });
     } catch (error) {
-      // If the error is already a ConvexError, re-throw it
       if (error instanceof ConvexError) {
         throw error;
       }
 
-      // Handle network errors and other fetch failures
       throw new ConvexError({
         message: "Network error when fetching content from Jina Reader API",
         data: {
@@ -574,10 +560,6 @@ export async function fetchAndProcessEvent({
   const generatedEvent = event.object;
   const generatedMetadata = EventMetadataSchema.parse(metadata.object);
 
-  // Deterministically compute the year from the MM-DD the model extracted.
-  // The model is unreliable at enforcing a year window in the prompt (see
-  // migrations/fix2027Dates.ts and fix2027FeedDates.ts for the history);
-  // this replaces the year whenever the source did not explicitly state one.
   const today = Temporal.Now.instant()
     .toZonedDateTimeISO(formatOffsetAsIANASoft(input.timezone))
     .toPlainDate();
@@ -614,16 +596,12 @@ export async function fetchAndProcessEvent({
   return { events, response };
 }
 
-/**
- * Validates Jina API response for common error patterns and content issues
- */
 export function validateJinaResponse(aiResult: {
   events: EventWithMetadata[];
   response: string;
 }): void {
   const responseText = aiResult.response.toLowerCase();
 
-  // 1. Check for Jina/network error responses
   if (
     responseText.includes("failed to fetch") ||
     responseText.includes("network error") ||
@@ -637,7 +615,6 @@ export function validateJinaResponse(aiResult: {
     });
   }
 
-  // 2. Check for HTTP error content
   if (
     responseText.includes("500 internal server error") ||
     responseText.includes("404 not found") ||
@@ -651,7 +628,6 @@ export function validateJinaResponse(aiResult: {
     });
   }
 
-  // 3. Check for robots.txt content specifically
   if (
     responseText.includes("user-agent:") &&
     responseText.includes("disallow:")
@@ -663,7 +639,6 @@ export function validateJinaResponse(aiResult: {
     });
   }
 
-  // 4. Check for minimal/empty content that Jina couldn't process
   if (responseText.trim().length < 100) {
     throw new ConvexError({
       message: "URL content parsing failed: Insufficient content retrieved",

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -26,7 +26,6 @@ import {
   shouldRegroupEvent,
 } from "./similarityHelpers";
 
-// Type for event data (based on AddToCalendarButtonProps)
 interface EventData {
   name: string;
   startDate: string;
@@ -40,7 +39,6 @@ interface EventData {
   [key: string]: unknown;
 }
 
-// Helper function to filter duplicates
 function filterDuplicates<T extends { id: string }>(items: T[]): T[] {
   const seen = new Set<string>();
   return items.filter((item) => {
@@ -52,7 +50,6 @@ function filterDuplicates<T extends { id: string }>(items: T[]): T[] {
   });
 }
 
-// Helper to batch-fetch users by IDs (avoids N+1 queries)
 async function batchGetUsersByIds(ctx: QueryCtx, userIds: string[]) {
   const uniqueIds = [...new Set(userIds)];
   const users = await Promise.all(
@@ -68,18 +65,14 @@ async function batchGetUsersByIds(ctx: QueryCtx, userIds: string[]) {
   return userMap;
 }
 
-// Helper used by paginated queries to hydrate events (batch-optimized)
-// Accepts full event documents to avoid redundant re-fetching
 export async function enrichEventsAndFilterNulls(
   ctx: QueryCtx,
   events: Doc<"events">[],
 ) {
   if (events.length === 0) return [];
 
-  // Use passed events directly - no need to re-fetch
   const validEvents = events;
 
-  // Batch fetch all eventFollows, comments, and eventToLists in parallel
   const [allEventFollows, allComments, allEventToLists] = await Promise.all([
     Promise.all(
       validEvents.map((event) =>
@@ -107,7 +100,6 @@ export async function enrichEventsAndFilterNulls(
     ),
   ]);
 
-  // Collect all unique user IDs (event creators + followers)
   const allUserIds: string[] = validEvents.map((e) => e.userId);
   for (const follows of allEventFollows) {
     for (const follow of follows) {
@@ -115,7 +107,6 @@ export async function enrichEventsAndFilterNulls(
     }
   }
 
-  // Collect all unique list IDs
   const allListIds: string[] = [];
   for (const etls of allEventToLists) {
     for (const etl of etls) {
@@ -123,7 +114,6 @@ export async function enrichEventsAndFilterNulls(
     }
   }
 
-  // Batch fetch all users and lists
   const [userMap, listDocs] = await Promise.all([
     batchGetUsersByIds(ctx, allUserIds),
     Promise.all(
@@ -136,7 +126,6 @@ export async function enrichEventsAndFilterNulls(
     ),
   ]);
 
-  // Build list map
   const uniqueListIds = [...new Set(allListIds)];
   const listMap = new Map<string, Doc<"lists">>();
   uniqueListIds.forEach((listId, i) => {
@@ -144,14 +133,12 @@ export async function enrichEventsAndFilterNulls(
     if (list) listMap.set(listId, list);
   });
 
-  // Assemble enriched events
   return validEvents.map((event, idx) => {
     const user = userMap.get(event.userId) ?? null;
     const eventFollowsRaw = allEventFollows[idx] ?? [];
     const comments = allComments[idx] ?? [];
     const eventToLists = allEventToLists[idx] ?? [];
 
-    // Enrich eventFollows with cached user data
     const eventFollows = eventFollowsRaw.map((follow) => {
       const follower = userMap.get(follow.userId);
       return {
@@ -167,7 +154,6 @@ export async function enrichEventsAndFilterNulls(
       };
     });
 
-    // Map lists from cache
     const lists: Doc<"lists">[] = [];
     for (const etl of eventToLists) {
       const list = listMap.get(etl.listId);
@@ -184,16 +170,13 @@ export async function enrichEventsAndFilterNulls(
   });
 }
 
-// Helper function to parse date/time with timezone using Temporal
 function parseDateTime(date: string, time: string, timeZone: string): Date {
-  // Validate inputs
   if (!date || !time) {
     throw new ConvexError(
       `Invalid date or time: date="${date}", time="${time}"`,
     );
   }
 
-  // Validate date format (YYYY-MM-DD)
   const datePattern = /^\d{4}-\d{2}-\d{2}$/;
   if (!datePattern.test(date)) {
     throw new ConvexError(
@@ -201,7 +184,6 @@ function parseDateTime(date: string, time: string, timeZone: string): Date {
     );
   }
 
-  // Validate time format (HH:MM or HH:MM:SS)
   const timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$/;
   if (!timePattern.test(time)) {
     throw new ConvexError(
@@ -210,19 +192,15 @@ function parseDateTime(date: string, time: string, timeZone: string): Date {
   }
 
   try {
-    // Ensure time has seconds
     const timeWithSeconds =
       time.includes(":") && time.split(":").length === 3 ? time : `${time}:00`;
 
-    // Use Temporal to properly handle timezone conversion
     const zonedDateTime = Temporal.ZonedDateTime.from(
       `${date}T${timeWithSeconds}[${timeZone || DEFAULT_TIMEZONE}]`,
     );
 
-    // Convert to a regular Date object
     return new Date(zonedDateTime.epochMilliseconds);
   } catch (error) {
-    // Fallback to simplified approach if Temporal fails
     console.warn(
       "Temporal parsing failed, falling back to simple Date parsing:",
       error,
@@ -233,7 +211,6 @@ function parseDateTime(date: string, time: string, timeZone: string): Date {
     const dateTimeString = `${date}T${timeWithSeconds}`;
     const parsedDate = new Date(dateTimeString);
 
-    // Validate that the Date object is valid
     if (isNaN(parsedDate.getTime())) {
       throw new ConvexError(
         `Invalid date/time combination: "${dateTimeString}"`,
@@ -244,9 +221,6 @@ function parseDateTime(date: string, time: string, timeZone: string): Date {
   }
 }
 
-/**
- * Get events for a specific user by username
- */
 export async function getEventsForUser(ctx: QueryCtx, userName: string) {
   const user = await ctx.db
     .query("users")
@@ -262,21 +236,17 @@ export async function getEventsForUser(ctx: QueryCtx, userName: string) {
     .withIndex("by_user", (q) => q.eq("userId", user.id))
     .collect();
 
-  // Sort by start date time
   return events.sort(
     (a, b) =>
       new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime(),
   );
 }
 
-/**
- * Get upcoming events for a user (created + saved)
- */
 export async function getUpcomingEventsForUser(
   ctx: QueryCtx,
   userName: string,
 ) {
-  const now = new Date(new Date().getTime() - 24 * 60 * 60 * 1000); // 24 hours ago
+  const now = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
 
   const user = await ctx.db
     .query("users")
@@ -287,14 +257,12 @@ export async function getUpcomingEventsForUser(
     return [];
   }
 
-  // Get created events
   const createdEvents = await ctx.db
     .query("events")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
     .filter((q) => q.gte(q.field("startDateTime"), now.toISOString()))
     .collect();
 
-  // Get saved events
   const eventFollows = await ctx.db
     .query("eventFollows")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
@@ -319,9 +287,6 @@ export async function getUpcomingEventsForUser(
   );
 }
 
-/**
- * Get events that a user is following (from lists, users, and individual events)
- */
 export async function getFollowingEventsForUser(
   ctx: QueryCtx,
   userName: string,
@@ -337,7 +302,6 @@ export async function getFollowingEventsForUser(
 
   const allEvents: Doc<"events">[] = [];
 
-  // Get events from followed individual events
   const eventFollows = await ctx.db
     .query("eventFollows")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
@@ -353,7 +317,6 @@ export async function getFollowingEventsForUser(
     }
   }
 
-  // Get events from followed lists
   const listFollows = await ctx.db
     .query("listFollows")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
@@ -376,7 +339,6 @@ export async function getFollowingEventsForUser(
     }
   }
 
-  // Get events from followed users
   const userFollows = await ctx.db
     .query("userFollows")
     .withIndex("by_follower", (q) => q.eq("followerId", user.id))
@@ -398,9 +360,6 @@ export async function getFollowingEventsForUser(
   );
 }
 
-/**
- * Get upcoming events from following (optimized version)
- */
 export async function getFollowingUpcomingEventsForUser(
   ctx: QueryCtx,
   userName: string,
@@ -418,7 +377,6 @@ export async function getFollowingUpcomingEventsForUser(
 
   const eventIds = new Set<string>();
 
-  // Collect event IDs from all sources
   const eventFollows = await ctx.db
     .query("eventFollows")
     .withIndex("by_user", (q) => q.eq("userId", user.id))
@@ -452,7 +410,6 @@ export async function getFollowingUpcomingEventsForUser(
     followedUserEvents.forEach((e) => eventIds.add(e.id));
   }
 
-  // Fetch upcoming events
   const upcomingEvents = [];
   for (const eventId of eventIds) {
     const event = await ctx.db
@@ -471,9 +428,6 @@ export async function getFollowingUpcomingEventsForUser(
   );
 }
 
-/**
- * Get saved events for a user
- */
 export async function getSavedEventsForUser(ctx: QueryCtx, userName: string) {
   const user = await ctx.db
     .query("users")
@@ -506,9 +460,6 @@ export async function getSavedEventsForUser(ctx: QueryCtx, userName: string) {
   );
 }
 
-/**
- * Get saved event IDs for a user
- */
 export async function getSavedEventIdsForUser(ctx: QueryCtx, userName: string) {
   const user = await ctx.db
     .query("users")
@@ -527,9 +478,6 @@ export async function getSavedEventIdsForUser(ctx: QueryCtx, userName: string) {
   return eventFollows.map((follow) => ({ id: follow.eventId }));
 }
 
-/**
- * Get possible duplicate events based on start time
- */
 export async function getPossibleDuplicateEvents(
   ctx: QueryCtx,
   startDateTime: Date,
@@ -539,7 +487,6 @@ export async function getPossibleDuplicateEvents(
   const startDateTimeUpperBound = new Date(startDateTime);
   startDateTimeUpperBound.setHours(startDateTime.getHours() + 1);
 
-  // Use range query with index instead of fetching all events and filtering
   const events = await ctx.db
     .query("events")
     .withIndex("by_startDateTime", (q) =>
@@ -552,9 +499,6 @@ export async function getPossibleDuplicateEvents(
   return events;
 }
 
-/**
- * Get a single event by ID
- */
 export async function getEventById(ctx: QueryCtx, eventId: string) {
   const event = await ctx.db
     .query("events")
@@ -565,7 +509,6 @@ export async function getEventById(ctx: QueryCtx, eventId: string) {
     return null;
   }
 
-  // Get related data
   const user = await ctx.db
     .query("users")
     .withIndex("by_custom_id", (q) => q.eq("id", event.userId))
@@ -576,11 +519,9 @@ export async function getEventById(ctx: QueryCtx, eventId: string) {
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
     .collect();
 
-  // Batch fetch all follower users (avoids N+1 queries)
   const followerIds = eventFollowsRaw.map((f) => f.userId);
   const followerMap = await batchGetUsersByIds(ctx, followerIds);
 
-  // Enrich eventFollows with user data
   const eventFollows = eventFollowsRaw.map((follow) => {
     const follower = followerMap.get(follow.userId);
     return {
@@ -617,7 +558,6 @@ export async function getEventById(ctx: QueryCtx, eventId: string) {
     }
   }
 
-  // If the user is not found, still return the event but log a warning
   if (!user) {
     console.warn(
       `User not found for event ${eventId} with userId ${event.userId}`,
@@ -634,9 +574,6 @@ export async function getEventById(ctx: QueryCtx, eventId: string) {
   };
 }
 
-/**
- * Get all events
- */
 export async function getAllEvents(ctx: QueryCtx) {
   const events = await ctx.db.query("events").collect();
   return events.sort(
@@ -645,9 +582,6 @@ export async function getAllEvents(ctx: QueryCtx) {
   );
 }
 
-/**
- * Get next upcoming events
- */
 export async function getNextEvents(
   ctx: QueryCtx,
   limit?: number,
@@ -655,11 +589,8 @@ export async function getNextEvents(
 ) {
   const now = new Date();
 
-  // Use range query with index instead of fetching all events and filtering
   const query = ctx.db.query("events").withIndex("by_startDateTime", (q) => {
     if (excludeCurrent) {
-      // Filter by endDateTime for excludeCurrent, but we need to fetch and filter
-      // since we don't have an endDateTime index
       return q.gte("startDateTime", now.toISOString());
     } else {
       return q.gte("startDateTime", now.toISOString());
@@ -668,7 +599,6 @@ export async function getNextEvents(
 
   const events = await query.collect();
 
-  // Additional filtering for excludeCurrent since we can't efficiently query endDateTime
   const filteredEvents = excludeCurrent
     ? events.filter((event) => new Date(event.endDateTime) >= now)
     : events;
@@ -681,9 +611,6 @@ export async function getNextEvents(
   return limit ? sortedEvents.slice(0, limit) : sortedEvents;
 }
 
-/**
- * Get discover events (excluding user's own events)
- */
 export async function getDiscoverEvents(
   ctx: QueryCtx,
   userId: string,
@@ -692,7 +619,6 @@ export async function getDiscoverEvents(
 ) {
   const now = new Date();
 
-  // Use compound index to filter by visibility and startDateTime efficiently
   const query = ctx.db
     .query("events")
     .withIndex("by_visibility_and_startDateTime", (q) =>
@@ -707,7 +633,7 @@ export async function getDiscoverEvents(
     if (excludeCurrent) {
       return new Date(event.endDateTime) >= now;
     }
-    return true; // visibility and startDateTime filters already applied in query
+    return true;
   });
 
   const sortedEvents = filteredEvents.sort(
@@ -718,9 +644,6 @@ export async function getDiscoverEvents(
   return limit ? sortedEvents.slice(0, limit) : sortedEvents;
 }
 
-/**
- * Create a new event
- */
 export async function createEvent(
   ctx: MutationCtx,
   userId: string,
@@ -734,7 +657,6 @@ export async function createEvent(
 ) {
   const eventId = generatePublicId();
 
-  // Parse dates and times
   const startTime = eventData.startTime || "00:00";
   const endTime = eventData.endTime || "23:59";
   const timeZone = eventData.timeZone || DEFAULT_TIMEZONE;
@@ -742,7 +664,6 @@ export async function createEvent(
   const startDateTime = parseDateTime(eventData.startDate, startTime, timeZone);
   const endDateTime = parseDateTime(eventData.endDate, endTime, timeZone);
 
-  // Find or create similarity group
   const similarityGroupId =
     (await findSimilarityGroup(ctx, {
       startDateTime: startDateTime.toISOString(),
@@ -752,18 +673,15 @@ export async function createEvent(
       location: eventData.location,
     })) || generateSimilarityGroupId();
 
-  // Determine effective visibility based on user's publicListEnabled setting if not specified
   let effectiveVisibility = visibility;
   if (effectiveVisibility === undefined) {
     const user = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", userId))
       .first();
-    // Default to user's publicListEnabled setting, or "private" if not set
     effectiveVisibility = user?.publicListEnabled ? "public" : "private";
   }
 
-  // Create the event with similarity group
   const eventDocId = await ctx.db.insert("events", {
     id: eventId,
     userId,
@@ -775,7 +693,6 @@ export async function createEvent(
     visibility: effectiveVisibility,
     created_at: new Date().toISOString(),
     updatedAt: null,
-    // Extract fields for easier querying
     name: eventData.name,
     image: eventData.images?.[0] || null,
     endDate: eventData.endDate,
@@ -786,18 +703,15 @@ export async function createEvent(
     startTime,
     description: eventData.description,
     batchId,
-    // Similarity group for feed grouping
     similarityGroupId,
   });
 
-  // Sync with aggregates for efficient stats
   const createdEvent = await ctx.db.get(eventDocId);
   if (createdEvent) {
     await eventsByCreation.replaceOrInsert(ctx, createdEvent, createdEvent);
     await eventsByStartTime.replaceOrInsert(ctx, createdEvent, createdEvent);
   }
 
-  // Add comment if provided
   if (comment && comment.length > 0) {
     await ctx.db.insert("comments", {
       content: comment,
@@ -810,7 +724,6 @@ export async function createEvent(
     });
   }
 
-  // Add to lists if provided, enforcing list contribution rules
   if (lists && lists.length > 0) {
     for (const list of lists) {
       if (list.value) {
@@ -819,12 +732,9 @@ export async function createEvent(
     }
   }
 
-  // Link event to creator's personal list. Use addEventToList so that
-  // followers of the personal list get the event propagated to their feed.
   const personalList = await getOrCreatePersonalList(ctx, userId);
   await addEventToList(ctx, eventId, personalList.id, userId);
 
-  // Add event to feeds (with similarity group for grouped feed support)
   await ctx.runMutation(internal.feedHelpers.updateEventInFeeds, {
     eventId,
     userId,
@@ -837,17 +747,12 @@ export async function createEvent(
   return { id: eventId };
 }
 
-/**
- * Regroup an event to a new similarity group
- * Updates: events table, userFeeds table, userFeedGroups table
- */
 async function regroupEvent(
   ctx: MutationCtx,
   eventId: string,
   oldGroupId: string,
   newGroupId: string,
 ): Promise<void> {
-  // Step 1: Update the event's similarityGroupId
   const event = await ctx.db
     .query("events")
     .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -861,32 +766,26 @@ async function regroupEvent(
     similarityGroupId: newGroupId,
   });
 
-  // Step 2: Update all userFeeds entries for this event
   const feedEntries = await ctx.db
     .query("userFeeds")
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
     .collect();
 
-  // Track affected feed+group pairs for userFeedGroups updates
   const affectedOldGroups = new Set<string>();
   const affectedNewGroups = new Set<string>();
 
   for (const entry of feedEntries) {
-    // Track old group (for cleanup/re-election)
     if (entry.similarityGroupId) {
       affectedOldGroups.add(`${entry.feedId}:${entry.similarityGroupId}`);
     }
 
-    // Update the feed entry
     await ctx.db.patch(entry._id, {
       similarityGroupId: newGroupId,
     });
 
-    // Track new group (for creation/update)
     affectedNewGroups.add(`${entry.feedId}:${newGroupId}`);
   }
 
-  // Step 3: Update userFeedGroups for affected old groups
   for (const pair of affectedOldGroups) {
     const [feedId, groupId] = pair.split(":");
     if (feedId && groupId) {
@@ -897,7 +796,6 @@ async function regroupEvent(
     }
   }
 
-  // Step 4: Update userFeedGroups for affected new groups
   for (const pair of affectedNewGroups) {
     const [feedId, groupId] = pair.split(":");
     if (feedId && groupId) {
@@ -909,9 +807,6 @@ async function regroupEvent(
   }
 }
 
-/**
- * Update an existing event
- */
 export async function updateEvent(
   ctx: MutationCtx,
   userId: string,
@@ -923,7 +818,6 @@ export async function updateEvent(
   visibility?: "public" | "private",
   isAdmin?: boolean,
 ) {
-  // Check if user owns the event or is admin
   const existingEvent = await ctx.db
     .query("events")
     .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -937,12 +831,10 @@ export async function updateEvent(
     throw new ConvexError("Unauthorized");
   }
 
-  // Parse dates and times
   const startTime = eventData.startTime || "00:00";
   const endTime = eventData.endTime || "23:59";
   const timeZone = eventData.timeZone || DEFAULT_TIMEZONE;
 
-  // Validate required date fields
   if (!eventData.startDate) {
     throw new ConvexError("Start date is required");
   }
@@ -953,7 +845,6 @@ export async function updateEvent(
   const startDateTime = parseDateTime(eventData.startDate, startTime, timeZone);
   const endDateTime = parseDateTime(eventData.endDate, endTime, timeZone);
 
-  // Update the event
   await ctx.db.patch(existingEvent._id, {
     event: eventData,
     eventMetadata,
@@ -961,7 +852,6 @@ export async function updateEvent(
     endDateTime: endDateTime.toISOString(),
     ...(visibility && { visibility }),
     updatedAt: new Date().toISOString(),
-    // Update extracted fields
     name: eventData.name,
     image: eventData.images?.[0] || null,
     endDate: eventData.endDate,
@@ -973,15 +863,12 @@ export async function updateEvent(
     description: eventData.description,
   });
 
-  // Get updated event for aggregates
   const updatedEvent = await ctx.db.get(existingEvent._id);
   if (updatedEvent) {
-    // Sync with aggregates (replace updates the sort keys)
     await eventsByCreation.replaceOrInsert(ctx, existingEvent, updatedEvent);
     await eventsByStartTime.replaceOrInsert(ctx, existingEvent, updatedEvent);
   }
 
-  // Handle comment
   const existingComment = await ctx.db
     .query("comments")
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
@@ -1009,14 +896,12 @@ export async function updateEvent(
     await ctx.db.delete(existingComment._id);
   }
 
-  // Handle lists
   if (lists !== undefined) {
     const existingEventToLists = await ctx.db
       .query("eventToLists")
       .withIndex("by_event", (q) => q.eq("eventId", eventId))
       .collect();
 
-    // Track which lists were removed and which were added
     const existingListIds = new Set(
       existingEventToLists.map((etl) => etl.listId),
     );
@@ -1024,14 +909,12 @@ export async function updateEvent(
       lists.filter((l) => l.value).map((l) => l.value),
     );
 
-    // Delete existing list associations that are no longer in the new list
     for (const etl of existingEventToLists) {
       if (!newListIds.has(etl.listId)) {
         await removeEventFromList(ctx, eventId, etl.listId, userId);
       }
     }
 
-    // Add new list associations
     if (lists.length > 0) {
       for (const list of lists) {
         if (list.value && !existingListIds.has(list.value)) {
@@ -1041,14 +924,12 @@ export async function updateEvent(
     }
   }
 
-  // Update feeds if visibility or time changed
   const visibilityChanged =
     visibility && existingEvent.visibility !== visibility;
   const timeChanged =
     existingEvent.startDateTime !== startDateTime.toISOString() ||
     existingEvent.endDateTime !== endDateTime.toISOString();
 
-  // Check if regrouping is needed (when similarity-affecting fields change)
   const newEventData = {
     startDateTime: startDateTime.toISOString(),
     endDateTime: endDateTime.toISOString(),
@@ -1061,7 +942,6 @@ export async function updateEvent(
     newEventData,
   );
 
-  // Determine the similarity group ID (may change if regrouping)
   let similarityGroupId = existingEvent.similarityGroupId;
 
   if (similarityFieldsChanged && existingEvent.similarityGroupId) {
@@ -1084,7 +964,6 @@ export async function updateEvent(
   }
 
   if (visibilityChanged || timeChanged) {
-    // If changing to private, remove from discover feed
     if (visibility === "private" && existingEvent.visibility === "public") {
       await ctx.runMutation(internal.feedHelpers.removeEventFromFeeds, {
         eventId,
@@ -1092,7 +971,6 @@ export async function updateEvent(
       });
     }
 
-    // Update event in feeds with new visibility and/or time (pass similarityGroupId for grouped feed support)
     await ctx.runMutation(internal.feedHelpers.updateEventInFeeds, {
       eventId,
       userId: existingEvent.userId,
@@ -1103,17 +981,12 @@ export async function updateEvent(
     });
 
     if (visibilityChanged) {
-      // updateEventInFeeds only touches creator/follower/discover feeds, but
-      // the event also lives in list_${listId} entries that removeEventFromFeeds
-      // intentionally preserves. Sync their `eventVisibility` so the
-      // index-level filter in getEventsForList stays correct after toggles.
       await ctx.runMutation(internal.feedHelpers.updateEventVisibilityInFeeds, {
         eventId,
         visibility: visibility || existingEvent.visibility,
       });
     }
 
-    // If changing to public, fan out to list followers
     if (visibility === "public" && existingEvent.visibility === "private") {
       const eventToLists = await ctx.db
         .query("eventToLists")
@@ -1143,9 +1016,6 @@ export async function updateEvent(
   return { id: eventId };
 }
 
-/**
- * Delete an event
- */
 export async function deleteEvent(
   ctx: MutationCtx,
   userId: string,
@@ -1165,7 +1035,6 @@ export async function deleteEvent(
     throw new ConvexError("Unauthorized");
   }
 
-  // Delete related records
   const eventFollows = await ctx.db
     .query("eventFollows")
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
@@ -1181,9 +1050,7 @@ export async function deleteEvent(
     .withIndex("by_event", (q) => q.eq("eventId", eventId))
     .collect();
 
-  // Delete all related records
   for (const ef of eventFollows) {
-    // Remove from eventFollows aggregate before deleting
     await eventFollowsAggregate.deleteIfExists(ctx, ef);
     await ctx.db.delete(ef._id);
   }
@@ -1196,34 +1063,25 @@ export async function deleteEvent(
     await ctx.db.delete(etl._id);
   }
 
-  // Remove event from all feeds, including the list_${listId} membership
-  // entries — the event row itself is going away, so its dedicated list
-  // feeds must too.
   await ctx.runMutation(internal.feedHelpers.removeEventFromFeeds, {
     eventId,
     keepCreatorFeed: false,
     keepListFeeds: false,
   });
 
-  // Remove from aggregates before deleting the event
   await eventsByCreation.deleteIfExists(ctx, event);
   await eventsByStartTime.deleteIfExists(ctx, event);
 
-  // Delete the event
   await ctx.db.delete(event._id);
 
   return { id: eventId };
 }
 
-/**
- * Follow an event
- */
 export async function followEvent(
   ctx: MutationCtx,
   userId: string,
   eventId: string,
 ) {
-  // Check if already following
   const existingFollow = await ctx.db
     .query("eventFollows")
     .withIndex("by_user_and_event", (q) =>
@@ -1237,7 +1095,6 @@ export async function followEvent(
       eventId,
     });
 
-    // Sync with eventFollows aggregate
     const createdFollow = await ctx.db.get(followId);
     if (createdFollow) {
       await eventFollowsAggregate.replaceOrInsert(
@@ -1247,14 +1104,12 @@ export async function followEvent(
       );
     }
 
-    // Get event to add to user's feed
     const event = await ctx.db
       .query("events")
       .withIndex("by_custom_id", (q) => q.eq("id", eventId))
       .unique();
 
     if (event) {
-      // Add to user's feed
       await ctx.runMutation(internal.feedHelpers.addEventToUserFeed, {
         userId,
         eventId,
@@ -1265,9 +1120,6 @@ export async function followEvent(
   return await getEventById(ctx, eventId);
 }
 
-/**
- * Unfollow an event
- */
 export async function unfollowEvent(
   ctx: MutationCtx,
   userId: string,
@@ -1329,7 +1181,6 @@ export async function unfollowEvent(
         await userFeedsAggregate.deleteIfExists(ctx, feedEntry);
         await ctx.db.delete(feedEntry._id);
 
-        // Sync grouped feed entry (removes group if empty, or updates primary/count)
         if (similarityGroupId) {
           await ctx.runMutation(
             internal.feedGroupHelpers.upsertGroupedFeedEntry,
@@ -1343,9 +1194,6 @@ export async function unfollowEvent(
   return await getEventById(ctx, eventId);
 }
 
-/**
- * Add event to list
- */
 export async function addEventToList(
   ctx: MutationCtx,
   eventId: string,
@@ -1368,12 +1216,10 @@ export async function addEventToList(
   } else if (contribution === "open") {
     // Open mode: anyone can contribute
   } else if (contribution === "owner") {
-    // Owner mode: only the list owner can contribute
     throw new ConvexError(
       "Cannot add event to list: contribution is restricted to owner only",
     );
   } else {
-    // Restricted mode: only members can contribute
     const membership = await ctx.db
       .query("listMembers")
       .withIndex("by_list_and_user", (q) =>
@@ -1401,11 +1247,8 @@ export async function addEventToList(
       listId,
     });
 
-    // Maintain the list's own feed (list_${listId}) so getEventsForList can
-    // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Add event to followers' feeds
     await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
       eventId,
       listId,
@@ -1413,9 +1256,6 @@ export async function addEventToList(
   }
 }
 
-/**
- * Remove event from list
- */
 export async function removeEventFromList(
   ctx: MutationCtx,
   eventId: string,
@@ -1438,12 +1278,10 @@ export async function removeEventFromList(
   } else if (contribution === "open") {
     // Open mode: anyone can contribute
   } else if (contribution === "owner") {
-    // Owner mode: only the list owner can contribute
     throw new ConvexError(
       "Cannot remove event from list: contribution is restricted to owner only",
     );
   } else {
-    // Restricted mode: only members can contribute
     const membership = await ctx.db
       .query("listMembers")
       .withIndex("by_list_and_user", (q) =>
@@ -1470,11 +1308,8 @@ export async function removeEventFromList(
       await ctx.db.delete(link._id);
     }
 
-    // Drop this event from the list's own feed before fanning out to
-    // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Remove event from followers' feeds
     await ctx.runMutation(
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
@@ -1485,9 +1320,6 @@ export async function removeEventFromList(
   }
 }
 
-/**
- * Toggle event visibility
- */
 export async function toggleEventVisibility(
   ctx: MutationCtx,
   userId: string,
@@ -1512,16 +1344,13 @@ export async function toggleEventVisibility(
     updatedAt: new Date().toISOString(),
   });
 
-  // Update feeds based on visibility change
   if (event.visibility !== visibility) {
-    // If changing to private, remove from public feeds
     if (visibility === "private") {
       await ctx.runMutation(internal.feedHelpers.removeEventFromFeeds, {
         eventId,
         keepCreatorFeed: true,
       });
     } else {
-      // If changing to public, add to feeds
       await ctx.runMutation(internal.feedHelpers.updateEventInFeeds, {
         eventId,
         userId: event.userId,
@@ -1530,7 +1359,6 @@ export async function toggleEventVisibility(
         endDateTime: event.endDateTime,
       });
 
-      // Fan out to list followers when event becomes public
       const eventToLists = await ctx.db
         .query("eventToLists")
         .withIndex("by_event", (q) => q.eq("eventId", eventId))
@@ -1547,9 +1375,6 @@ export async function toggleEventVisibility(
       }
     }
 
-    // Sync eventVisibility on persistent feed entries (creator + list_*).
-    // updateEventInFeeds / removeEventFromFeeds don't touch list_* visibility,
-    // so the getEventsForList index filter would otherwise read a stale value.
     await ctx.runMutation(internal.feedHelpers.updateEventVisibilityInFeeds, {
       eventId,
       visibility,
@@ -1559,9 +1384,6 @@ export async function toggleEventVisibility(
   return event;
 }
 
-/**
- * Get user stats using aggregates for O(log(n)) performance
- */
 export async function getUserStats(ctx: QueryCtx, userName: string) {
   const user = await ctx.db
     .query("users")
@@ -1584,11 +1406,9 @@ export async function getUserStats(ctx: QueryCtx, userName: string) {
   const nowMs = now.getTime();
   const sevenDaysAgoMs = sevenDaysAgo.getTime();
 
-  // Run all aggregate queries in parallel for better performance
   const feedId = `user_${user.id}`;
   const [capturesThisWeek, allTimeOwnEvents, totalFollows, upcomingEvents] =
     await Promise.all([
-      // Count events created in last 7 days using aggregate - O(log(n))
       eventsByCreation.count(ctx, {
         namespace: user.id,
         bounds: {
@@ -1597,17 +1417,14 @@ export async function getUserStats(ctx: QueryCtx, userName: string) {
         },
       }),
 
-      // Count all-time events (own) using aggregate - O(log(n))
       eventsByCreation.count(ctx, {
         namespace: user.id,
       }),
 
-      // Count total event follows using aggregate - O(log(n))
       eventFollowsAggregate.count(ctx, {
         namespace: user.id,
       }),
 
-      // Count upcoming events (own + followed) using userFeeds aggregate - O(log(n))
       userFeedsAggregate.count(ctx, {
         namespace: feedId,
         bounds: {
@@ -1626,9 +1443,6 @@ export async function getUserStats(ctx: QueryCtx, userName: string) {
   };
 }
 
-/**
- * Get events for user with pagination (upcoming or past)
- */
 export async function getEventsForUserPaginated(
   ctx: QueryCtx,
   userName: string,
@@ -1655,11 +1469,10 @@ export async function getEventsForUserPaginated(
       // Index provides ascending order by startDateTime by default as it's the second field.
       .filter((q) => q.gte(q.field("startDateTime"), now));
   } else {
-    // "past"
     queryBuilder = ctx.db
       .query("events")
       .withIndex("by_user_and_startDateTime", (q) => q.eq("userId", user.id))
-      .order("desc") // Reverse the natural index order to get most recent past events first
+      .order("desc")
       .filter((q) => q.lt(q.field("startDateTime"), now));
   }
 

--- a/packages/backend/convex/model/files.ts
+++ b/packages/backend/convex/model/files.ts
@@ -1,6 +1,3 @@
-/**
- * Upload base64 image to CDN
- */
 export async function uploadImageToCDNFromBase64(
   base64Image: string,
   contentType?: string,
@@ -13,7 +10,6 @@ export async function uploadImageToCDNFromBase64(
 
     const base64Data = base64Image.replace(/^data:image\/\w+;base64,/, "");
 
-    // Convert base64 string to Uint8Array (Convex doesn't have Buffer)
     const binaryString = atob(base64Data);
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {

--- a/packages/backend/convex/model/lists.ts
+++ b/packages/backend/convex/model/lists.ts
@@ -1,19 +1,5 @@
 import type { QueryCtx } from "../_generated/server";
 
-/**
- * Determine which of the given lists the current viewer is allowed to see.
- *
- * Mirrors the access rules used elsewhere (see `lists.checkListAccess` and
- * `feedHelpers.canUserViewListForFeed`): public/unlisted lists are visible
- * to anyone; private lists only to their owner or to a member.
- *
- * IMPORTANT: This is the single source of truth for what lists a viewer may
- * know about. The result is used to strip private-unviewable lists from
- * `event.lists` before it's returned to any client, in both feed queries
- * (feeds.ts) and the list-detail query (lists.ts `getEventsForList`). The
- * `SavedByModal` on the client explicitly trusts the server's filtering —
- * every code path that populates `event.lists` MUST pass it through here.
- */
 export async function getViewableListIds(
   ctx: QueryCtx,
   lists: { id: string; userId: string; visibility: string }[],
@@ -27,7 +13,6 @@ export async function getViewableListIds(
       viewableIds.add(list.id);
       continue;
     }
-    // Private list — viewer must be owner or a member to see it.
     if (viewerId && list.userId === viewerId) {
       viewableIds.add(list.id);
       continue;

--- a/packages/backend/convex/model/notifications.ts
+++ b/packages/backend/convex/model/notifications.ts
@@ -1,6 +1,5 @@
 import type { QueryCtx } from "../_generated/server";
 
-// Types for notification operations
 export interface NotificationResult {
   success: boolean;
   id?: string;
@@ -16,21 +15,14 @@ export interface BatchNotificationResult {
   errors: { userId?: string; error: string }[];
 }
 
-/**
- * Get all users from the database
- */
 export async function getAllUsers(ctx: QueryCtx) {
   return await ctx.db.query("users").collect();
 }
 
-/**
- * Get upcoming events for a user within the next week
- */
 export async function getUpcomingEventsForUser(ctx: QueryCtx, userId: string) {
   const now = new Date();
   const oneWeekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
-  // Get events created by the user
   const userEvents = await ctx.db
     .query("events")
     .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -42,7 +34,6 @@ export async function getUpcomingEventsForUser(ctx: QueryCtx, userId: string) {
     )
     .collect();
 
-  // Get events the user is following
   const eventFollows = await ctx.db
     .query("eventFollows")
     .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -70,7 +61,6 @@ export async function getUpcomingEventsForUser(ctx: QueryCtx, userId: string) {
 
   const validFollowedEvents = followedEvents.filter((event) => event !== null);
 
-  // Combine and deduplicate events
   const allEvents = [...userEvents, ...validFollowedEvents];
   const eventMap = new Map(allEvents.map((event) => [event.id, event]));
   const uniqueEvents = Array.from(eventMap.values());
@@ -78,9 +68,6 @@ export async function getUpcomingEventsForUser(ctx: QueryCtx, userId: string) {
   return uniqueEvents;
 }
 
-/**
- * Get users who started their trial 5 days ago and are still trialing
- */
 export async function getTrialExpirationUsers(ctx: QueryCtx) {
   const fiveBusinessDaysAgo = new Date();
   fiveBusinessDaysAgo.setDate(fiveBusinessDaysAgo.getDate() - 5);
@@ -97,7 +84,6 @@ export async function getTrialExpirationUsers(ctx: QueryCtx) {
           ? JSON.parse(user.publicMetadata)
           : user.publicMetadata;
 
-      // Type guard to check if metadata has the expected structure
       if (
         !metadata ||
         typeof metadata !== "object" ||
@@ -129,9 +115,6 @@ export async function getTrialExpirationUsers(ctx: QueryCtx) {
   });
 }
 
-/**
- * Generate a prompt for creating a weekly notification with events
- */
 export function getPromptForWeeklyNotificationWithEvents(
   eventDescriptions: string,
 ): string {
@@ -161,9 +144,6 @@ Example output:
 Remember to vary your output for different weeks, maintaining the exciting and unique elements that make each week special.`;
 }
 
-/**
- * Generate notification content for a user based on their upcoming events
- */
 export async function generateWeeklyNotificationContent(
   ctx: QueryCtx,
   userId: string,
@@ -193,11 +173,8 @@ export async function generateWeeklyNotificationContent(
     summary =
       "Keep capturing events you see. Missing any? Check your screenshots now!";
   } else {
-    // For 3+ events, we'll need to generate AI content
-    // This will be handled in the action that calls the AI
     const eventDescriptions = upcomingEvents
       .map((event) => {
-        // Safely access event data
         const eventData = event.event as Record<string, unknown> | undefined;
         const name =
           (eventData?.name as string) || event.name || "Untitled Event";

--- a/packages/backend/convex/model/oneSignal.ts
+++ b/packages/backend/convex/model/oneSignal.ts
@@ -1,13 +1,10 @@
 "use node";
 
-// OneSignal REST API base URL
 const ONE_SIGNAL_API_URL = "https://onesignal.com/api/v1";
 
-// Use CONVEX_ENV for explicit environment detection, fallback to NODE_ENV
 const ENV = process.env.CONVEX_ENV || process.env.NODE_ENV || "production";
 const IS_DEV = ENV === "development";
 
-// Log environment detection for debugging
 console.log("OneSignal Environment Detection:", {
   CONVEX_ENV: process.env.CONVEX_ENV,
   NODE_ENV: process.env.NODE_ENV,
@@ -15,7 +12,6 @@ console.log("OneSignal Environment Detection:", {
   IS_DEV,
 });
 
-// OneSignal API key from environment variables
 const ONE_SIGNAL_REST_API_KEY = IS_DEV
   ? process.env.ONE_SIGNAL_REST_API_KEY_DEV
   : process.env.ONE_SIGNAL_REST_API_KEY_PROD;
@@ -24,7 +20,6 @@ const EXPO_PUBLIC_ONE_SIGNAL_APP_ID = IS_DEV
   ? process.env.EXPO_PUBLIC_ONE_SIGNAL_APP_ID_DEV
   : process.env.EXPO_PUBLIC_ONE_SIGNAL_APP_ID_PROD;
 
-// Check if OneSignal is properly configured
 if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
   console.warn(
     "OneSignal API key or App ID not configured. Notifications will not be sent.",
@@ -49,7 +44,6 @@ export interface SendNotificationParams {
   eventId?: string;
 }
 
-// OneSignal API response types
 interface OneSignalSuccessResponse {
   id: string;
   recipients: number;
@@ -65,9 +59,6 @@ interface OneSignalErrorResponse {
 
 type OneSignalResponse = OneSignalSuccessResponse | OneSignalErrorResponse;
 
-/**
- * Sends a notification to a specific user using OneSignal's API
- */
 export async function sendNotification({
   userId,
   title,
@@ -84,7 +75,6 @@ export async function sendNotification({
   id?: string;
   error?: string;
 }> {
-  // If OneSignal is not configured, log and return early
   if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
     console.error("OneSignal API key or App ID not configured", {
       userId,
@@ -99,11 +89,9 @@ export async function sendNotification({
     };
   }
 
-  // Generate a notification ID if not provided
   const finalNotificationId = notificationId || crypto.randomUUID();
 
   try {
-    // Prepare the notification payload
     const payload = {
       app_id: EXPO_PUBLIC_ONE_SIGNAL_APP_ID,
       include_external_user_ids: [userId],
@@ -119,7 +107,6 @@ export async function sendNotification({
       url: url,
     };
 
-    // Send the notification using OneSignal's REST API
     const response = await fetch(`${ONE_SIGNAL_API_URL}/notifications`, {
       method: "POST",
       headers: {
@@ -163,9 +150,6 @@ export async function sendNotification({
   }
 }
 
-/**
- * Sends a notification to multiple users using OneSignal's API
- */
 export async function sendBatchNotifications({
   userIds,
   title,
@@ -184,7 +168,6 @@ export async function sendBatchNotifications({
   error?: string;
   recipients?: number;
 }> {
-  // If OneSignal is not configured, log and return early
   if (!ONE_SIGNAL_REST_API_KEY || !EXPO_PUBLIC_ONE_SIGNAL_APP_ID) {
     console.error("OneSignal API key or App ID not configured", {
       userIds: userIds.length,
@@ -200,7 +183,6 @@ export async function sendBatchNotifications({
   }
 
   try {
-    // Prepare the notification payload
     const payload = {
       app_id: EXPO_PUBLIC_ONE_SIGNAL_APP_ID,
       include_external_user_ids: userIds,
@@ -214,7 +196,6 @@ export async function sendBatchNotifications({
       url: url,
     };
 
-    // Send the notification using OneSignal's REST API
     const response = await fetch(`${ONE_SIGNAL_API_URL}/notifications`, {
       method: "POST",
       headers: {

--- a/packages/backend/convex/model/posthog.ts
+++ b/packages/backend/convex/model/posthog.ts
@@ -4,7 +4,6 @@ const POSTHOG_API_URL = "https://app.posthog.com";
 const POSTHOG_KEY = process.env.POSTHOG_KEY;
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || POSTHOG_API_URL;
 
-// PostHog recommends keeping batches under ~1000 events
 const POSTHOG_BATCH_SIZE = 500;
 
 export interface UserProperties {
@@ -29,7 +28,6 @@ function chunkArray<T>(array: T[], size: number): T[][] {
   return chunks;
 }
 
-/** Batch identify multiple users in PostHog using the /batch endpoint */
 export async function batchIdentifyUsers(users: IdentifyUserParams[]): Promise<{
   success: boolean;
   successCount: number;

--- a/packages/backend/convex/model/similarityHelpers.ts
+++ b/packages/backend/convex/model/similarityHelpers.ts
@@ -2,20 +2,14 @@ import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { generatePublicId } from "../utils";
 
-// Constants for similarity detection
 export const SIMILARITY_THRESHOLDS = {
-  // Time proximity threshold in minutes (±60 minutes)
   startTimeThreshold: 60,
   endTimeThreshold: 60,
-  // Text similarity threshold (10%)
   nameThreshold: 0.1,
   descriptionThreshold: 0.1,
   locationThreshold: 0.1,
 } as const;
 
-/**
- * Convert text to a word frequency vector
- */
 export function textToVector(text: string): Map<string, number> {
   const wordMap = new Map<string, number>();
   const words = text.toLowerCase().match(/\w+/g) || [];
@@ -27,9 +21,6 @@ export function textToVector(text: string): Map<string, number> {
   return wordMap;
 }
 
-/**
- * Calculate cosine similarity between two word frequency vectors
- */
 export function cosineSimilarity(
   vector1: Map<string, number>,
   vector2: Map<string, number>,
@@ -65,9 +56,6 @@ export function cosineSimilarity(
   return dotProduct / magnitude;
 }
 
-/**
- * Event data extracted for similarity comparison
- */
 export interface EventSimilarityData {
   startDateTime: string;
   endDateTime: string;
@@ -76,9 +64,6 @@ export interface EventSimilarityData {
   location?: string;
 }
 
-/**
- * Check if two events are similar based on time and text similarity
- */
 export function areEventsSimilar(
   event1: EventSimilarityData,
   event2: EventSimilarityData,
@@ -88,7 +73,6 @@ export function areEventsSimilar(
   const endTime1 = new Date(event1.endDateTime).getTime();
   const endTime2 = new Date(event2.endDateTime).getTime();
 
-  // Check time proximity (in minutes)
   const startTimeDifference = Math.abs(startTime1 - startTime2) / (1000 * 60);
   const endTimeDifference = Math.abs(endTime1 - endTime2) / (1000 * 60);
 
@@ -99,7 +83,6 @@ export function areEventsSimilar(
     return false;
   }
 
-  // Check text similarity
   const nameSimilarity = cosineSimilarity(
     textToVector(event1.name || ""),
     textToVector(event2.name || ""),
@@ -122,18 +105,10 @@ export function areEventsSimilar(
   );
 }
 
-/**
- * Generate a new similarity group ID
- */
 export function generateSimilarityGroupId(): string {
   return `sg_${generatePublicId()}`;
 }
 
-/**
- * Find an existing similarity group among nearby events
- * Returns the similarityGroupId if found, or null if no similar events exist
- * @param excludeEventId - Optional event ID to exclude from the search (used during regrouping)
- */
 export async function findSimilarityGroup(
   ctx: MutationCtx | QueryCtx,
   eventData: EventSimilarityData,
@@ -141,12 +116,10 @@ export async function findSimilarityGroup(
 ): Promise<string | null> {
   const startDateTime = new Date(eventData.startDateTime);
 
-  // Search window: events within ±2 hours of the start time
-  const windowMs = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
+  const windowMs = 2 * 60 * 60 * 1000;
   const lowerBound = new Date(startDateTime.getTime() - windowMs);
   const upperBound = new Date(startDateTime.getTime() + windowMs);
 
-  // Query events within the time window
   const candidateEvents = await ctx.db
     .query("events")
     .withIndex("by_startDateTime", (q) =>
@@ -156,14 +129,11 @@ export async function findSimilarityGroup(
     )
     .collect();
 
-  // Check each candidate for similarity
   for (const candidate of candidateEvents) {
-    // Skip events without a similarity group
     if (!candidate.similarityGroupId) {
       continue;
     }
 
-    // Skip the event being updated (to avoid matching itself during regrouping)
     if (excludeEventId && candidate.id === excludeEventId) {
       continue;
     }
@@ -184,10 +154,6 @@ export async function findSimilarityGroup(
   return null;
 }
 
-/**
- * Find similarity group for backfill migration
- * Uses earlier events (by creation date) to establish groups
- */
 export async function findSimilarityGroupForBackfill(
   ctx: MutationCtx,
   event: Doc<"events">,
@@ -205,7 +171,6 @@ export async function findSimilarityGroupForBackfill(
   const lowerBound = new Date(startDateTime.getTime() - windowMs);
   const upperBound = new Date(startDateTime.getTime() + windowMs);
 
-  // Query events within the time window that were created before this event
   const candidateEvents = await ctx.db
     .query("events")
     .withIndex("by_startDateTime", (q) =>
@@ -216,9 +181,7 @@ export async function findSimilarityGroupForBackfill(
     .filter((q) => q.lt(q.field("created_at"), event.created_at))
     .collect();
 
-  // Check each candidate for similarity
   for (const candidate of candidateEvents) {
-    // Skip events without a similarity group
     if (!candidate.similarityGroupId) {
       continue;
     }
@@ -239,18 +202,10 @@ export async function findSimilarityGroupForBackfill(
   return null;
 }
 
-/**
- * Select the primary event for a feed's similarity group
- * Primary selection is feed-scoped via userFeeds membership
- * Priority:
- * 1. If this is a user feed, prefer that user's own event in the group
- * 2. Otherwise, earliest by created_at (deterministic)
- */
 export async function selectPrimaryEventForFeed(
   ctx: MutationCtx | QueryCtx,
   args: { feedId: string; similarityGroupId: string },
 ): Promise<Doc<"events"> | null> {
-  // Get all userFeeds entries for this feed+group
   const membership = await ctx.db
     .query("userFeeds")
     .withIndex("by_feed_group", (q) =>
@@ -264,7 +219,6 @@ export async function selectPrimaryEventForFeed(
     return null;
   }
 
-  // Fetch all member events
   const memberEvents = await Promise.all(
     membership.map(async (m) => {
       return await ctx.db
@@ -282,7 +236,6 @@ export async function selectPrimaryEventForFeed(
     return null;
   }
 
-  // Priority 1: If this is a user feed, prefer that user's own event
   const feedUserId = args.feedId.startsWith("user_")
     ? args.feedId.replace("user_", "")
     : null;
@@ -294,7 +247,6 @@ export async function selectPrimaryEventForFeed(
     }
   }
 
-  // Priority 2: earliest by created_at (deterministic)
   const sorted = validEvents.sort(
     (a, b) =>
       new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
@@ -302,9 +254,6 @@ export async function selectPrimaryEventForFeed(
   return sorted[0] ?? null;
 }
 
-/**
- * Get the count of events in a feed's similarity group
- */
 export async function getGroupMemberCount(
   ctx: MutationCtx | QueryCtx,
   args: { feedId: string; similarityGroupId: string },
@@ -321,10 +270,6 @@ export async function getGroupMemberCount(
   return membership.length;
 }
 
-/**
- * Determines if event changes warrant a regroup check
- * Returns true if any similarity-affecting fields changed
- */
 export function shouldRegroupEvent(
   existingEvent: Doc<"events">,
   newEventData: {
@@ -347,10 +292,6 @@ export function shouldRegroupEvent(
   return timeChanged || nameChanged || descriptionChanged || locationChanged;
 }
 
-/**
- * Get one representative event from a similarity group (excluding a specific event)
- * Used to check if an event still belongs to its current group
- */
 export async function getRepresentativeGroupMember(
   ctx: MutationCtx | QueryCtx,
   similarityGroupId: string,
@@ -367,10 +308,6 @@ export async function getRepresentativeGroupMember(
   return members[0] ?? null;
 }
 
-/**
- * Determine the new similarity group for an updated event
- * Returns the new group ID and whether regrouping is needed
- */
 export async function determineNewSimilarityGroup(
   ctx: MutationCtx,
   eventId: string,
@@ -380,7 +317,6 @@ export async function determineNewSimilarityGroup(
   newGroupId: string;
   needsRegroup: boolean;
 }> {
-  // Step 1: Check if event still fits in current group
   const currentGroupMember = await getRepresentativeGroupMember(
     ctx,
     currentGroupId,
@@ -397,25 +333,19 @@ export async function determineNewSimilarityGroup(
     });
 
     if (stillSimilarToCurrentGroup) {
-      // Still fits in current group, no regroup needed
       return { newGroupId: currentGroupId, needsRegroup: false };
     }
   }
 
-  // Step 2: Event no longer fits current group. Search for a new group.
-  // Exclude the event being updated to avoid matching itself
   const foundGroupId = await findSimilarityGroup(ctx, eventData, eventId);
 
   if (foundGroupId && foundGroupId !== currentGroupId) {
-    // Found a different existing group
     return { newGroupId: foundGroupId, needsRegroup: true };
   }
 
   if (!foundGroupId) {
-    // No similar events found - create a new unique group
     return { newGroupId: generateSimilarityGroupId(), needsRegroup: true };
   }
 
-  // Found same group (shouldn't normally happen after checking), no regroup needed
   return { newGroupId: currentGroupId, needsRegroup: false };
 }

--- a/packages/backend/convex/model/utils/urlScheme.ts
+++ b/packages/backend/convex/model/utils/urlScheme.ts
@@ -1,16 +1,8 @@
-/**
- * Utility to determine the appropriate URL scheme based on environment
- */
 
-/**
- * Returns the URL scheme to use for deep links based on the current environment
- */
 export function getUrlScheme() {
-  // Use CONVEX_ENV for explicit environment detection, fallback to NODE_ENV
   const ENV = process.env.CONVEX_ENV || process.env.NODE_ENV || "production";
   const isDev = ENV === "development";
 
-  // Log environment detection for debugging
   console.log("Deep link scheme detection:", {
     CONVEX_ENV: process.env.CONVEX_ENV,
     NODE_ENV: process.env.NODE_ENV,
@@ -19,21 +11,14 @@ export function getUrlScheme() {
     scheme: isDev ? "soonlist.dev" : "soonlist",
   });
 
-  // Return appropriate scheme
   if (isDev) {
     return "soonlist.dev";
   }
   return "soonlist";
 }
 
-/**
- * Creates a deep link URL with the proper scheme based on environment
- * @param path The path for the deep link (without leading slash)
- * @returns Fully formed URL string with proper scheme
- */
 export function createDeepLink(path: string) {
   const scheme = getUrlScheme();
-  // Ensure path doesn't start with a slash
   const cleanPath = path.startsWith("/") ? path.substring(1) : path;
   return `${scheme}://${cleanPath}`;
 }

--- a/packages/backend/convex/model/utils/urlScheme.ts
+++ b/packages/backend/convex/model/utils/urlScheme.ts
@@ -1,4 +1,3 @@
-
 export function getUrlScheme() {
   const ENV = process.env.CONVEX_ENV || process.env.NODE_ENV || "production";
   const isDev = ENV === "development";

--- a/packages/backend/convex/notifications.ts
+++ b/packages/backend/convex/notifications.ts
@@ -387,7 +387,6 @@ export const getTrialExpirationUsersQuery = internalQuery({
   },
 });
 
-
 export const push = internalAction({
   args: {
     eventId: v.string(),

--- a/packages/backend/convex/notifications.ts
+++ b/packages/backend/convex/notifications.ts
@@ -8,9 +8,6 @@ import * as OneSignal from "./model/oneSignal";
 import { createDeepLink } from "./model/utils/urlScheme";
 import { generateNotificationId } from "./utils";
 
-/**
- * Send a single notification to a specific user
- */
 export const sendSingleNotification = action({
   args: {
     userId: v.string(),
@@ -59,9 +56,6 @@ export const sendSingleNotification = action({
   },
 });
 
-/**
- * Send weekly notifications to all users
- */
 export const sendWeeklyNotifications = internalAction({
   args: {},
   returns: v.object({
@@ -84,7 +78,6 @@ export const sendWeeklyNotifications = internalAction({
     successfulNotifications: number;
     errors: { userId: string; error: string }[];
   }> => {
-    // Get all users
     const allUsers: {
       id: string;
       username: string;
@@ -92,7 +85,6 @@ export const sendWeeklyNotifications = internalAction({
       displayName: string;
     }[] = await ctx.runQuery(internal.notifications.getAllUsersQuery);
 
-    // Process notifications concurrently
     const results = await Promise.all(
       allUsers.map(
         async (user: {
@@ -147,9 +139,6 @@ export const sendWeeklyNotifications = internalAction({
   },
 });
 
-/**
- * Send trial expiration reminders to users who started their trial 5 days ago
- */
 export const sendTrialExpirationReminders = internalAction({
   args: {},
   returns: v.object({
@@ -171,7 +160,6 @@ export const sendTrialExpirationReminders = internalAction({
     successfulNotifications: number;
     errors: { error: string }[];
   }> => {
-    // Get users who started their trial 5 days ago
     const trialUsers: {
       id: string;
       username: string;
@@ -190,7 +178,6 @@ export const sendTrialExpirationReminders = internalAction({
       };
     }
 
-    // Extract user IDs
     const userIds: string[] = trialUsers.map(
       (user: {
         id: string;
@@ -200,7 +187,6 @@ export const sendTrialExpirationReminders = internalAction({
       }) => user.id,
     );
 
-    // Send batch notification using OneSignal
     const result = await OneSignal.sendBatchNotifications({
       userIds,
       title: "2 days left on your trial",
@@ -277,9 +263,6 @@ export const sendMarketingNotification = internalAction({
   },
 });
 
-/**
- * Internal action to process a single user's weekly notification
- */
 export const processUserWeeklyNotification = internalAction({
   args: { userId: v.string() },
   returns: v.object({
@@ -293,7 +276,6 @@ export const processUserWeeklyNotification = internalAction({
     const notificationId = generateNotificationId();
 
     try {
-      // Get notification content for the user
       const content: {
         title: string;
         message: string;
@@ -309,7 +291,6 @@ export const processUserWeeklyNotification = internalAction({
       let message = content.message;
       const title = content.title;
 
-      // If we have event descriptions, generate AI content
       if (content.eventDescriptions) {
         const prompt = Notifications.getPromptForWeeklyNotificationWithEvents(
           content.eventDescriptions,
@@ -330,7 +311,6 @@ export const processUserWeeklyNotification = internalAction({
         }
       }
 
-      // Send notification using OneSignal
       const result = await OneSignal.sendNotification({
         userId: args.userId,
         title,
@@ -361,9 +341,6 @@ export const processUserWeeklyNotification = internalAction({
   },
 });
 
-/**
- * Internal query to generate weekly notification content for a user
- */
 export const generateWeeklyNotificationContentQuery = internalQuery({
   args: { userId: v.string() },
   returns: v.object({
@@ -380,9 +357,6 @@ export const generateWeeklyNotificationContentQuery = internalQuery({
   },
 });
 
-/**
- * Internal query to get all users
- */
 export const getAllUsersQuery = internalQuery({
   args: {},
   returns: v.array(
@@ -398,9 +372,6 @@ export const getAllUsersQuery = internalQuery({
   },
 });
 
-/**
- * Internal query to get trial expiration users
- */
 export const getTrialExpirationUsersQuery = internalQuery({
   args: {},
   returns: v.array(
@@ -416,19 +387,12 @@ export const getTrialExpirationUsersQuery = internalQuery({
   },
 });
 
-// ============================================================================
-// INTERNAL ACTIONS FOR WORKFLOW
-// ============================================================================
 
-/**
- * Send push notification for event creation
- */
 export const push = internalAction({
   args: {
     eventId: v.string(),
     userId: v.string(),
     userName: v.string(),
-    // Optional: for batch processing, explicitly pass the position
     batchPosition: v.optional(v.number()),
     batchTotal: v.optional(v.number()),
   },
@@ -440,7 +404,6 @@ export const push = internalAction({
   handler: async (ctx, args) => {
     const { eventId, userId, batchPosition, batchTotal } = args;
 
-    // Get the event to extract the name for notification
     const event = await ctx.runQuery(internal.events.getEventById, {
       eventId,
     });
@@ -452,18 +415,13 @@ export const push = internalAction({
       };
     }
 
-    // Determine the event count/position
     let eventCount: number;
 
     if (batchPosition !== undefined && batchTotal !== undefined) {
-      // For batch processing, we need to get the count BEFORE this batch
-      // and add the position within the batch
       const todayEvents = await ctx.runQuery(
         internal.events.getTodayEventsCount,
         { userId },
       );
-      // Subtract the total batch size to get count before this batch
-      // Then add the current position
       const countBeforeBatch = Math.max(0, todayEvents.length - batchTotal);
       eventCount = countBeforeBatch + batchPosition;
       console.log(
@@ -471,7 +429,6 @@ export const push = internalAction({
           `today's total: ${todayEvents.length}, count for this event: ${eventCount}`,
       );
     } else {
-      // Get today's event count for this user (for non-batch captures)
       const todayEvents = await ctx.runQuery(
         internal.events.getTodayEventsCount,
         { userId },
@@ -480,7 +437,6 @@ export const push = internalAction({
       console.log(`Single event notification - today's count: ${eventCount}`);
     }
 
-    // Generate notification content based on count
     let title: string;
     let subtitle: string;
     let body: string;
@@ -503,10 +459,8 @@ export const push = internalAction({
       subtitle = event.name;
     }
 
-    // Create deep link
     const url = createDeepLink(`event/${eventId}`);
 
-    // Send notification
     const result = await OneSignal.sendNotification({
       userId,
       title,
@@ -526,9 +480,6 @@ export const push = internalAction({
   },
 });
 
-/**
- * Send failure notification for event creation
- */
 export const pushBatchSummary = internalAction({
   args: {
     userId: v.string(),
@@ -546,14 +497,12 @@ export const pushBatchSummary = internalAction({
   handler: async (ctx, args) => {
     const { userId, message, successCount, failureCount } = args;
 
-    // Get today's total event count
     const todayEvents = await ctx.runQuery(
       internal.events.getTodayEventsCount,
       { userId },
     );
     const totalCount = todayEvents.length;
 
-    // Create batch summary notification with daily count
     let title: string;
     let subtitle: string | undefined;
     let body: string;
@@ -562,7 +511,6 @@ export const pushBatchSummary = internalAction({
       title = "Events captured ✨";
       subtitle = `Successfully captured ${successCount} events`;
 
-      // Add daily count message
       if (totalCount === successCount && totalCount === 1) {
         body = "First capture today! 🤔 What's next?";
       } else if (totalCount === 2) {
@@ -579,7 +527,6 @@ export const pushBatchSummary = internalAction({
     }
     const deepLink = createDeepLink(`batch/${args.batchId}`);
 
-    // Send notification
     const result = await OneSignal.sendNotification({
       userId,
       title,
@@ -617,11 +564,9 @@ export const pushFailure = internalAction({
   handler: async (_ctx, args) => {
     const { userId, failureReason } = args;
 
-    // Create failure notification content
     const title = "Event creation failed";
     const body = "We couldn't create your event. Please try again.";
 
-    // Send notification
     const result = await OneSignal.sendNotification({
       userId,
       title,

--- a/packages/backend/convex/posthog.ts
+++ b/packages/backend/convex/posthog.ts
@@ -6,7 +6,7 @@ import { internalAction, internalQuery } from "./_generated/server";
 import * as PostHog from "./model/posthog";
 
 interface UserStats {
-  visitorId: string; // email - used as distinct_id in PostHog
+  visitorId: string;
   upcoming_created_events_count: number;
   upcoming_saved_events_count: number;
   upcoming_events_count: number;
@@ -25,9 +25,6 @@ const userStatsValidator = v.object({
   days_since_last_event_created: v.union(v.number(), v.null()),
 });
 
-/**
- * Debug query to check stats for a specific user by username
- */
 export const debugUserStats = internalQuery({
   args: { username: v.string() },
   returns: v.union(userStatsValidator, v.null()),
@@ -122,9 +119,6 @@ export const debugUserStats = internalQuery({
   },
 });
 
-/**
- * Fetch all users with computed stats for PostHog sync
- */
 export const getAllUsersWithStatsQuery = internalQuery({
   args: {},
   returns: v.array(userStatsValidator),
@@ -216,9 +210,6 @@ export const getAllUsersWithStatsQuery = internalQuery({
   },
 });
 
-/**
- * Sync user properties to PostHog (called by daily cron)
- */
 export const syncUserPropertiesToPostHog = internalAction({
   args: {},
   returns: v.object({

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -1,7 +1,6 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-// Define reusable validators
 export const priorityValidator = v.object({
   text: v.string(),
   emoji: v.string(),
@@ -26,7 +25,6 @@ export const onboardingDataValidator = v.object({
   priority: v.optional(priorityValidator), // Keep for backward compatibility
   watchedDemo: v.optional(v.boolean()), // Whether user watched the demo
   completedAt: v.optional(v.string()), // ISO date string
-  // Subscription fields
   subscribed: v.optional(v.boolean()),
   subscribedAt: v.optional(v.string()), // ISO date string
   subscriptionPlan: v.optional(v.string()),
@@ -67,7 +65,6 @@ export default defineSchema({
     visibility: v.union(v.literal("public"), v.literal("private")),
     created_at: v.string(), // ISO date string
     updatedAt: v.union(v.string(), v.null()), // ISO date string or null
-    // Fields extracted from nested event object
     name: v.optional(v.string()),
     image: v.optional(v.union(v.string(), v.null())), // First image from images array or null
     endDate: v.optional(v.string()),
@@ -77,10 +74,7 @@ export default defineSchema({
     startDate: v.optional(v.string()),
     startTime: v.optional(v.string()),
     description: v.optional(v.string()),
-    // Batch tracking
     batchId: v.optional(v.string()),
-    // Similarity group ID (set on creation; optional during migration)
-    // Format: "sg_" + generatePublicId()
     similarityGroupId: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
@@ -146,12 +140,6 @@ export default defineSchema({
     slug: v.optional(v.string()),
     created_at: v.string(), // ISO date string
     updatedAt: v.union(v.string(), v.null()), // ISO date string or null
-    // Set once the list's `list_${id}` userFeeds entries are known to mirror
-    // `eventToLists` — populated immediately on list creation (new lists
-    // never need the backfill fallback) and retroactively by
-    // `migrations/backfillListFeeds`. Absence signals getEventsForList to
-    // use the junction-scan fallback during the backfill window. Field is
-    // optional so pre-existing docs validate until the migration runs.
     feedBackfilledAt: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
@@ -191,10 +179,8 @@ export default defineSchema({
     publicWebsite: v.union(v.string(), v.null()),
     publicMetadata: v.union(v.any(), v.null()), // JSON field
     emoji: v.union(v.string(), v.null()),
-    // Onboarding fields - now properly typed
     onboardingData: v.union(onboardingDataValidator, v.null()),
     onboardingCompletedAt: v.union(v.string(), v.null()), // ISO date string or null
-    // Public list sharing
     publicListEnabled: v.optional(v.boolean()),
     publicListName: v.optional(v.string()),
     hasSharedListBefore: v.optional(v.boolean()),
@@ -229,23 +215,20 @@ export default defineSchema({
     addedAt: v.number(), // When added to feed (timestamp)
     hasEnded: v.boolean(), // Pre-computed field: true if event has ended, false if ongoing/upcoming (now required)
     beforeThisDateTime: v.optional(v.string()), // Optional ISO date string for custom filtering
-    // Group membership for grouped feed derivation (optional during migration)
     similarityGroupId: v.optional(v.string()),
-    // Event visibility for filtering public feeds (optional during migration)
     eventVisibility: v.optional(
       v.union(v.literal("public"), v.literal("private")),
     ),
-    // Source list tracking — which list surfaced this event into this feed
     sourceListId: v.optional(v.string()),
   })
     .index("by_feed_hasEnded_startTime", [
       "feedId",
       "hasEnded",
       "eventStartTime",
-    ]) // For efficient filtering and sorting
-    .index("by_feed_event", ["feedId", "eventId"]) // For deduplication checks
-    .index("by_event", ["eventId"]) // For event removal across all feeds
-    .index("by_feed_group", ["feedId", "similarityGroupId"]) // Lookup membership for a given feed+group
+    ])
+    .index("by_feed_event", ["feedId", "eventId"])
+    .index("by_event", ["eventId"])
+    .index("by_feed_group", ["feedId", "similarityGroupId"])
     .index("by_feed_visibility_hasEnded_startTime", [
       "feedId",
       "eventVisibility",
@@ -253,18 +236,14 @@ export default defineSchema({
       "eventStartTime",
     ]), // For filtering by visibility before pagination
 
-  // Grouped feed table - one entry per similarity group per feed (used for pagination and server-side grouping)
   userFeedGroups: defineTable({
     feedId: v.string(),
     similarityGroupId: v.string(),
-    // Which specific event to display (event custom id string)
     primaryEventId: v.string(),
-    // Same ordering/filtering shape as legacy feed entries
     eventStartTime: v.number(),
     eventEndTime: v.number(),
     addedAt: v.number(),
     hasEnded: v.boolean(),
-    // Server-computed, feed-scoped count (memberCount - 1)
     similarEventsCount: v.number(),
   })
     .index("by_feed_hasEnded_startTime", [
@@ -317,6 +296,6 @@ export default defineSchema({
     createdAt: v.string(), // ISO date string
     revokedAt: v.union(v.string(), v.null()), // ISO date string or null
   })
-    .index("by_token", ["token"]) // For quick token lookup
+    .index("by_token", ["token"])
     .index("by_user", ["userId"]),
 });

--- a/packages/backend/convex/shareTokens.ts
+++ b/packages/backend/convex/shareTokens.ts
@@ -5,7 +5,6 @@ import { internalMutation, internalQuery, mutation } from "./_generated/server";
 function generateShareToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
-  // Convert to lowercase hex string
   return Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
@@ -17,7 +16,6 @@ export const createShareToken = mutation({
   },
   returns: v.object({ token: v.string() }),
   handler: async (ctx, { userId }) => {
-    // Authentication check
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       throw new ConvexError({
@@ -26,7 +24,6 @@ export const createShareToken = mutation({
       });
     }
 
-    // Authorization check - ensure the authenticated user matches the requested userId
     if (identity.subject !== userId) {
       throw new ConvexError({
         message: "You can only create share tokens for yourself",
@@ -57,7 +54,6 @@ export const createShareToken = mutation({
 
     const username = user.username;
 
-    // Generate a unique token, checking for collisions
     let token: string;
     let attempts = 0;
     const maxAttempts = 10;

--- a/packages/backend/convex/users.ts
+++ b/packages/backend/convex/users.ts
@@ -13,10 +13,6 @@ import { onboardingDataValidator, userAdditionalInfoValidator } from "./schema";
 
 const MAX_USERNAME_LENGTH = 64;
 
-/**
- * Generate a unique username based on user's name or email
- * Uses slug-like generation: tries simplest form first, then adds numbers
- */
 async function generateUniqueUsername(
   db: DatabaseReader,
   firstName?: string | null,
@@ -30,15 +26,14 @@ async function generateUniqueUsername(
     timestamp: new Date().toISOString(),
   });
 
-  // Clean and format names for username (slug-like)
   const slugify = (text: string | null | undefined) => {
     if (!text) return "";
     const result = text
       .toLowerCase()
       .trim()
-      .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
-      .replace(/^-+|-+$/g, "") // Remove leading/trailing hyphens
-      .replace(/-+/g, "-"); // Replace multiple hyphens with single
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .replace(/-+/g, "-");
 
     console.log("[USERNAME_GEN] Slugified", { input: text, output: result });
     return result;
@@ -54,36 +49,29 @@ async function generateUniqueUsername(
     emailPrefix,
   });
 
-  // Create a list of username candidates in order of preference
   const candidates: string[] = [];
 
-  // 1. Try just firstname (most common for social platforms)
   if (cleanFirst) {
     candidates.push(cleanFirst);
   }
 
-  // 2. Try firstname + lastname variations
-  // Only use characters allowed by username validation: letters, numbers, hyphens, underscores
   if (cleanFirst && cleanLast) {
-    candidates.push(`${cleanFirst}${cleanLast}`); // johnsmith
-    candidates.push(`${cleanFirst}-${cleanLast}`); // john-smith
-    candidates.push(`${cleanFirst}_${cleanLast}`); // john_smith
+    candidates.push(`${cleanFirst}${cleanLast}`);
+    candidates.push(`${cleanFirst}-${cleanLast}`);
+    candidates.push(`${cleanFirst}_${cleanLast}`);
   }
 
-  // 3. Try just lastname
   if (cleanLast) {
     candidates.push(cleanLast);
   }
 
-  // 4. Try email prefix
   if (emailPrefix && emailPrefix !== cleanFirst && emailPrefix !== cleanLast) {
     candidates.push(emailPrefix);
   }
 
-  // 5. Try combinations with first initial
   if (cleanFirst && cleanLast) {
-    candidates.push(`${cleanFirst[0]}${cleanLast}`); // jsmith
-    candidates.push(`${cleanFirst[0]}-${cleanLast}`); // j-smith
+    candidates.push(`${cleanFirst[0]}${cleanLast}`);
+    candidates.push(`${cleanFirst[0]}-${cleanLast}`);
   }
 
   console.log("[USERNAME_GEN] Generated candidates", {
@@ -91,13 +79,12 @@ async function generateUniqueUsername(
     candidateCount: candidates.length,
   });
 
-  // Filter candidates by length and ensure minimum length (4 characters minimum)
   const validCandidates = candidates
     .filter(
       (username) =>
         username.length >= 4 && username.length <= MAX_USERNAME_LENGTH,
     )
-    .slice(0, 10); // Limit to first 10 candidates
+    .slice(0, 10);
 
   console.log("[USERNAME_GEN] Valid candidates after filtering", {
     validCandidates,
@@ -105,7 +92,6 @@ async function generateUniqueUsername(
     filteredOut: candidates.length - validCandidates.length,
   });
 
-  // Batch check all candidates at once
   if (validCandidates.length > 0) {
     console.log("[USERNAME_GEN] Checking candidate availability...");
     const existingUsers = await Promise.all(
@@ -128,7 +114,6 @@ async function generateUniqueUsername(
       ),
     });
 
-    // Return first available candidate
     for (const candidate of validCandidates) {
       if (!takenUsernames.has(candidate)) {
         console.log("[USERNAME_GEN] SUCCESS: Found available username", {
@@ -140,11 +125,8 @@ async function generateUniqueUsername(
     }
   }
 
-  // If all candidates are taken, add numbers to the best candidate
-  // Ensure the base username is at least 4 characters long
   let baseUsername = validCandidates[0] || "user";
 
-  // If the base username is too short, pad it to meet the 4-character minimum
   if (baseUsername.length < 4) {
     console.log(
       "[USERNAME_GEN] Base username too short, padding to meet 4-character minimum",
@@ -153,7 +135,6 @@ async function generateUniqueUsername(
         length: baseUsername.length,
       },
     );
-    // Pad with 'x' characters to reach minimum length
     baseUsername = baseUsername.padEnd(4, "x");
     console.log("[USERNAME_GEN] Padded base username", {
       paddedBase: baseUsername,
@@ -169,8 +150,7 @@ async function generateUniqueUsername(
     },
   );
 
-  // Ensure base username with numbers fits within limit
-  const maxNumberLength = MAX_USERNAME_LENGTH - baseUsername.length - 1; // -1 for the number
+  const maxNumberLength = MAX_USERNAME_LENGTH - baseUsername.length - 1;
   if (maxNumberLength > 0) {
     const maxNumber = Math.pow(10, maxNumberLength) - 1;
 
@@ -180,7 +160,6 @@ async function generateUniqueUsername(
       baseUsernameLength: baseUsername.length,
     });
 
-    // Batch check numbered usernames (1-99)
     const numberedCandidates: string[] = [];
     for (let i = 1; i < 100 && i <= maxNumber; i++) {
       numberedCandidates.push(`${baseUsername}${i}`);
@@ -235,7 +214,6 @@ async function generateUniqueUsername(
     }
   }
 
-  // Ultimate fallback: use timestamp (ensure it fits)
   const timestamp = Date.now().toString();
   const fallbackUsername = `${baseUsername}${timestamp}`;
 
@@ -256,13 +234,9 @@ async function generateUniqueUsername(
     return fallbackUsername;
   }
 
-  // If even timestamp is too long, truncate the base and add timestamp
-  // Ensure we have at least 1 character from the base to maintain some personalization
-  // while still ensuring the final username is at least 4 characters long
   const minBaseChars = Math.max(1, 4 - timestamp.length);
   const maxBaseChars = MAX_USERNAME_LENGTH - timestamp.length;
 
-  // Use the maximum possible characters from base while respecting constraints
   const truncatedBase = baseUsername.substring(
     0,
     Math.max(minBaseChars, maxBaseChars),
@@ -280,9 +254,6 @@ async function generateUniqueUsername(
   return finalUsername;
 }
 
-/**
- * Generate a unique username - requires guest authentication
- */
 export const generateUsername = query({
   args: {
     guestUserId: v.string(),
@@ -309,7 +280,6 @@ export const generateUsername = query({
       timestamp: new Date().toISOString(),
     });
 
-    // Validate guest user ID format
     if (!args.guestUserId?.startsWith("guest_")) {
       console.error("[USERNAME_GEN] ERROR: Invalid guest user ID", {
         guestUserId: args.guestUserId,
@@ -324,7 +294,6 @@ export const generateUsername = query({
       let result: string;
 
       if (isLastAttempt) {
-        // On the last attempt, use timestamp-based generation for maximum uniqueness
         console.log(
           "[USERNAME_GEN] Using timestamp-based generation (final attempt)",
           {
@@ -343,7 +312,6 @@ export const generateUsername = query({
 
         result = `${baseUsername}${timestamp}`;
 
-        // Ensure it fits within length limits
         if (result.length > MAX_USERNAME_LENGTH) {
           const truncatedBase = baseUsername.substring(
             0,
@@ -359,7 +327,6 @@ export const generateUsername = query({
           strategy: "timestamp_final_attempt",
         });
       } else {
-        // Use normal username generation for non-final attempts
         console.log("[USERNAME_GEN] Using normal username generation", {
           retryAttempt,
           maxRetries,
@@ -395,9 +362,6 @@ export const generateUsername = query({
   },
 });
 
-/**
- * Get a user by their ID
- */
 export const getById = query({
   args: { id: v.string() },
   handler: async (ctx, args) => {
@@ -409,9 +373,6 @@ export const getById = query({
   },
 });
 
-/**
- * Get a user by their username
- */
 export const getByUsername = query({
   args: { userName: v.string() },
   handler: async (ctx, args) => {
@@ -423,9 +384,6 @@ export const getByUsername = query({
   },
 });
 
-/**
- * Get the current authenticated user
- */
 export const getCurrentUser = query({
   args: {},
   handler: async (ctx) => {
@@ -442,9 +400,6 @@ export const getCurrentUser = query({
   },
 });
 
-/**
- * Update user additional info (bio, public contact info)
- */
 export const updateAdditionalInfo = mutation({
   args: {
     userId: v.string(),
@@ -460,7 +415,6 @@ export const updateAdditionalInfo = mutation({
       });
     }
 
-    // Verify that the authenticated user's ID matches the userId being updated
     if (identity.subject !== args.userId) {
       throw new ConvexError({
         message: "Unauthorized: You can only update your own profile",
@@ -498,9 +452,6 @@ export const updateAdditionalInfo = mutation({
   },
 });
 
-/**
- * Save onboarding data for a user
- */
 export const saveOnboardingData = mutation({
   args: {
     userId: v.string(),
@@ -516,7 +467,6 @@ export const saveOnboardingData = mutation({
       });
     }
 
-    // Verify that the authenticated user's ID matches the userId being updated
     if (identity.subject !== args.userId) {
       throw new ConvexError({
         message: "Unauthorized: You can only update your own onboarding data",
@@ -536,10 +486,8 @@ export const saveOnboardingData = mutation({
       throw new ConvexError("User not found");
     }
 
-    // Get existing onboarding data - now properly typed
     const existingData = user.onboardingData || {};
 
-    // Merge existing data with new data
     const { userId: _, ...newData } = args;
     const mergedData = {
       ...existingData,
@@ -555,9 +503,6 @@ export const saveOnboardingData = mutation({
   },
 });
 
-/**
- * Get onboarding data for a user
- */
 export const getOnboardingData = query({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
@@ -574,9 +519,6 @@ export const getOnboardingData = query({
   },
 });
 
-/**
- * Delete a user account and all related data
- */
 export const deleteAccount = mutation({
   args: { userId: v.string() },
   returns: v.null(),
@@ -587,7 +529,6 @@ export const deleteAccount = mutation({
       throw new ConvexError("User not authenticated");
     }
 
-    // Verify that the authenticated user's ID matches the userId being deleted
     if (identity.subject !== args.userId) {
       throw new ConvexError("User not authorized to delete this account");
     }
@@ -601,7 +542,6 @@ export const deleteAccount = mutation({
       throw new ConvexError("User not found");
     }
 
-    // Delete user from Clerk first
     const clerkSecretKey = process.env.CLERK_SECRET_KEY;
     if (!clerkSecretKey) {
       throw new ConvexError("Clerk secret key not configured");
@@ -626,17 +566,14 @@ export const deleteAccount = mutation({
         );
       }
     } catch (error) {
-      // If it's already a ConvexError, re-throw it
       if (error instanceof ConvexError) {
         throw error;
       }
-      // For other errors (network, etc.), wrap in ConvexError
       throw new ConvexError(
         `Failed to delete user from Clerk: ${String(error)}`,
       );
     }
 
-    // Use the new centralized cascade delete mutation
     await ctx.runMutation(internal.users.deleteUserAndCascade, {
       userId: args.userId,
     });
@@ -645,9 +582,6 @@ export const deleteAccount = mutation({
   },
 });
 
-/**
- * Reset onboarding for a user
- */
 export const resetOnboarding = mutation({
   args: { userId: v.string() },
   returns: v.null(),
@@ -660,7 +594,6 @@ export const resetOnboarding = mutation({
       });
     }
 
-    // Verify that the authenticated user's ID matches the userId being updated
     if (identity.subject !== args.userId) {
       throw new ConvexError({
         message: "Unauthorized: You can only reset your own onboarding",
@@ -690,9 +623,6 @@ export const resetOnboarding = mutation({
   },
 });
 
-/**
- * Set onboarding completed timestamp
- */
 export const setOnboardingCompletedAt = mutation({
   args: {
     userId: v.string(),
@@ -708,7 +638,6 @@ export const setOnboardingCompletedAt = mutation({
       });
     }
 
-    // Verify that the authenticated user's ID matches the userId being updated
     if (identity.subject !== args.userId) {
       throw new ConvexError({
         message: "Unauthorized: You can only update your own onboarding status",
@@ -728,7 +657,6 @@ export const setOnboardingCompletedAt = mutation({
       throw new ConvexError("User not found");
     }
 
-    // Update onboarding data to include completedAt - now properly typed
     const existingData = user.onboardingData || {};
     const updatedData = {
       ...existingData,
@@ -745,9 +673,6 @@ export const setOnboardingCompletedAt = mutation({
   },
 });
 
-/**
- * Internal mutation to sync user data from Clerk webhook
- */
 export const syncFromClerk = internalMutation({
   args: {
     id: v.string(),
@@ -781,7 +706,6 @@ export const syncFromClerk = internalMutation({
       .withIndex("by_custom_id", (q) => q.eq("id", args.id))
       .unique();
 
-    // Username must be set during signup - fail if missing
     const username = args.username;
     if (!username || username.trim() === "") {
       throw new ConvexError({
@@ -821,15 +745,11 @@ export const syncFromClerk = internalMutation({
         onboardingCompletedAt: null,
       });
 
-      // Create personal list for new user
       await getOrCreatePersonalList(ctx, args.id);
     }
   },
 });
 
-/**
- * Internal mutation to delete user from Clerk webhook
- */
 export const deleteUser = internalMutation({
   args: { id: v.string() },
   handler: async (ctx, args) => {
@@ -842,16 +762,12 @@ export const deleteUser = internalMutation({
       console.warn(`User ${args.id} not found for deletion`);
       return;
     }
-    // Use the new centralized cascade delete mutation
     await ctx.runMutation(internal.users.deleteUserAndCascade, {
       userId: args.id,
     });
   },
 });
 
-/**
- * Update user's public list settings
- */
 export const updatePublicListSettings = mutation({
   args: {
     userId: v.string(),
@@ -867,7 +783,6 @@ export const updatePublicListSettings = mutation({
       );
     }
 
-    // Verify that the authenticated user's ID matches the userId being updated
     if (identity.subject !== args.userId) {
       throw new ConvexError(
         "Unauthorized: You can only update your own public list settings",
@@ -897,7 +812,6 @@ export const updatePublicListSettings = mutation({
 
     await ctx.db.patch(user._id, updates);
 
-    // If publicListEnabled changed, bulk update all user's event visibility
     if (
       args.publicListEnabled !== undefined &&
       args.publicListEnabled !== user.publicListEnabled
@@ -917,12 +831,6 @@ export const updatePublicListSettings = mutation({
   },
 });
 
-/**
- * One-shot mutation for the first-share setup sheet.
- * Atomically commits list name, profile edits, and the hasSharedListBefore flag.
- * Also flips publicListEnabled to true (if it was false) and schedules the
- * bulk event visibility update that updatePublicListSettings would have done.
- */
 export const completeFirstShareSetup = mutation({
   args: {
     userId: v.string(),
@@ -991,9 +899,6 @@ export const completeFirstShareSetup = mutation({
   },
 });
 
-/**
- * Get user's public list if enabled
- */
 export const getPublicList = query({
   args: { username: v.string() },
   handler: async (ctx, args) => {
@@ -1019,10 +924,6 @@ export const getPublicList = query({
   },
 });
 
-/**
- * INTERNAL: Centralized cascade deletion logic for a user.
- * This function should be called by other mutations that need to delete a user.
- */
 export const deleteUserAndCascade = internalMutation({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
@@ -1036,14 +937,12 @@ export const deleteUserAndCascade = internalMutation({
       return;
     }
 
-    // Delete events created by user and their cascade dependencies
     const events = await ctx.db
       .query("events")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .collect();
 
     for (const event of events) {
-      // Delete comments on this event (by all users)
       const eventComments = await ctx.db
         .query("comments")
         .withIndex("by_event", (q) => q.eq("eventId", event.id))
@@ -1052,7 +951,6 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(comment._id);
       }
 
-      // Delete follows of this event (by all users)
       const eventFollowsOfEvent = await ctx.db
         .query("eventFollows")
         .withIndex("by_event", (q) => q.eq("eventId", event.id))
@@ -1061,7 +959,6 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(follow._id);
       }
 
-      // Delete eventToLists associations for this event
       const eventToListsOfEvent = await ctx.db
         .query("eventToLists")
         .withIndex("by_event", (q) => q.eq("eventId", event.id))
@@ -1070,12 +967,6 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(etl._id);
       }
 
-      // Remove the event from every userFeeds entry it lives in — including
-      // list_${listId} entries in OTHER users' lists, followedLists_* and
-      // followedUsers_* entries in their followers' feeds, and the discover
-      // feed. Without this, those rows hydrate as null in future queries
-      // (sparse pagination and dead data growth). Scheduled so the
-      // user-deletion mutation stays within transaction limits.
       await ctx.scheduler.runAfter(
         0,
         internal.feedHelpers.removeEventFromFeeds,
@@ -1086,11 +977,9 @@ export const deleteUserAndCascade = internalMutation({
         },
       );
 
-      // Delete the event itself
       await ctx.db.delete(event._id);
     }
 
-    // Delete comments by user (on other users' events)
     const comments = await ctx.db
       .query("comments")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1099,14 +988,12 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(comment._id);
     }
 
-    // Delete lists created by user and their cascade dependencies
     const lists = await ctx.db
       .query("lists")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
       .collect();
 
     for (const list of lists) {
-      // Delete follows of this list (by all users)
       const listFollowsOfList = await ctx.db
         .query("listFollows")
         .withIndex("by_list", (q) => q.eq("listId", list.id))
@@ -1115,7 +1002,6 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(follow._id);
       }
 
-      // Delete eventToLists associations for this list
       const eventToListsOfList = await ctx.db
         .query("eventToLists")
         .withIndex("by_list", (q) => q.eq("listId", list.id))
@@ -1124,20 +1010,15 @@ export const deleteUserAndCascade = internalMutation({
         await ctx.db.delete(etl._id);
       }
 
-      // Schedule cleanup of the list's own feed (list_${listId}) entries.
-      // Deferring to an action keeps this user-deletion mutation within
-      // transaction limits for users who own many lists with large feeds.
       await ctx.scheduler.runAfter(
         0,
         internal.feedHelpers.removeListFeedAction,
         { listId: list.id },
       );
 
-      // Delete the list itself
       await ctx.db.delete(list._id);
     }
 
-    // Delete event follows by user (follows of other users' events)
     const eventFollows = await ctx.db
       .query("eventFollows")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1146,7 +1027,6 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(follow._id);
     }
 
-    // Delete list follows by user (follows of other users' lists)
     const listFollows = await ctx.db
       .query("listFollows")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1155,7 +1035,6 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(follow._id);
     }
 
-    // Delete push tokens
     const pushTokens = await ctx.db
       .query("pushTokens")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1164,7 +1043,6 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(token._id);
     }
 
-    // Delete event batches
     const eventBatches = await ctx.db
       .query("eventBatches")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
@@ -1173,7 +1051,6 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(batch._id);
     }
 
-    // Delete user feeds
     const userFeeds = await ctx.db
       .query("userFeeds")
       .filter((q) => q.eq(q.field("feedId"), `user_${args.userId}`))
@@ -1182,7 +1059,6 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(feed._id);
     }
 
-    // Delete user follows (both as follower and following)
     const followsAsFollower = await ctx.db
       .query("userFollows")
       .withIndex("by_follower", (q) => q.eq("followerId", args.userId))
@@ -1195,14 +1071,10 @@ export const deleteUserAndCascade = internalMutation({
       await ctx.db.delete(follow._id);
     }
 
-    // Finally, delete the user record
     await ctx.db.delete(user._id);
   },
 });
 
-/**
- * Follow a user - their public events will appear in the follower's feed
- */
 export const followUser = mutation({
   args: {
     followingId: v.string(),
@@ -1216,12 +1088,10 @@ export const followUser = mutation({
 
     const followerId = identity.subject;
 
-    // Can't follow yourself
     if (followerId === followingId) {
       throw new ConvexError("Cannot follow yourself");
     }
 
-    // Check if target user exists
     const targetUser = await ctx.db
       .query("users")
       .withIndex("by_custom_id", (q) => q.eq("id", followingId))
@@ -1231,7 +1101,6 @@ export const followUser = mutation({
       throw new ConvexError("User not found");
     }
 
-    // Check if already following
     const existingFollow = await ctx.db
       .query("userFollows")
       .withIndex("by_follower_and_following", (q) =>
@@ -1243,13 +1112,11 @@ export const followUser = mutation({
       return { success: true, alreadyFollowing: true };
     }
 
-    // Create the follow relationship
     await ctx.db.insert("userFollows", {
       followerId,
       followingId,
     });
 
-    // Add the followed user's events to the follower's feed
     await ctx.runMutation(internal.feedHelpers.addUserEventsToUserFeed, {
       userId: followerId,
       followedUserId: followingId,
@@ -1259,9 +1126,6 @@ export const followUser = mutation({
   },
 });
 
-/**
- * Unfollow a user - their events will be removed from the follower's feed
- */
 export const unfollowUser = mutation({
   args: {
     followingId: v.string(),
@@ -1275,7 +1139,6 @@ export const unfollowUser = mutation({
 
     const followerId = identity.subject;
 
-    // Find the existing follow relationship
     const existingFollow = await ctx.db
       .query("userFollows")
       .withIndex("by_follower_and_following", (q) =>
@@ -1287,10 +1150,8 @@ export const unfollowUser = mutation({
       return { success: true, wasFollowing: false };
     }
 
-    // Delete the follow relationship
     await ctx.db.delete(existingFollow._id);
 
-    // Remove the unfollowed user's events from the follower's feed
     await ctx.runMutation(internal.feedHelpers.removeUserEventsFromUserFeed, {
       userId: followerId,
       unfollowedUserId: followingId,
@@ -1300,9 +1161,6 @@ export const unfollowUser = mutation({
   },
 });
 
-/**
- * Check if the current user follows a specific user
- */
 export const isFollowingUser = query({
   args: {
     followingId: v.string(),
@@ -1327,9 +1185,6 @@ export const isFollowingUser = query({
   },
 });
 
-/**
- * Get users that the current user is following
- */
 export const getFollowingUsers = query({
   args: {},
   handler: async (ctx) => {
@@ -1361,9 +1216,6 @@ export const getFollowingUsers = query({
   },
 });
 
-/**
- * Get the count of followers for a user
- */
 export const getFollowerCount = query({
   args: {
     userId: v.string(),
@@ -1378,14 +1230,6 @@ export const getFollowerCount = query({
   },
 });
 
-/**
- * INTERNAL: Bulk update visibility of all events for a user and their feed entries
- * Called when publicListEnabled is toggled
- */
-/**
- * Batch mutation: update visibility for one page of events.
- * Feed updates are scheduled asynchronously to keep each transaction lightweight.
- */
 export const bulkUpdateEventVisibilityBatch = internalMutation({
   args: {
     userId: v.string(),
@@ -1415,7 +1259,6 @@ export const bulkUpdateEventVisibilityBatch = internalMutation({
         updatedAt: new Date().toISOString(),
       });
 
-      // Schedule feed visibility update in a separate transaction
       await ctx.scheduler.runAfter(
         0,
         internal.feedHelpers.updateEventVisibilityInFeeds,
@@ -1423,14 +1266,12 @@ export const bulkUpdateEventVisibilityBatch = internalMutation({
       );
 
       if (visibility === "private") {
-        // Schedule removal from discover/follower feeds
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.removeEventFromFeeds,
           { eventId: event.id, keepCreatorFeed: true },
         );
       } else {
-        // Schedule adding to appropriate feeds
         await ctx.scheduler.runAfter(
           0,
           internal.feedHelpers.updateEventInFeeds,
@@ -1457,9 +1298,6 @@ export const bulkUpdateEventVisibilityBatch = internalMutation({
   },
 });
 
-/**
- * Action: orchestrate paginated bulk visibility update.
- */
 export const bulkUpdateEventVisibilityAction = internalAction({
   args: {
     userId: v.string(),

--- a/packages/backend/convex/utils.ts
+++ b/packages/backend/convex/utils.ts
@@ -10,22 +10,16 @@ export function generatePublicId() {
 }
 
 export function generateNumericId(): number {
-  // Use a base timestamp relative to a more recent epoch to reduce digits
-  // Using Jan 1, 2024 as base: 1704067200000
   const baseEpoch = 1704067200000;
   const relativeTimestamp = Date.now() - baseEpoch;
 
-  // Add cryptographically secure random digits for additional entropy
   const randomArray = new Uint32Array(1);
   crypto.getRandomValues(randomArray);
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion, @typescript-eslint/no-non-null-assertion
-  const randomPart = randomArray[0]! % 1000; // Get last 3 digits (0-999)
+  const randomPart = randomArray[0]! % 1000;
 
-  // Combine relative timestamp with random part
-  // This creates a smaller number that stays within safe integer range
   const result = relativeTimestamp * 1000 + randomPart;
 
-  // Ensure we don't exceed MAX_SAFE_INTEGER
   if (result > Number.MAX_SAFE_INTEGER) {
     throw new Error("Generated ID would exceed safe integer range");
   }
@@ -50,9 +44,6 @@ export function deploymentName() {
   return regex.exec(url)?.[1];
 }
 
-/**
- * Safely converts an unknown value to a string for error logging
- */
 export function safeStringify(value: unknown): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
@@ -60,16 +51,13 @@ export function safeStringify(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
-    // If JSON.stringify fails, try to get a meaningful string representation
     if (typeof value === "object") {
-      // For objects, try to get constructor name or use toString
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const objectConstructor = (value as Record<string, unknown>)
         .constructor as { name?: string } | undefined;
       if (objectConstructor?.name && objectConstructor.name !== "Object") {
         return `[${objectConstructor.name} object]`;
       }
-      // Use toString() which might be more informative than [object Object]
       try {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const stringValue = (value as { toString?: () => string }).toString?.();
@@ -80,7 +68,6 @@ export function safeStringify(value: unknown): string {
         return "[object Object]";
       }
     }
-    // For primitives that failed JSON.stringify, just return their type
     return `[${typeof value}]`;
   }
 }

--- a/packages/backend/convex/workflows/eventIngestion.ts
+++ b/packages/backend/convex/workflows/eventIngestion.ts
@@ -6,7 +6,6 @@ import { query } from "../_generated/server";
 
 const workflow = new WorkflowManager(components.workflow);
 
-// Validators for complex types
 const listValidator = v.object({
   value: v.string(),
 });
@@ -28,7 +27,6 @@ export const eventFromImageBase64Workflow = workflow.define({
       base64Image: undefined,
       sendNotification: undefined,
     };
-    // ── step 1 (parallel)
     const [aiResult, uploadedImageUrl] = await Promise.all([
       step.runAction(
         internal.ai.extractEventFromBase64Image,
@@ -47,14 +45,12 @@ export const eventFromImageBase64Workflow = workflow.define({
       ),
     ]);
 
-    // ── step 2 validate
     const firstEvent = await step.runAction(
       internal.ai.validateFirstEvent,
       { events: aiResult.events },
       { name: "validateEvent" },
     );
 
-    // ── step 3 write DB
     const eventId = await step.runMutation(
       internal.events.insertEvent,
       {
@@ -65,7 +61,6 @@ export const eventFromImageBase64Workflow = workflow.define({
       { name: "insertEvent" },
     );
 
-    // ── step 4 push notification
     if (args.sendNotification ?? true) {
       await step.runAction(
         internal.notifications.push,
@@ -97,7 +92,6 @@ export const eventFromUrlWorkflow = workflow.define({
       sendNotification: undefined,
     };
 
-    // ── step 1: Extract content from URL and process with AI
     const aiResult = await step.runAction(
       internal.ai.extractEventFromUrl,
       {
@@ -107,14 +101,12 @@ export const eventFromUrlWorkflow = workflow.define({
       { name: "extractEventFromUrl" },
     );
 
-    // ── step 2: Validate first event
     const firstEvent = await step.runAction(
       internal.ai.validateFirstEvent,
       { events: aiResult.events },
       { name: "validateEvent" },
     );
 
-    // ── step 3: Write to database
     const eventId = await step.runMutation(
       internal.events.insertEvent,
       {
@@ -125,7 +117,6 @@ export const eventFromUrlWorkflow = workflow.define({
       { name: "insertEvent" },
     );
 
-    // ── step 4: Send push notification
     if (args.sendNotification ?? true) {
       await step.runAction(
         internal.notifications.push,
@@ -157,7 +148,6 @@ export const eventFromTextWorkflow = workflow.define({
       sendNotification: undefined,
     };
 
-    // ── step 1: Extract content from raw text and process with AI
     const aiResult = await step.runAction(
       internal.ai.extractEventFromText,
       {
@@ -167,14 +157,12 @@ export const eventFromTextWorkflow = workflow.define({
       { name: "extractEventFromText" },
     );
 
-    // ── step 2: Validate first event
     const firstEvent = await step.runAction(
       internal.ai.validateFirstEvent,
       { events: aiResult.events },
       { name: "validateEvent" },
     );
 
-    // ── step 3: Write to database
     const eventId = await step.runMutation(
       internal.events.insertEvent,
       {
@@ -185,7 +173,6 @@ export const eventFromTextWorkflow = workflow.define({
       { name: "insertEvent" },
     );
 
-    // ── step 4: Send push notification
     if (args.sendNotification ?? true) {
       await step.runAction(
         internal.notifications.push,
@@ -199,9 +186,6 @@ export const eventFromTextWorkflow = workflow.define({
   returns: v.string(),
 });
 
-/**
- * Get workflow status for client-side tracking
- */
 export const getWorkflowStatus = query({
   args: { workflowId: v.string() },
   returns: v.object({
@@ -227,12 +211,10 @@ export const getWorkflowStatus = query({
         },
       );
 
-      // Determine the current step and progress
       let currentStep: string | undefined;
       let progress: number | undefined;
 
       if (status.workflow.runResult) {
-        // Workflow is complete
         const runResult = status.workflow.runResult;
         if (runResult.kind === "success") {
           return {
@@ -252,7 +234,6 @@ export const getWorkflowStatus = query({
             startedAt: status.workflow._creationTime,
           };
         } else {
-          // cancelled case
           return {
             workflowId: args.workflowId,
             status: "canceled" as const,
@@ -261,9 +242,8 @@ export const getWorkflowStatus = query({
         }
       }
 
-      // Workflow is in progress
       const inProgressSteps = status.inProgress;
-      const totalSteps = 4; // Based on our workflow: extract+upload (parallel), validate, insert, notify
+      const totalSteps = 4;
 
       if (inProgressSteps.length > 0) {
         const latestStep = inProgressSteps[inProgressSteps.length - 1] || {
@@ -272,9 +252,8 @@ export const getWorkflowStatus = query({
         };
         currentStep = latestStep.step.name;
 
-        // Calculate progress based on completed steps
         const completedSteps = latestStep.stepNumber || 0;
-        progress = Math.min((completedSteps / totalSteps) * 100, 90); // Cap at 90% until complete
+        progress = Math.min((completedSteps / totalSteps) * 100, 90);
       } else {
         currentStep = "Starting";
         progress = 10;
@@ -288,7 +267,6 @@ export const getWorkflowStatus = query({
         startedAt: status.workflow._creationTime,
       };
     } catch (error) {
-      // Workflow might not exist or be cleaned up
       return {
         workflowId: args.workflowId,
         status: "failed" as const,

--- a/packages/backend/convex/workflows/onComplete.ts
+++ b/packages/backend/convex/workflows/onComplete.ts
@@ -22,7 +22,6 @@ export const handleEventIngestionComplete = internalMutation({
     } else if (result.kind === "failed") {
       console.error("Event ingestion failed:", result.error);
 
-      // Send failure notification to user
       try {
         await ctx.scheduler.runAfter(0, internal.notifications.pushFailure, {
           userId: context.userId,
@@ -37,7 +36,6 @@ export const handleEventIngestionComplete = internalMutation({
         );
       }
     } else {
-      // Cancelled case
       console.log("Event ingestion was canceled");
       // Optionally send cancellation notification
     }

--- a/packages/backend/convex/workflows/testFailures.ts
+++ b/packages/backend/convex/workflows/testFailures.ts
@@ -7,9 +7,6 @@ import { DEFAULT_VISIBILITY } from "../constants";
 
 const workflow = new WorkflowManager(components.workflow);
 
-/**
- * Test function that simulates AI extraction failure
- */
 export const testAIExtractionFailure = mutation({
   args: {
     userId: v.string(),
@@ -23,7 +20,6 @@ export const testAIExtractionFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a known bad base64 string that will cause AI extraction to fail
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromImageBase64Workflow,
@@ -53,9 +49,6 @@ export const testAIExtractionFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates image upload failure
- */
 export const testImageUploadFailure = mutation({
   args: {
     userId: v.string(),
@@ -69,7 +62,6 @@ export const testImageUploadFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with empty base64 string that will cause upload to fail
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromImageBase64Workflow,
@@ -99,9 +91,6 @@ export const testImageUploadFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates validation failure by providing data that won't validate
- */
 export const testValidationFailure = mutation({
   args: {
     userId: v.string(),
@@ -115,7 +104,6 @@ export const testValidationFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a base64 string that might extract but will fail validation
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromImageBase64Workflow,
@@ -146,10 +134,6 @@ export const testValidationFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates database insertion failure
- * This is harder to simulate without actually breaking the DB, so we'll rely on integration testing
- */
 export const testDatabaseFailure = mutation({
   args: {
     userId: v.string(),
@@ -169,9 +153,6 @@ export const testDatabaseFailure = mutation({
   },
 });
 
-/**
- * Workflow status checker to validate that workflows are failing and notifications are being sent
- */
 export const checkWorkflowFailureStatus = mutation({
   args: {
     workflowId: vWorkflowId,
@@ -225,9 +206,6 @@ export const checkWorkflowFailureStatus = mutation({
   },
 });
 
-/**
- * Utility function to test notification system directly
- */
 export const testNotificationSystemDirectly = mutation({
   args: {
     userId: v.string(),
@@ -241,7 +219,6 @@ export const testNotificationSystemDirectly = mutation({
   }),
   handler: async (ctx, args) => {
     try {
-      // Directly test the failure notification system
       await ctx.scheduler.runAfter(0, internal.notifications.pushFailure, {
         userId: args.userId,
         userName: args.username,
@@ -262,9 +239,6 @@ export const testNotificationSystemDirectly = mutation({
   },
 });
 
-/**
- * Test function that simulates URL fetch failure
- */
 export const simulateUrlFetchFailure = mutation({
   args: {
     userId: v.string(),
@@ -278,7 +252,6 @@ export const simulateUrlFetchFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with an invalid URL that will cause fetch to fail
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -308,9 +281,6 @@ export const simulateUrlFetchFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates URL content parsing failure
- */
 export const simulateUrlContentParsingFailure = mutation({
   args: {
     userId: v.string(),
@@ -324,7 +294,6 @@ export const simulateUrlContentParsingFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a URL that returns invalid/unparseable content
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -354,9 +323,6 @@ export const simulateUrlContentParsingFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates URL AI processing failure
- */
 export const simulateUrlAiProcessingFailure = mutation({
   args: {
     userId: v.string(),
@@ -370,7 +336,6 @@ export const simulateUrlAiProcessingFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a URL that returns content but will fail AI processing
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -400,9 +365,6 @@ export const simulateUrlAiProcessingFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates URL validation failure
- */
 export const simulateUrlValidationFailure = mutation({
   args: {
     userId: v.string(),
@@ -416,7 +378,6 @@ export const simulateUrlValidationFailure = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a URL that might extract content but fail validation
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -446,9 +407,6 @@ export const simulateUrlValidationFailure = mutation({
   },
 });
 
-/**
- * Test function that simulates URL database failure
- */
 export const simulateUrlDatabaseFailure = mutation({
   args: {
     userId: v.string(),
@@ -460,9 +418,6 @@ export const simulateUrlDatabaseFailure = mutation({
     note: v.string(),
   }),
   handler: (_ctx, _args) => {
-    // Database failures are hard to simulate safely in production
-    // This would need to be tested with integration tests or by temporarily
-    // modifying the database schema to reject valid inserts
     return {
       success: false,
       workflowId: "test-url-db-failure",
@@ -471,9 +426,6 @@ export const simulateUrlDatabaseFailure = mutation({
   },
 });
 
-/**
- * Test URL workflow with valid data to ensure the workflow works correctly
- */
 export const testUrlWorkflowSuccess = mutation({
   args: {
     userId: v.string(),
@@ -487,7 +439,6 @@ export const testUrlWorkflowSuccess = mutation({
     ctx,
     args,
   ): Promise<{ success: boolean; workflowId: string }> => {
-    // Start workflow with a valid URL that should succeed
     const workflowId: string = await workflow.start(
       ctx,
       internal.workflows.eventIngestion.eventFromUrlWorkflow,
@@ -517,9 +468,6 @@ export const testUrlWorkflowSuccess = mutation({
   },
 });
 
-/**
- * Validation function specifically for URL workflow testing
- */
 export const validateUrlWorkflowFailure = mutation({
   args: {
     workflowId: vWorkflowId,
@@ -535,7 +483,6 @@ export const validateUrlWorkflowFailure = mutation({
   }),
   handler: async (ctx, args) => {
     try {
-      // Get workflow status
       const status = await ctx.runQuery(
         components.workflow.workflow.getStatus,
         {
@@ -556,7 +503,6 @@ export const validateUrlWorkflowFailure = mutation({
           isWorkflowFailed = true;
           error = runResult.error;
 
-          // Try to determine which step failed from the error message
           if (error.includes("extractEventFromUrl")) {
             failureStep = "URL_FETCH_OR_AI_PROCESSING";
           } else if (error.includes("validateEvent")) {
@@ -571,8 +517,6 @@ export const validateUrlWorkflowFailure = mutation({
         }
       }
 
-      // For URL workflow testing, we assume the URL-specific notification was sent
-      // In a real implementation, we would check the notification logs/database
       const hasUrlFailureNotification = isWorkflowFailed;
 
       return {
@@ -599,9 +543,6 @@ export const validateUrlWorkflowFailure = mutation({
   },
 });
 
-/**
- * Validation function to check URL workflow success scenarios
- */
 export const validateUrlWorkflowSuccess = mutation({
   args: {
     workflowId: vWorkflowId,
@@ -636,9 +577,8 @@ export const validateUrlWorkflowSuccess = mutation({
         if (runResult.kind === "success") {
           isWorkflowSuccessful = true;
           eventId = runResult.returnValue as string;
-          hasSuccessNotification = true; // Assume notification was sent for success
+          hasSuccessNotification = true;
 
-          // Extract completed steps from the workflow execution
           completedSteps = [
             "extractEventFromUrl",
             "validateEvent",
@@ -646,7 +586,6 @@ export const validateUrlWorkflowSuccess = mutation({
             "sendPush",
           ];
 
-          // Calculate execution time if available
           if (status.workflow._creationTime) {
             executionTime = Date.now() - status.workflow._creationTime;
           }
@@ -676,9 +615,6 @@ export const validateUrlWorkflowSuccess = mutation({
   },
 });
 
-/**
- * Validation function to verify URL workflow notification delivery
- */
 export const validateUrlWorkflowNotifications = mutation({
   args: {
     userId: v.string(),
@@ -696,8 +632,6 @@ export const validateUrlWorkflowNotifications = mutation({
     error: v.optional(v.string()),
   }),
   handler: async (ctx, args) => {
-    // In a real implementation, this would query the notifications table/system
-    // For now, we'll simulate the validation based on workflow status
     try {
       const status = await ctx.runQuery(
         components.workflow.workflow.getStatus,


### PR DESCRIPTION
## Summary
Mechanical pass: removes descriptive comments, section dividers, TODOs,
and non-operational JSDoc from `packages/backend`.

Kept: ESLint/TypeScript/Prettier/Biome pragmas, triple-slash directives,
source-map comments, Convex `"use node"` directives, and JSDoc with
operational tags (@deprecated, @throws, @internal, @override).

`convex/_generated/` is auto-generated and not modified.

Pure comment removal — no functional code changes.

## Test plan
- [ ] CI passes (typecheck, lint, format)
- [ ] Convex deploy succeeds
- [ ] Spot-check diffs

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stripped non-functional comments across `packages/backend` and ran Prettier to normalize formatting. No logic changes; build and runtime behavior are unchanged.

- **Refactors**
  - Removed prose comments, section dividers, TODOs/FIXMEs, and non-operational JSDoc; preserved ESLint/TypeScript/Prettier/Biome pragmas, triple-slash directives, source maps, Convex "use node", and operational JSDoc tags (`@deprecated`, `@throws`, `@internal`, `@override`).
  - Ran Prettier on modified files to satisfy formatting checks; left `convex/_generated/` untouched.

<sup>Written for commit 9f70cd42c070a3d2c4e233d75669a9625e0d7638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a mechanical comment-stripping pass across `packages/backend/convex`, removing descriptive comments, section dividers, TODOs, and non-operational JSDoc. No functional code changes are introduced — all 1,805 deleted lines are comments only.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every deletion is a comment; no functional code was changed.

All 1,805 removed lines are comments, JSDoc blocks, section dividers, or inline annotations. The diff was spot-checked across the largest changed files and no executable code was touched. No P0/P1 findings exist.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/schema.ts | Removed inline comments on index definitions and field annotations; schema structure and all index definitions are unchanged. |
| packages/backend/convex/lists.ts | Largest single-file deletion (224 lines); all deletions are comments and JSDoc — functional code intact. |
| packages/backend/convex/events.ts | Stripped JSDoc blocks and inline comments; all query/mutation handlers are functionally identical. |
| packages/backend/convex/users.ts | Removed section dividers and descriptive comments; no logic changes. |
| packages/backend/convex/model/events.ts | Removed descriptive comments throughout; business logic unchanged. |
| packages/backend/convex/workflows/eventIngestion.ts | Removed step labels (e.g. '── step 1') and JSDoc; workflow steps and logic are identical. |
| packages/backend/convex/feedHelpers.ts | Comment-only removal; feed mutation logic is untouched. |
| packages/backend/convex/migrations/fix2027Dates.ts | Removed usage instructions from JSDoc and inline comments; migration logic is unchanged. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[45 files changed] --> B[Pure comment removal]
    B --> C[Descriptive comments]
    B --> D[Section dividers]
    B --> E[Non-operational JSDoc]
    B --> F[TODOs]
    G[Kept untouched] --> H[ESLint/TS/Prettier pragmas]
    G --> I[Triple-slash directives]
    G --> J[Source-map comments]
    G --> K[Convex 'use node' directives]
    G --> L[JSDoc with @deprecated/@throws/@internal]
    G --> M[convex/_generated/ auto-gen files]
    B -->|1805 lines deleted| N[No functional code changed]
```

<sub>Reviews (1): Last reviewed commit: ["chore: strip non-functional comments fro..."](https://github.com/jaronheard/soonlist-turbo/commit/b55d44fa0a073ad9690e30372ea4276c672e9c04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29428984)</sub>

<!-- /greptile_comment -->