### PR TITLE
feat(expo): tappable event attribution, From these Soonlists for multiple

### DIFF
--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -58,15 +58,35 @@ function combineUsers(creator: UserForDisplay, savers: UserForDisplay[]) {
   return out;
 }
 
-function RowWrapper({ children }: { children: React.ReactNode }) {
+function RowWrapper({
+  children,
+  onRowPress,
+}: {
+  children: React.ReactNode;
+  /** Catches the full row width so taps do not pass through to the event card. */
+  onRowPress?: () => void;
+}) {
+  const inner = (
+    <View
+      className="w-full flex-row items-center"
+      style={{ minHeight: ROW_HEIGHT, columnGap: 7 }}
+    >
+      {children}
+    </View>
+  );
   return (
-    <View className="mt-0.5 px-3">
-      <View
-        className="flex-row items-center"
-        style={{ minHeight: ROW_HEIGHT, columnGap: 7 }}
-      >
-        {children}
-      </View>
+    <View className="mt-0.5 px-3" style={{ alignSelf: "stretch" }}>
+      {onRowPress ? (
+        <Pressable
+          onPress={onRowPress}
+          accessibilityRole="button"
+          style={({ pressed }) => (pressed ? { opacity: 0.85 } : undefined)}
+        >
+          {inner}
+        </Pressable>
+      ) : (
+        inner
+      )}
     </View>
   );
 }
@@ -193,12 +213,18 @@ function NameList({
   maxNames,
   currentUserId,
   onOverflowPress,
+  nameLinksEnabled = true,
 }: {
   users: UserForDisplay[];
   extraCount: number;
   maxNames: number;
   currentUserId?: string;
   onOverflowPress?: () => void;
+  /**
+   * When false, names are plain text so the row can open the From these
+   * Soonlists sheet instead of deep-linking to a profile.
+   */
+  nameLinksEnabled?: boolean;
 }) {
   const nameUsers = users.slice(0, maxNames);
   if (nameUsers.length === 0 && extraCount === 0) return null;
@@ -217,7 +243,11 @@ function NameList({
           {nameUsers.map((user, i) => (
             <Text
               key={user.id}
-              onPress={() => navigateToUser(user, currentUserId)}
+              onPress={
+                nameLinksEnabled
+                  ? () => navigateToUser(user, currentUserId)
+                  : undefined
+              }
             >
               {displayName(user)}
               {i < nameUsers.length - 1 ? ", " : ""}
@@ -380,7 +410,6 @@ function MySoonlistRow({
   const otherSavers = savers.filter(
     (s) => s.id !== creator.id && s.id !== currentUserId,
   );
-  const openModal = () => setShowModal(true);
 
   // Viewer captured alone: handoff says collapse the row entirely.
   if (isOwnEvent && otherSavers.length === 0) {
@@ -390,21 +419,29 @@ function MySoonlistRow({
   if (isOwnEvent) {
     const stackUsers = otherSavers.slice(0, 3);
     const extraNameCount = Math.max(otherSavers.length - 2, 0);
+    const [singleSaver] = otherSavers;
+    const multipleSavers = otherSavers.length > 1;
+    const openFromSoonlists = () => setShowModal(true);
+    const onRowAction =
+      multipleSavers || !singleSaver
+        ? openFromSoonlists
+        : () => navigateToUser(singleSaver, currentUserId);
     return (
       <>
-        <RowWrapper>
+        <RowWrapper onRowPress={onRowAction}>
           <RowText className="text-neutral-2">Also saved by</RowText>
           <AvatarStack
             users={stackUsers}
             size={avatarSize}
-            onPress={openModal}
+            onPress={onRowAction}
           />
           <NameList
             users={otherSavers}
             extraCount={extraNameCount}
             maxNames={2}
             currentUserId={currentUserId}
-            onOverflowPress={openModal}
+            onOverflowPress={openFromSoonlists}
+            nameLinksEnabled={!multipleSavers}
           />
         </RowWrapper>
         <SavedByModal
@@ -419,25 +456,33 @@ function MySoonlistRow({
     );
   }
 
-  const capturerBadge = (
-    <Pressable
-      onPress={() => navigateToUser(creator, currentUserId)}
-      hitSlop={HIT_SLOP}
-      className="flex-row items-center"
-      style={{ columnGap: 7, flexShrink: 1, minWidth: 0 }}
-    >
+  const [singleSaver] = otherSavers;
+  const multipleSavers = otherSavers.length > 1;
+  const openFromSoonlists = () => setShowModal(true);
+  const onRowWithSaversAction =
+    multipleSavers || !singleSaver
+      ? openFromSoonlists
+      : () => navigateToUser(singleSaver, currentUserId);
+
+  const capturerContent = (
+    <>
       <CapturerAvatar user={creator} size={avatarSize} />
       <RowText className="font-semibold text-black" style={{ flexShrink: 1 }}>
         {displayName(creator)}
       </RowText>
-    </Pressable>
+    </>
   );
 
   if (otherSavers.length === 0) {
     return (
-      <RowWrapper>
+      <RowWrapper onRowPress={() => navigateToUser(creator, currentUserId)}>
         <RowText className="text-neutral-2">Captured by</RowText>
-        {capturerBadge}
+        <View
+          className="flex-row items-center"
+          style={{ columnGap: 7, flexShrink: 1, minWidth: 0 }}
+        >
+          {capturerContent}
+        </View>
       </RowWrapper>
     );
   }
@@ -446,17 +491,29 @@ function MySoonlistRow({
   const extraNameCount = Math.max(otherSavers.length - 1, 0);
   return (
     <>
-      <RowWrapper>
+      <RowWrapper onRowPress={onRowWithSaversAction}>
         <RowText className="text-neutral-2">Captured by</RowText>
-        {capturerBadge}
+        <Pressable
+          onPress={() => navigateToUser(creator, currentUserId)}
+          hitSlop={HIT_SLOP}
+          className="flex-row items-center"
+          style={{ columnGap: 7, flexShrink: 1, minWidth: 0 }}
+        >
+          {capturerContent}
+        </Pressable>
         <RowText className="text-neutral-3">·</RowText>
-        <AvatarStack users={stackUsers} size={avatarSize} onPress={openModal} />
+        <AvatarStack
+          users={stackUsers}
+          size={avatarSize}
+          onPress={onRowWithSaversAction}
+        />
         <NameList
           users={otherSavers}
           extraCount={extraNameCount}
           maxNames={1}
           currentUserId={currentUserId}
-          onOverflowPress={openModal}
+          onOverflowPress={openFromSoonlists}
+          nameLinksEnabled={!multipleSavers}
         />
       </RowWrapper>
       <SavedByModal
@@ -493,30 +550,38 @@ function MySceneRow({
   const [showModal, setShowModal] = useState(false);
   const avatarSize = Math.round(iconSize * 1.25); // 20px at fontScale=1
   const listIconSize = Math.round(iconSize * 0.8125); // 13px at fontScale=1
-  const openModal = () => setShowModal(true);
 
   // Capturer first, then savers in order, dedup'd. Per the handoff the Scene
   // row shows no "+N" for extra savers — tapping the stack opens the modal.
-  const stackUsers = combineUsers(creator, savers).slice(0, 3);
+  const allPeople = combineUsers(creator, savers);
+  const stackUsers = allPeople.slice(0, 3);
   const remainingListsCount = additionalSourceCount ?? 0;
+  const openFromSoonlists = () => setShowModal(true);
+  const onRowAction =
+    allPeople.length > 1
+      ? openFromSoonlists
+      : () => navigateToUser(creator, currentUserId);
 
   return (
     <>
-      <RowWrapper>
+      <RowWrapper onRowPress={onRowAction}>
         <ListChip
           name={sourceListName}
           slug={sourceListSlug}
           size={listIconSize}
         />
         {remainingListsCount > 0 ? (
-          <OverflowPill count={remainingListsCount} onPress={openModal} />
+          <OverflowPill
+            count={remainingListsCount}
+            onPress={openFromSoonlists}
+          />
         ) : null}
         <RowText className="text-neutral-3">·</RowText>
         <AvatarStack
           users={stackUsers}
           size={avatarSize}
           capturerId={creator.id}
-          onPress={openModal}
+          onPress={onRowAction}
         />
       </RowWrapper>
       <SavedByModal
@@ -531,8 +596,8 @@ function MySceneRow({
   );
 }
 
-// Discover tab and List detail page. Not covered by the attribution-row
-// redesign; kept unchanged so those screens render as before.
+// Discover tab and List detail page. Includes full-width press capture so
+// background taps do not pass through to the event card.
 function PeoplePrimaryRow({
   creator,
   savers,
@@ -559,14 +624,37 @@ function PeoplePrimaryRow({
   const remainingUsersCount = allUsers.length - displayUsers.length;
   const remainingListsCount = additionalSourceCount ?? 0;
   const avatarSize = iconSize * 0.9;
-  const openModal = () => setShowModal(true);
+  const isMultiUser = allUsers.length > 1;
+  const openFromSoonlists = () => setShowModal(true);
 
   const hasAnyListInfo =
     !!sourceListSlug || !!sourceListName || remainingListsCount > 0;
 
+  const onRowPress = () => {
+    if (isOwnEvent) {
+      if (hasAnyListInfo) {
+        openFromSoonlists();
+      } else {
+        navigateToUser(creator, currentUserId);
+      }
+      return;
+    }
+    const [singleUser] = allUsers;
+    if (isMultiUser || !singleUser) {
+      openFromSoonlists();
+    } else {
+      navigateToUser(singleUser, currentUserId);
+    }
+  };
+
   return (
     <>
-      <View className="mx-auto mt-1 flex-row flex-wrap items-center justify-center gap-2">
+      <Pressable
+        onPress={onRowPress}
+        className="mx-auto mt-1 w-full flex-row flex-wrap items-center justify-center gap-2"
+        accessibilityRole="button"
+        style={({ pressed }) => (pressed ? { opacity: 0.9 } : undefined)}
+      >
         {isOwnEvent ? (
           <Pressable
             onPress={() => navigateToUser(creator, currentUserId)}
@@ -580,7 +668,11 @@ function PeoplePrimaryRow({
           displayUsers.map((user, index) => (
             <Pressable
               key={user.id}
-              onPress={() => navigateToUser(user, currentUserId)}
+              onPress={() =>
+                isMultiUser
+                  ? openFromSoonlists()
+                  : navigateToUser(user, currentUserId)
+              }
               hitSlop={HIT_SLOP}
               className="flex-row items-center gap-1"
             >
@@ -595,7 +687,10 @@ function PeoplePrimaryRow({
           ))
         )}
         {!isOwnEvent && remainingUsersCount > 0 && (
-          <OverflowPill count={remainingUsersCount} onPress={openModal} />
+          <OverflowPill
+            count={remainingUsersCount}
+            onPress={openFromSoonlists}
+          />
         )}
         {hasAnyListInfo && (
           <>
@@ -604,11 +699,14 @@ function PeoplePrimaryRow({
             </Text>
             <ListChipLegacy name={sourceListName} slug={sourceListSlug} />
             {remainingListsCount > 0 && (
-              <OverflowPill count={remainingListsCount} onPress={openModal} />
+              <OverflowPill
+                count={remainingListsCount}
+                onPress={openFromSoonlists}
+              />
             )}
           </>
         )}
-      </View>
+      </Pressable>
       <SavedByModal
         visible={showModal}
         onClose={() => setShowModal(false)}

--- a/apps/expo/src/components/EventAttributionRow.tsx
+++ b/apps/expo/src/components/EventAttributionRow.tsx
@@ -456,13 +456,9 @@ function MySoonlistRow({
     );
   }
 
-  const [singleSaver] = otherSavers;
-  const multipleSavers = otherSavers.length > 1;
+  // Reaching this branch implies otherSavers.length >= 1, so the row shows
+  // creator + 1+ savers (2+ people total) — always open the modal.
   const openFromSoonlists = () => setShowModal(true);
-  const onRowWithSaversAction =
-    multipleSavers || !singleSaver
-      ? openFromSoonlists
-      : () => navigateToUser(singleSaver, currentUserId);
 
   const capturerContent = (
     <>
@@ -491,7 +487,7 @@ function MySoonlistRow({
   const extraNameCount = Math.max(otherSavers.length - 1, 0);
   return (
     <>
-      <RowWrapper onRowPress={onRowWithSaversAction}>
+      <RowWrapper onRowPress={openFromSoonlists}>
         <RowText className="text-neutral-2">Captured by</RowText>
         <Pressable
           onPress={() => navigateToUser(creator, currentUserId)}
@@ -505,7 +501,7 @@ function MySoonlistRow({
         <AvatarStack
           users={stackUsers}
           size={avatarSize}
-          onPress={onRowWithSaversAction}
+          onPress={openFromSoonlists}
         />
         <NameList
           users={otherSavers}
@@ -513,7 +509,7 @@ function MySoonlistRow({
           maxNames={1}
           currentUserId={currentUserId}
           onOverflowPress={openFromSoonlists}
-          nameLinksEnabled={!multipleSavers}
+          nameLinksEnabled={false}
         />
       </RowWrapper>
       <SavedByModal

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -33,6 +33,7 @@ import {
   PenSquare,
   ShareIcon,
 } from "~/components/icons";
+import { OverflowPill } from "~/components/OverflowPill";
 import { SavedByModal } from "~/components/SavedByModal";
 import { useAddEventFlow } from "~/hooks/useAddEventFlow";
 import { useEventActions } from "~/hooks/useEventActions";
@@ -258,6 +259,19 @@ export function UserEventListItem(props: UserEventListItemProps) {
     showCreator === "always" ||
     (showCreator === "otherUsers" && !isCurrentUser) ||
     (showCreator === "savedFromOthers" && isSavedFromOthersEligible);
+
+  const fallbackOverflowCount = additionalSourceCount ?? 0;
+  const hasListAttributionInFallback =
+    !!sourceListSlug || !!sourceListName || fallbackOverflowCount > 0;
+  const showListOnlyAttribution =
+    !shouldShowCreator && hasListAttributionInFallback;
+
+  // Modal wins when there are multiple list sources OR when there is no slug
+  // to navigate to; otherwise tap the row → open the single source list.
+  const onFallbackListAttributionRowPress =
+    fallbackOverflowCount > 0 || !sourceListSlug
+      ? () => setShowFallbackSavedByModal(true)
+      : () => router.push(`/list/${sourceListSlug}`);
 
   const isOwner = demoMode || isCurrentUser;
 
@@ -520,10 +534,14 @@ export function UserEventListItem(props: UserEventListItemProps) {
               lists={(event as { lists?: Doc<"lists">[] }).lists}
               variant={attributionVariant}
             />
-          ) : sourceListSlug ||
-            sourceListName ||
-            (additionalSourceCount ?? 0) > 0 ? (
-            <View className="mx-auto mt-1 flex-row items-center gap-1">
+          ) : showListOnlyAttribution ? (
+            <Pressable
+              onPress={onFallbackListAttributionRowPress}
+              className="mx-auto mt-1 w-full flex-row items-center justify-center gap-1 self-stretch"
+              accessibilityRole="button"
+              accessibilityLabel="View list attribution"
+              style={({ pressed }) => (pressed ? { opacity: 0.85 } : undefined)}
+            >
               <Text className="text-xs text-neutral-2">via</Text>
               {sourceListSlug ? (
                 <Pressable
@@ -551,19 +569,11 @@ export function UserEventListItem(props: UserEventListItemProps) {
                   ) : null}
                 </View>
               )}
-              {additionalSourceCount && additionalSourceCount > 0 ? (
-                <Pressable
-                  onPress={() => setShowFallbackSavedByModal(true)}
-                  hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-                >
-                  <View className="rounded-full bg-interactive-3 px-1.5 py-0.5">
-                    <Text className="text-xs font-medium text-interactive-1">
-                      +{additionalSourceCount}
-                    </Text>
-                  </View>
-                </Pressable>
-              ) : null}
-            </View>
+              <OverflowPill
+                count={fallbackOverflowCount}
+                onPress={() => setShowFallbackSavedByModal(true)}
+              />
+            </Pressable>
           ) : null}
           <SavedByModal
             visible={showFallbackSavedByModal}


### PR DESCRIPTION
## Summary
- Full-width `Pressable` on attribution rows so taps no longer pass through to the event card.
- When more than one person (or, for the list-only fallback, more than one list source) is involved, the primary action opens **From these Soonlists** (`SavedByModal`); a single person or list still deep-links to profile or list.
- List-only `via` fallback uses the same row press behavior and reuses `OverflowPill` for the `+N` chip.

## Test plan
- [ ] Follow feed: list-primary row — empty padding opens modal with multiple savers, single saver navigates to user; list name still opens list.
- [ ] Home feed: people-only / saved-from-others — same expectations for "Also saved by" / "Captured by".
- [ ] Profile or feed with `showCreator` off but list attribution: `via` row fully tappable; `+N` and row background open modal; single slug row navigates to list.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make event attribution rows and the list-only “via” fallback fully tappable. Taps open “From these Soonlists” when there are multiple people or lists, or deep-link to the single profile/list, with no pass-through to the event card.

- **New Features**
  - Full-width press capture on attribution rows and the fallback “via” row to block taps from hitting the event card.
  - Smart routing: multiple savers/lists open the From these Soonlists sheet; a single saver/list navigates to their profile/list.
  - MySoonlistRow “Captured by”: when there’s a creator + saver(s), the row and avatar stack always open From these Soonlists; the creator chip still links to the profile.
  - Consistent touch targets and accessibility: avatar stack, “+N” pill, and the row trigger the same action; name links disable when multiple; PeoplePrimary and fallback rows have press feedback and reuse `OverflowPill` for the “+N” chip.

<sup>Written for commit a02f13331a024db9a8b384c31e0788774d855316. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes attribution rows fully tappable by wrapping them in `Pressable`, implementing smart routing (modal for multiple savers/lists, direct navigation for a single one) across `MySoonlistRow`, `MySceneRow`, `PeoplePrimaryRow`, and the list-only \"via\" fallback in `UserEventsList`. The logic is well-structured: `OverflowPill` safely guards its own `count <= 0` case, `nameLinksEnabled` is toggled correctly to avoid competing tap targets, and `onFallbackListAttributionRowPress` properly gates modal vs. list navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style suggestions with no correctness or data-integrity impact.

No P0 or P1 issues found. The routing logic is correct and consistent across all row variants. The only note is a P2 about nested Pressable touch propagation in PeoplePrimaryRow, which is a known RN pattern that works correctly in practice and is covered by the test plan.

No files require special attention; manually verify the isOwnEvent + hasAnyListInfo path in PeoplePrimaryRow on both iOS and Android as part of the existing test plan.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/expo/src/components/EventAttributionRow.tsx | Adds full-width Pressable to RowWrapper and smart multi-vs-single routing (modal vs. navigate) across MySoonlistRow, MySceneRow, and PeoplePrimaryRow. Logic is correct; OverflowPill guard and nameLinksEnabled toggling are consistent. |
| apps/expo/src/components/UserEventsList.tsx | Replaces the bare View list-only "via" row with a full-width Pressable and reuses OverflowPill. onFallbackListAttributionRowPress logic correctly gates modal vs. list navigation; OverflowPill safely returns null at count=0. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps attribution row] --> B{Row type?}

    B --> C[MySoonlistRow / MySceneRow]
    B --> D[PeoplePrimaryRow]
    B --> E[Fallback via row]

    C --> F{Multiple savers/people?}
    F -- Yes --> G[Open SavedByModal]
    F -- No --> H{Single saver exists?}
    H -- Yes --> I[Navigate to user profile]
    H -- No --> G

    D --> J{isOwnEvent?}
    J -- Yes --> K{hasAnyListInfo?}
    K -- Yes --> G
    K -- No --> I
    J -- No --> L{isMultiUser?}
    L -- Yes --> G
    L -- No --> I

    E --> M{fallbackOverflowCount > 0 OR no slug?}
    M -- Yes --> N[Open FallbackSavedByModal]
    M -- No --> O[Navigate to list]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/expo/src/components/EventAttributionRow.tsx`, line 659-666 ([link](https://github.com/jaronheard/soonlist-turbo/blob/4dc74c57cc40846b28793450c86a58c2651f229d/apps/expo/src/components/EventAttributionRow.tsx#L659-L666)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Nested Pressable relies on implicit RN touch propagation**

   In `PeoplePrimaryRow`, when `isOwnEvent && hasAnyListInfo`, the outer `Pressable`'s `onRowPress` calls `openFromSoonlists()`, but the inner "You" chip `Pressable` calls `navigateToUser(creator, currentUserId)`. The intended split (chip → profile, background → modal) relies on React Native's responder system preventing the outer handler from firing when the inner one claims the touch. This generally works, but nested-Pressable double-firing is a known, platform-dependent pitfall. If the outer also fires, you'd get both a push navigation and the modal opening simultaneously. Consider using a `TouchableWithoutFeedback` (or a plain `View`) as the outer touch target for just the background area to make the behavior explicit, or verify the interaction on both iOS and Android.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/src/components/EventAttributionRow.tsx
   Line: 659-666

   Comment:
   **Nested Pressable relies on implicit RN touch propagation**

   In `PeoplePrimaryRow`, when `isOwnEvent && hasAnyListInfo`, the outer `Pressable`'s `onRowPress` calls `openFromSoonlists()`, but the inner "You" chip `Pressable` calls `navigateToUser(creator, currentUserId)`. The intended split (chip → profile, background → modal) relies on React Native's responder system preventing the outer handler from firing when the inner one claims the touch. This generally works, but nested-Pressable double-firing is a known, platform-dependent pitfall. If the outer also fires, you'd get both a push navigation and the modal opening simultaneously. Consider using a `TouchableWithoutFeedback` (or a plain `View`) as the outer touch target for just the background area to make the behavior explicit, or verify the interaction on both iOS and Android.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/EventAttributionRow.tsx
Line: 659-666

Comment:
**Nested Pressable relies on implicit RN touch propagation**

In `PeoplePrimaryRow`, when `isOwnEvent && hasAnyListInfo`, the outer `Pressable`'s `onRowPress` calls `openFromSoonlists()`, but the inner "You" chip `Pressable` calls `navigateToUser(creator, currentUserId)`. The intended split (chip → profile, background → modal) relies on React Native's responder system preventing the outer handler from firing when the inner one claims the touch. This generally works, but nested-Pressable double-firing is a known, platform-dependent pitfall. If the outer also fires, you'd get both a push navigation and the modal opening simultaneously. Consider using a `TouchableWithoutFeedback` (or a plain `View`) as the outer touch target for just the background area to make the behavior explicit, or verify the interaction on both iOS and Android.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): make event attribution row f..."](https://github.com/jaronheard/soonlist-turbo/commit/4dc74c57cc40846b28793450c86a58c2651f229d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29540858)</sub>

<!-- /greptile_comment -->