### PR TITLE
Sync event follows with personal lists and add backfill migration

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillFollowedEventsToPersonalLists from "../migrations/backfillFollowedEventsToPersonalLists.js";
 import type * as migrations_backfillListFeeds from "../migrations/backfillListFeeds.js";
 import type * as migrations_backfillSourceListId from "../migrations/backfillSourceListId.js";
 import type * as migrations_backfillUserFeedVisibility from "../migrations/backfillUserFeedVisibility.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillFollowedEventsToPersonalLists": typeof migrations_backfillFollowedEventsToPersonalLists;
   "migrations/backfillListFeeds": typeof migrations_backfillListFeeds;
   "migrations/backfillSourceListId": typeof migrations_backfillSourceListId;
   "migrations/backfillUserFeedVisibility": typeof migrations_backfillUserFeedVisibility;

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -589,6 +589,20 @@ export const addEventToListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If the event is no longer linked to this list (e.g. queued fanout from
+    // an earlier write that has since been reverted), skip fanout to avoid
+    // stale followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (!currentMembership) {
+      return;
+    }
+
     const event = await ctx.db
       .query("events")
       .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -643,6 +657,19 @@ export const removeEventFromListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If this scheduled removal is stale and the event is currently linked
+    // to the list again, preserve the followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (currentMembership) {
+      return;
+    }
+
     const listFollows = await ctx.db
       .query("listFollows")
       .withIndex("by_list", (q) => q.eq("listId", listId))

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -79,6 +79,12 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     const nextCursor = result.isDone ? null : result.continueCursor;
 
+    if (!result.isDone && result.page.length === 0) {
+      throw new Error(
+        `backfillFollowedEventsToPersonalListsBatch: paginator returned an empty page at cursor ${cursor} before completion`,
+      );
+    }
+
     if (!result.isDone && nextCursor !== cursor) {
       await ctx.scheduler.runAfter(
         0,
@@ -90,7 +96,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         },
       );
     } else if (!result.isDone) {
-      console.error(
+      throw new Error(
         `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
       );
     }

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -34,6 +34,15 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
     const personalListIdsByUser = new Map<string, string>();
 
     for (const follow of result.page) {
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", follow.eventId))
+        .first();
+
+      if (!event) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
+import { getOrCreatePersonalList } from "../lists";
+
+const DEFAULT_BATCH_SIZE = 50;
+
+/**
+ * Backfill direct event follows into each follower's personal Soonlist.
+ *
+ * Idempotent: existing eventToLists links are skipped via by_event_and_list.
+ * Each follower-feed fan-out is scheduled separately so a large personal-list
+ * audience does not count against this batch transaction.
+ */
+export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    linked: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("eventFollows")
+      .paginate({ numItems: batchSize, cursor });
+
+    let linked = 0;
+    const personalListIdsByUser = new Map<string, string>();
+
+    for (const follow of result.page) {
+      let personalListId = personalListIdsByUser.get(follow.userId);
+      if (!personalListId) {
+        const personalList = await getOrCreatePersonalList(ctx, follow.userId);
+        personalListId = personalList.id;
+        personalListIdsByUser.set(follow.userId, personalListId);
+      }
+
+      const existing = await ctx.db
+        .query("eventToLists")
+        .withIndex("by_event_and_list", (q) =>
+          q.eq("eventId", follow.eventId).eq("listId", personalListId),
+        )
+        .first();
+
+      if (existing) {
+        continue;
+      }
+
+      await ctx.db.insert("eventToLists", {
+        eventId: follow.eventId,
+        listId: personalListId,
+      });
+      await addEventToListFeedInline(ctx, follow.eventId, personalListId);
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addEventToListFollowersFeeds,
+        {
+          eventId: follow.eventId,
+          listId: personalListId,
+        },
+      );
+      linked++;
+    }
+
+    const nextCursor = result.isDone ? null : result.continueCursor;
+
+    if (!result.isDone && nextCursor !== cursor) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfillFollowedEventsToPersonalLists
+          .backfillFollowedEventsToPersonalListsBatch,
+        {
+          cursor: nextCursor,
+          batchSize,
+        },
+      );
+    } else if (!result.isDone) {
+      console.error(
+        `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
+      );
+    }
+
+    return {
+      processed: result.page.length,
+      linked,
+      nextCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+export const backfillFollowedEventsToPersonalLists = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { batchSize }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.migrations.backfillFollowedEventsToPersonalLists
+        .backfillFollowedEventsToPersonalListsBatch,
+      {
+        cursor: null,
+        batchSize: batchSize ?? DEFAULT_BATCH_SIZE,
+      },
+    );
+    return null;
+  },
+});

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -32,6 +32,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     let linked = 0;
     const personalListIdsByUser = new Map<string, string>();
+    const missingUserIds = new Set<string>();
 
     for (const follow of result.page) {
       const event = await ctx.db
@@ -43,8 +44,22 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         continue;
       }
 
+      if (missingUserIds.has(follow.userId)) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
+        const user = await ctx.db
+          .query("users")
+          .withIndex("by_custom_id", (q) => q.eq("id", follow.userId))
+          .first();
+
+        if (!user) {
+          missingUserIds.add(follow.userId);
+          continue;
+        }
+
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);
         personalListId = personalList.id;
         personalListIdsByUser.set(follow.userId, personalListId);

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1259,6 +1259,9 @@ export async function followEvent(
         userId,
         eventId,
       });
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await addEventToList(ctx, eventId, personalList.id, userId);
     }
   }
 
@@ -1294,6 +1297,9 @@ export async function unfollowEvent(
       if (isCreator) {
         return await getEventById(ctx, eventId);
       }
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await removeEventFromList(ctx, eventId, personalList.id, userId);
 
       const listFollows = await ctx.db
         .query("listFollows")

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1260,6 +1260,8 @@ export async function followEvent(
         eventId,
       });
 
+      // Keep personal list membership in sync with follows so subscribers of
+      // this user's Soonlist see the same public events.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await addEventToList(ctx, eventId, personalList.id, userId);
     }
@@ -1298,6 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
+      // Remove followed events from the user's personal list so list
+      // subscribers lose this source unless the event still exists in another
+      // followed list.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 
@@ -1411,11 +1416,16 @@ export async function addEventToList(
     // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Add event to followers' feeds
-    await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
-      eventId,
-      listId,
-    });
+    // Add event to followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.feedHelpers.addEventToListFollowersFeeds,
+      {
+        eventId,
+        listId,
+      },
+    );
   }
 }
 
@@ -1480,8 +1490,10 @@ export async function removeEventFromList(
     // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Remove event from followers' feeds
-    await ctx.runMutation(
+    // Remove event from followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
         eventId,

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1300,9 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
-      // Remove followed events from the user's personal list so list
-      // subscribers lose this source unless the event still exists in another
-      // followed list.
+      // Personal list membership is source-of-truth for a user's Soonlist.
+      // Follow-created entries are not separately tagged from manually-added
+      // entries, so unfollow removes this personal-list link by design.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 


### PR DESCRIPTION
## Summary

Reimplements #1052 from the pull request description only.

- Keeps direct event follows in sync with each user's personal Soonlist by adding/removing personal-list membership during follow/unfollow.
- Adds an idempotent batched migration to backfill existing `eventFollows` into followers' personal lists.
- Schedules follower-feed fan-out and batch chaining through Convex scheduling to avoid running fan-out work inside the initiating transaction.
- Guards scheduled list feed fan-out/removal against stale jobs so current `eventToLists` membership remains the source of truth.

## Testing

- `pnpm -F @soonlist/backend typecheck`
- `pnpm -F @soonlist/backend lint` (passes with existing warnings)
- `pnpm -F @soonlist/backend format`