### PR TITLE
fix(expo): restore header legibility on iOS <26

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/feed/_layout.tsx
@@ -5,6 +5,7 @@ import { Stack } from "expo-router";
 import { CaptureOverlayButton } from "~/components/CaptureOverlayButton";
 import { ProfileMenu } from "~/components/ProfileMenu";
 import { useShareMyList } from "~/hooks/useShareMyList";
+import { HEADER_BLUR_EFFECT } from "~/utils/headerOptions";
 
 export default function FeedLayout() {
   const { requestShare } = useShareMyList();
@@ -19,7 +20,7 @@ export default function FeedLayout() {
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,
           headerTransparent: true,
-          headerBlurEffect: "none",
+          headerBlurEffect: HEADER_BLUR_EFFECT,
         }}
       >
         <Stack.Screen

--- a/apps/expo/src/app/(tabs)/following/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/following/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from "expo-router";
 
 import { CaptureOverlayButton } from "~/components/CaptureOverlayButton";
 import { ProfileMenu } from "~/components/ProfileMenu";
+import { HEADER_BLUR_EFFECT } from "~/utils/headerOptions";
 
 export default function FollowingLayout() {
   return (
@@ -16,7 +17,7 @@ export default function FollowingLayout() {
           headerTintColor: "#5A32FB",
           headerShadowVisible: false,
           headerTransparent: true,
-          headerBlurEffect: "none",
+          headerBlurEffect: HEADER_BLUR_EFFECT,
         }}
       >
         <Stack.Screen

--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -35,6 +35,7 @@ import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
+import { HEADER_BLUR_EFFECT } from "~/utils/headerOptions";
 
 function formatMemberSince(createdAtIso: string): string {
   const d = new Date(createdAtIso);
@@ -377,7 +378,7 @@ export default function UserProfilePage() {
           title: screenTitle,
           headerLargeTitle: false,
           headerTransparent: true,
-          headerBlurEffect: "none",
+          headerBlurEffect: HEADER_BLUR_EFFECT,
           headerShadowVisible: false,
           headerTintColor: "#5A32FB",
           headerTitleStyle: {

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -46,6 +46,7 @@ import Config from "~/utils/config";
 import { getUserTimeZone } from "~/utils/dates";
 import { logDebug, logError } from "~/utils/errorLogging";
 import { getAccessGroup } from "~/utils/getAccessGroup";
+import { HEADER_BLUR_EFFECT } from "~/utils/headerOptions";
 
 const styles = StyleSheet.create({
   container: {
@@ -210,7 +211,7 @@ const InitialLayout = () => {
     <Stack
       screenOptions={{
         headerTransparent: true,
-        headerBlurEffect: "none",
+        headerBlurEffect: HEADER_BLUR_EFFECT,
         headerTintColor: "#5A32FB",
         headerTitleStyle: {
           fontWeight: "bold",

--- a/apps/expo/src/utils/headerOptions.ts
+++ b/apps/expo/src/utils/headerOptions.ts
@@ -1,0 +1,10 @@
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
+
+// iOS 26 renders an inline large-title bar with its own blurred chrome as
+// content scrolls under it, so we want fully transparent headers there.
+// On iOS <26 a transparent header with no blur lets scroll content bleed
+// into the title and controls and makes them unreadable — fall back to a
+// light system-chrome blur so the native nav bar stays legible.
+export const HEADER_BLUR_EFFECT = SUPPORTS_LIQUID_GLASS
+  ? "none"
+  : "systemChromeMaterialLight";


### PR DESCRIPTION
## Summary

iOS 26 draws the inline large-title bar with its own blurred chrome as content scrolls under it. On iOS <26 our transparent headers have no blur, so scroll content bleeds through titles, avatars, and controls — unreadable.

Centralize the decision in one helper (`HEADER_BLUR_EFFECT`): `"none"` on iOS 26+ (unchanged), `"systemChromeMaterialLight"` on iOS <26. Wire it through the root `Stack` screenOptions plus the three layouts that override the default. iOS 26 is untouched.

## Approach

- New helper `apps/expo/src/utils/headerOptions.ts` exports `HEADER_BLUR_EFFECT`, gated by the existing `SUPPORTS_LIQUID_GLASS` constant. One branch, one place.
- Replaced the hard-coded `headerBlurEffect: "none"` in all four places that set it. Other screens inherit the fix through the root `Stack`.

No UI-visible behavior changes on iOS 26 — the value resolves to `"none"`, matching the previous literal.

## Screens audited

| Screen | File | Outcome |
|---|---|---|
| My Soonlist | `apps/expo/src/app/(tabs)/feed/_layout.tsx` | **fixed** (explicit override) |
| My Scene | `apps/expo/src/app/(tabs)/following/_layout.tsx` | **fixed** (explicit override) |
| User profile (`@username`) | `apps/expo/src/app/[username]/index.tsx` | **fixed** (explicit override) |
| Event detail | `apps/expo/src/app/event/[id]/index.tsx` | **fixed via root** (inherits) |
| List detail | `apps/expo/src/app/list/[slug].tsx` | **fixed via root** (inherits) |
| Event detail loading / invalid / not-found states | `apps/expo/src/app/event/[id]/index.tsx` | **fixed via root** (inherits) |
| User profile loading / not-found states | `apps/expo/src/app/[username]/index.tsx` | **fixed via root** (inherits) |
| Add event (modal) | `apps/expo/src/app/add.tsx` + root override | inherits (no regression) |
| New event / share extension (modal) | `apps/expo/src/app/new.tsx` + root override | inherits (no regression) |
| Batch results | `apps/expo/src/app/batch/[batchId]/index.tsx` | inherits (no regression) |
| Event edit | root override: solid `#E0D9FF` header | already legible, untouched |
| Settings / Account | root override: solid `#F4F1FF` header | already legible, untouched |
| Settings / Profile edit | root override: solid `#F4F1FF` header | already legible, untouched |
| Settings / Timezone | root override: solid `#F4F1FF` header | already legible, untouched |
| Discover (hidden tab) | `apps/expo/src/app/(tabs)/discover.tsx` | no Stack.Screen header |
| Auth / onboarding | `headerShown: false` | n/a |

Discover is currently hidden via `NativeTabs.Trigger hidden`; if it's ever re-enabled it'll need its own `_layout.tsx` or reuse the helper.

## Screens changed

Four call sites for the blur setting, plus the new helper:

- `apps/expo/src/utils/headerOptions.ts` (new)
- `apps/expo/src/app/_layout.tsx` (root — covers event detail, list detail, modals)
- `apps/expo/src/app/(tabs)/feed/_layout.tsx` (My Soonlist)
- `apps/expo/src/app/(tabs)/following/_layout.tsx` (My Scene)
- `apps/expo/src/app/[username]/index.tsx` (public profile)

## Test plan

- [ ] **iOS 18 / iOS <26 simulator**: on My Soonlist, scroll the event list — title "My Soonlist", avatar, and share icon remain readable over content. No content shows through them.
- [ ] **iOS 18 / iOS <26 simulator**: same check on My Scene (title, avatar).
- [ ] **iOS 18 / iOS <26 simulator**: same check on a public profile (`@jaron`) — title, hero row, Subscribe button stay legible on scroll.
- [ ] **iOS 18 / iOS <26 simulator**: same check on an event detail page — share and overflow icons stay legible over description/image.
- [ ] **iOS 26 simulator**: confirm My Soonlist, My Scene, public profile, and event detail look identical to `main`. No extra bar, no changed spacing, no new blur at rest.
- [ ] Safe-area insets unchanged: floating action buttons still sit above the home indicator; content still scrolls under the status bar.
- [ ] Status-bar tap still scrolls lists to top.
- [ ] Pull-to-refresh still works on feed lists.
- [ ] Floating "Save"/"Add to Calendar" buttons on event detail are unaffected.
- [ ] Before/after screenshots on iOS <26 for: My Soonlist, My Scene, a public profile, an event detail page.

https://claude.ai/code/session_017FgPG7moSTjsCz9hUra6dG

---
_Generated by [Claude Code](https://claude.ai/code/session_017FgPG7moSTjsCz9hUra6dG)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable headers on iOS <26 by applying a light system blur when content scrolls under transparent headers. iOS 26+ behavior stays the same.

- **Bug Fixes**
  - Added `HEADER_BLUR_EFFECT` in `utils/headerOptions.ts` to choose `"none"` on iOS 26+ and `"systemChromeMaterialLight"` on iOS <26.
  - Applied to the root `Stack` and screens that override it: My Soonlist, My Scene, and public profile.
  - Event and list detail inherit the fix; iOS 26 visuals are unchanged.

<sup>Written for commit d69617a6cb0656e73f64864bf38f4cff99589404. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes the `headerBlurEffect` header option into a single helper (`HEADER_BLUR_EFFECT` in `apps/expo/src/utils/headerOptions.ts`) that resolves to `"none"` on iOS 26+ (unchanged behavior) and `"systemChromeMaterialLight"` on iOS <26 to prevent scroll content from bleeding through transparent navigation bars. Four call sites are updated to reference the helper; all other screens inherit the fix through the root `Stack`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is additive, iOS 26 behavior is unchanged, and the fix is well-scoped

All changes are mechanical substitutions of a hardcoded "none" with a constant that resolves to "none" on iOS 26+ and a valid blur effect string on earlier versions. No logic changes, no data flow affected, and the helper correctly reuses the existing SUPPORTS_LIQUID_GLASS constant evaluated at module load time. No P0/P1 findings.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/utils/headerOptions.ts | New helper that exports HEADER_BLUR_EFFECT — "none" on iOS 26+, "systemChromeMaterialLight" on iOS <26; clean and correct |
| apps/expo/src/app/_layout.tsx | Root Stack screenOptions updated to use HEADER_BLUR_EFFECT; propagates fix to all inheriting screens |
| apps/expo/src/app/(tabs)/feed/_layout.tsx | Feed layout updated to use HEADER_BLUR_EFFECT; no other changes |
| apps/expo/src/app/(tabs)/following/_layout.tsx | Following layout updated to use HEADER_BLUR_EFFECT; no other changes |
| apps/expo/src/app/[username]/index.tsx | User profile screen updated to use HEADER_BLUR_EFFECT; no other changes |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[headerOptions.ts] -->|imports| B[SUPPORTS_LIQUID_GLASS from useLiquidGlass.ts]
    B -->|iOS 26+| C["HEADER_BLUR_EFFECT = none"]
    B -->|iOS less than 26| D["HEADER_BLUR_EFFECT = systemChromeMaterialLight"]
    A --> E["_layout.tsx Root Stack screenOptions"]
    A --> F["feed/_layout.tsx"]
    A --> G["following/_layout.tsx"]
    A --> H["username/index.tsx"]
    E -->|inherits| I["event/id/index.tsx"]
    E -->|inherits| J["list/slug.tsx"]
    E -->|inherits| K["add.tsx / new.tsx / modals"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(expo): restore header legibility on ..."](https://github.com/jaronheard/soonlist-turbo/commit/d69617a6cb0656e73f64864bf38f4cff99589404) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29539093)</sub>

<!-- /greptile_comment -->