### PR TITLE
feat(backend): sync followed events to personal lists

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillFollowedEventsToPersonalLists from "../migrations/backfillFollowedEventsToPersonalLists.js";
 import type * as migrations_backfillListFeeds from "../migrations/backfillListFeeds.js";
 import type * as migrations_backfillSourceListId from "../migrations/backfillSourceListId.js";
 import type * as migrations_backfillUserFeedVisibility from "../migrations/backfillUserFeedVisibility.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillFollowedEventsToPersonalLists": typeof migrations_backfillFollowedEventsToPersonalLists;
   "migrations/backfillListFeeds": typeof migrations_backfillListFeeds;
   "migrations/backfillSourceListId": typeof migrations_backfillSourceListId;
   "migrations/backfillUserFeedVisibility": typeof migrations_backfillUserFeedVisibility;

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -589,6 +589,20 @@ export const addEventToListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If the event is no longer linked to this list (e.g. queued fanout from
+    // an earlier write that has since been reverted), skip fanout to avoid
+    // stale followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (!currentMembership) {
+      return;
+    }
+
     const event = await ctx.db
       .query("events")
       .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -643,6 +657,19 @@ export const removeEventFromListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If this scheduled removal is stale and the event is currently linked
+    // to the list again, preserve the followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (currentMembership) {
+      return;
+    }
+
     const listFollows = await ctx.db
       .query("listFollows")
       .withIndex("by_list", (q) => q.eq("listId", listId))

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -79,6 +79,12 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     const nextCursor = result.isDone ? null : result.continueCursor;
 
+    if (!result.isDone && result.page.length === 0) {
+      throw new Error(
+        `backfillFollowedEventsToPersonalListsBatch: paginator returned an empty page at cursor ${cursor} before completion`,
+      );
+    }
+
     if (!result.isDone && nextCursor !== cursor) {
       await ctx.scheduler.runAfter(
         0,
@@ -90,7 +96,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         },
       );
     } else if (!result.isDone) {
-      console.error(
+      throw new Error(
         `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
       );
     }

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -34,6 +34,15 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
     const personalListIdsByUser = new Map<string, string>();
 
     for (const follow of result.page) {
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", follow.eventId))
+        .first();
+
+      if (!event) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
+import { getOrCreatePersonalList } from "../lists";
+
+const DEFAULT_BATCH_SIZE = 50;
+
+/**
+ * Backfill direct event follows into each follower's personal Soonlist.
+ *
+ * Idempotent: existing eventToLists links are skipped via by_event_and_list.
+ * Each follower-feed fan-out is scheduled separately so a large personal-list
+ * audience does not count against this batch transaction.
+ */
+export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    linked: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("eventFollows")
+      .paginate({ numItems: batchSize, cursor });
+
+    let linked = 0;
+    const personalListIdsByUser = new Map<string, string>();
+
+    for (const follow of result.page) {
+      let personalListId = personalListIdsByUser.get(follow.userId);
+      if (!personalListId) {
+        const personalList = await getOrCreatePersonalList(ctx, follow.userId);
+        personalListId = personalList.id;
+        personalListIdsByUser.set(follow.userId, personalListId);
+      }
+
+      const existing = await ctx.db
+        .query("eventToLists")
+        .withIndex("by_event_and_list", (q) =>
+          q.eq("eventId", follow.eventId).eq("listId", personalListId),
+        )
+        .first();
+
+      if (existing) {
+        continue;
+      }
+
+      await ctx.db.insert("eventToLists", {
+        eventId: follow.eventId,
+        listId: personalListId,
+      });
+      await addEventToListFeedInline(ctx, follow.eventId, personalListId);
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addEventToListFollowersFeeds,
+        {
+          eventId: follow.eventId,
+          listId: personalListId,
+        },
+      );
+      linked++;
+    }
+
+    const nextCursor = result.isDone ? null : result.continueCursor;
+
+    if (!result.isDone && nextCursor !== cursor) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfillFollowedEventsToPersonalLists
+          .backfillFollowedEventsToPersonalListsBatch,
+        {
+          cursor: nextCursor,
+          batchSize,
+        },
+      );
+    } else if (!result.isDone) {
+      console.error(
+        `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
+      );
+    }
+
+    return {
+      processed: result.page.length,
+      linked,
+      nextCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+export const backfillFollowedEventsToPersonalLists = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { batchSize }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.migrations.backfillFollowedEventsToPersonalLists
+        .backfillFollowedEventsToPersonalListsBatch,
+      {
+        cursor: null,
+        batchSize: batchSize ?? DEFAULT_BATCH_SIZE,
+      },
+    );
+    return null;
+  },
+});

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -32,6 +32,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     let linked = 0;
     const personalListIdsByUser = new Map<string, string>();
+    const missingUserIds = new Set<string>();
 
     for (const follow of result.page) {
       const event = await ctx.db
@@ -43,8 +44,22 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         continue;
       }
 
+      if (missingUserIds.has(follow.userId)) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
+        const user = await ctx.db
+          .query("users")
+          .withIndex("by_custom_id", (q) => q.eq("id", follow.userId))
+          .first();
+
+        if (!user) {
+          missingUserIds.add(follow.userId);
+          continue;
+        }
+
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);
         personalListId = personalList.id;
         personalListIdsByUser.set(follow.userId, personalListId);

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1259,6 +1259,9 @@ export async function followEvent(
         userId,
         eventId,
       });
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await addEventToList(ctx, eventId, personalList.id, userId);
     }
   }
 
@@ -1294,6 +1297,9 @@ export async function unfollowEvent(
       if (isCreator) {
         return await getEventById(ctx, eventId);
       }
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await removeEventFromList(ctx, eventId, personalList.id, userId);
 
       const listFollows = await ctx.db
         .query("listFollows")

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1260,6 +1260,8 @@ export async function followEvent(
         eventId,
       });
 
+      // Keep personal list membership in sync with follows so subscribers of
+      // this user's Soonlist see the same public events.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await addEventToList(ctx, eventId, personalList.id, userId);
     }
@@ -1298,6 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
+      // Remove followed events from the user's personal list so list
+      // subscribers lose this source unless the event still exists in another
+      // followed list.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 
@@ -1411,11 +1416,16 @@ export async function addEventToList(
     // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Add event to followers' feeds
-    await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
-      eventId,
-      listId,
-    });
+    // Add event to followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.feedHelpers.addEventToListFollowersFeeds,
+      {
+        eventId,
+        listId,
+      },
+    );
   }
 }
 
@@ -1480,8 +1490,10 @@ export async function removeEventFromList(
     // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Remove event from followers' feeds
-    await ctx.runMutation(
+    // Remove event from followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
         eventId,

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1300,9 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
-      // Remove followed events from the user's personal list so list
-      // subscribers lose this source unless the event still exists in another
-      // followed list.
+      // Personal list membership is source-of-truth for a user's Soonlist.
+      // Follow-created entries are not separately tagged from manually-added
+      // entries, so unfollow removes this personal-list link by design.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 


### PR DESCRIPTION
## Summary

Syncs direct event follows into each follower's personal Soonlist so their subscribers see the same public events they do. Includes a backfill migration for existing follows and hardens the list-feed fanout against scheduler races and mutation limits.

## Changes

### Features
- On `followEvent`, add the event to the follower's personal list (via `getOrCreatePersonalList`), which triggers the normal list-feed fanout to that user's subscribers.
- On `unfollowEvent`, remove the event from the follower's personal list. Follow-created links are not distinguished from manually-added ones — unfollow removes the personal-list link by design.
- New `migrations/backfillFollowedEventsToPersonalLists` internal mutation: paginates `eventFollows`, creates personal-list links idempotently (guarded by `by_event_and_list`), runs the inline per-user feed write synchronously, and schedules follower-feed fanout separately.

### Bug Fixes / Hardening
- `addEventToListFollowersFeeds` and `removeEventFromListFollowersFeeds` now re-check current `eventToLists` membership before fanning out. Prevents stale scheduled fanout from leaving orphaned `followedLists` entries when a prior write was reverted, or from clearing entries when the link was re-added.
- Backfill skips follows whose `userId` has no matching user row (orphaned follows) and caches the missing-user set per batch.
- Backfill aborts if the paginator stalls (non-empty page / cursor unchanged) to avoid infinite reschedules.

### Refactoring
- `addEventToList` and `removeEventFromList` now schedule follower-feed fanout via `ctx.scheduler.runAfter(0, ...)` instead of `ctx.runMutation(...)`. Keeps the triggering mutation small and avoids document-read/write limits when a list has many followers.

## Files Changed

- `packages/backend/convex/model/events.ts` — wire personal-list sync into follow/unfollow; move follower-feed fanout to scheduler.
- `packages/backend/convex/feedHelpers.ts` — add current-membership guards on add/remove followers-feeds mutations.
- `packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts` — new paginated, idempotent backfill.
- `packages/backend/convex/_generated/api.d.ts` — regenerated for new migration module.

## Test Plan

- [ ] Follow a public event as user B where user A subscribes to B's Soonlist; confirm the event appears in A's feed.
- [ ] Unfollow the same event; confirm it disappears from A's feed and from B's personal list.
- [ ] Run `backfillFollowedEventsToPersonalLists` in a dev deployment against seeded `eventFollows`; verify personal-list entries created, idempotent on re-run, orphaned follows skipped.
- [ ] Exercise a list with many followers (or simulate) to confirm the scheduler-based fanout avoids hitting mutation limits.
- [ ] Verify stale scheduled fanout is skipped when membership has since changed (add-then-remove and remove-then-add races).

## Notes

- Reimplementation of PR #1052, opened on a fresh branch for a clean AI code review.
- Original branch: `codex/reimplement-pr-1052-follow-sync` (still present).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync direct event follows into each user’s personal Soonlist so their subscribers see the same public events. Includes an idempotent backfill and safer, scalable fanout.

- **New Features**
  - On follow, add the event to the follower’s personal list; on unfollow, remove it.
  - Added `migrations/backfillFollowedEventsToPersonalLists` to paginate existing follows and create list links idempotently.

- **Bug Fixes**
  - Fanout mutations now re-check `eventToLists` membership to skip stale jobs.
  - Follower-feed fanout moved to `ctx.scheduler.runAfter(0, ...)` to avoid mutation limits.
  - Backfill skips orphaned follow users and aborts if the paginator stalls.

<sup>Written for commit a58987ae06cfdd2fc359cdb7da04d975dce9dfc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs direct event follows into each follower's personal Soonlist by wiring `getOrCreatePersonalList` + `addEventToList`/`removeEventFromList` into `followEvent`/`unfollowEvent`, and adds a paginated backfill migration for existing follows. It also hardens scheduled fanout by adding a current-membership re-check at the start of both `addEventToListFollowersFeeds` and `removeEventFromListFollowersFeeds`, and moves those fanout calls from `ctx.runMutation` to `ctx.scheduler.runAfter(0, ...)` to stay within mutation write limits for large lists.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming the intentional unfollow-removes-manual-entry product decision is acceptable.

All remaining findings are P2. The stall-detection comment is purely informational. The design decision in unfollowEvent is explicitly documented as intentional by the author, but it is a lossy operation (removes manually-added personal-list links on unfollow) that warrants explicit product sign-off before shipping.

packages/backend/convex/model/events.ts — unfollowEvent's unconditional personal-list removal

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/model/events.ts | Wires personal-list sync into followEvent/unfollowEvent and switches follower-feed fanout from inline ctx.runMutation to ctx.scheduler.runAfter(0); the unfollow path unconditionally removes personal-list links regardless of how they were created, which is documented as intentional but is a lossy design. |
| packages/backend/convex/feedHelpers.ts | Adds a current-membership guard at the top of both addEventToListFollowersFeeds and removeEventFromListFollowersFeeds to make scheduled fanout idempotent under add/remove races; logic is correct and symmetric. |
| packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts | New paginated, idempotent backfill mutation; correctly caches personalListId per user, skips orphaned follows, uses by_event_and_list to guard duplicates, and aborts on cursor stall; the stall detection only applies meaningfully after the first page but is functionally safe. |
| packages/backend/convex/_generated/api.d.ts | Regenerated type declarations for the new backfillFollowedEventsToPersonalLists migration module; no manual changes required. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (follower)
    participant FE as followEvent / unfollowEvent
    participant PL as getOrCreatePersonalList
    participant ATL as addEventToList / removeEventFromList
    participant FH as feedHelpers (inline)
    participant SCH as Convex Scheduler
    participant AELF as addEventToListFollowersFeeds
    participant RELF as removeEventFromListFollowersFeeds

    U->>FE: followEvent(userId, eventId)
    FE->>PL: getOrCreatePersonalList(userId)
    PL-->>FE: personalList
    FE->>ATL: addEventToList(eventId, personalList.id, userId)
    ATL->>FH: addEventToListFeedInline (sync)
    ATL->>SCH: runAfter(0, addEventToListFollowersFeeds)
    SCH->>AELF: [separate tx] check membership → fanout to list subscribers

    U->>FE: unfollowEvent(userId, eventId)
    FE->>PL: getOrCreatePersonalList(userId)
    PL-->>FE: personalList
    FE->>ATL: removeEventFromList(eventId, personalList.id, userId)
    ATL->>FH: removeEventFromListFeedInline (sync)
    ATL->>SCH: runAfter(0, removeEventFromListFollowersFeeds)
    SCH->>RELF: [separate tx] check membership → remove from list subscribers' feeds
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/model/events.ts
Line: 1303-1307

Comment:
**Unfollow silently removes manually-added personal list entries**

`removeEventFromList` is called unconditionally on unfollow, so if a user first added an event to their personal list manually and later also followed that event (or vice-versa), unfollowing will silently delete the personal-list link they created themselves. There is no tagging to distinguish follow-created links from manually-added ones, so the two actions are permanently coupled. The PR description acknowledges this as "by design," but it is a one-way, lossy operation that could surprise users (and is hard to recover from without a re-add). Consider whether this product decision has been explicitly reviewed, or whether a reference-count / source tag on the `eventToLists` row would be a safer approach.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
Line: 104-116

Comment:
**Stall detection only meaningful after the first page**

`nextCursor !== cursor` uses strict equality. For the very first invocation `cursor` is `null` and `nextCursor` is `result.continueCursor` (a string), so they will never be equal and the stall branch is unreachable for the first page. This is correct behavior and causes no bug — the empty-page guard above already handles the pathological first-page case — but a clarifying comment noting that the stall check only applies when `cursor !== null` would help future maintainers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(backend): skip orphaned follow users..."](https://github.com/jaronheard/soonlist-turbo/commit/a58987ae06cfdd2fc359cdb7da04d975dce9dfc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29547471)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->