### PR TITLE
feat(backend): sync followed events to personal lists (re-land with fix)

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as files from "../files.js";
 import type * as guestOnboarding from "../guestOnboarding.js";
 import type * as http from "../http.js";
 import type * as lists from "../lists.js";
+import type * as migrations_backfillFollowedEventsToPersonalLists from "../migrations/backfillFollowedEventsToPersonalLists.js";
 import type * as migrations_backfillListFeeds from "../migrations/backfillListFeeds.js";
 import type * as migrations_backfillSourceListId from "../migrations/backfillSourceListId.js";
 import type * as migrations_backfillUserFeedVisibility from "../migrations/backfillUserFeedVisibility.js";
@@ -76,6 +77,7 @@ declare const fullApi: ApiFromModules<{
   guestOnboarding: typeof guestOnboarding;
   http: typeof http;
   lists: typeof lists;
+  "migrations/backfillFollowedEventsToPersonalLists": typeof migrations_backfillFollowedEventsToPersonalLists;
   "migrations/backfillListFeeds": typeof migrations_backfillListFeeds;
   "migrations/backfillSourceListId": typeof migrations_backfillSourceListId;
   "migrations/backfillUserFeedVisibility": typeof migrations_backfillUserFeedVisibility;

--- a/packages/backend/convex/feedHelpers.ts
+++ b/packages/backend/convex/feedHelpers.ts
@@ -589,6 +589,20 @@ export const addEventToListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If the event is no longer linked to this list (e.g. queued fanout from
+    // an earlier write that has since been reverted), skip fanout to avoid
+    // stale followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (!currentMembership) {
+      return;
+    }
+
     const event = await ctx.db
       .query("events")
       .withIndex("by_custom_id", (q) => q.eq("id", eventId))
@@ -643,6 +657,19 @@ export const removeEventFromListFollowersFeeds = internalMutation({
     listId: v.string(),
   },
   handler: async (ctx, { eventId, listId }) => {
+    // If this scheduled removal is stale and the event is currently linked
+    // to the list again, preserve the followedLists entries.
+    const currentMembership = await ctx.db
+      .query("eventToLists")
+      .withIndex("by_event_and_list", (q) =>
+        q.eq("eventId", eventId).eq("listId", listId),
+      )
+      .first();
+
+    if (currentMembership) {
+      return;
+    }
+
     const listFollows = await ctx.db
       .query("listFollows")
       .withIndex("by_list", (q) => q.eq("listId", listId))

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -79,6 +79,12 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     const nextCursor = result.isDone ? null : result.continueCursor;
 
+    if (!result.isDone && result.page.length === 0) {
+      throw new Error(
+        `backfillFollowedEventsToPersonalListsBatch: paginator returned an empty page at cursor ${cursor} before completion`,
+      );
+    }
+
     if (!result.isDone && nextCursor !== cursor) {
       await ctx.scheduler.runAfter(
         0,
@@ -90,7 +96,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         },
       );
     } else if (!result.isDone) {
-      console.error(
+      throw new Error(
         `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
       );
     }

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -34,6 +34,15 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
     const personalListIdsByUser = new Map<string, string>();
 
     for (const follow of result.page) {
+      const event = await ctx.db
+        .query("events")
+        .withIndex("by_custom_id", (q) => q.eq("id", follow.eventId))
+        .first();
+
+      if (!event) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -1,0 +1,115 @@
+import { v } from "convex/values";
+
+import { internal } from "../_generated/api";
+import { internalMutation } from "../_generated/server";
+import { addEventToListFeedInline } from "../feedHelpers";
+import { getOrCreatePersonalList } from "../lists";
+
+const DEFAULT_BATCH_SIZE = 50;
+
+/**
+ * Backfill direct event follows into each follower's personal Soonlist.
+ *
+ * Idempotent: existing eventToLists links are skipped via by_event_and_list.
+ * Each follower-feed fan-out is scheduled separately so a large personal-list
+ * audience does not count against this batch transaction.
+ */
+export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    batchSize: v.number(),
+  },
+  returns: v.object({
+    processed: v.number(),
+    linked: v.number(),
+    nextCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
+  handler: async (ctx, { cursor, batchSize }) => {
+    const result = await ctx.db
+      .query("eventFollows")
+      .paginate({ numItems: batchSize, cursor });
+
+    let linked = 0;
+    const personalListIdsByUser = new Map<string, string>();
+
+    for (const follow of result.page) {
+      let personalListId = personalListIdsByUser.get(follow.userId);
+      if (!personalListId) {
+        const personalList = await getOrCreatePersonalList(ctx, follow.userId);
+        personalListId = personalList.id;
+        personalListIdsByUser.set(follow.userId, personalListId);
+      }
+
+      const existing = await ctx.db
+        .query("eventToLists")
+        .withIndex("by_event_and_list", (q) =>
+          q.eq("eventId", follow.eventId).eq("listId", personalListId),
+        )
+        .first();
+
+      if (existing) {
+        continue;
+      }
+
+      await ctx.db.insert("eventToLists", {
+        eventId: follow.eventId,
+        listId: personalListId,
+      });
+      await addEventToListFeedInline(ctx, follow.eventId, personalListId);
+      await ctx.scheduler.runAfter(
+        0,
+        internal.feedHelpers.addEventToListFollowersFeeds,
+        {
+          eventId: follow.eventId,
+          listId: personalListId,
+        },
+      );
+      linked++;
+    }
+
+    const nextCursor = result.isDone ? null : result.continueCursor;
+
+    if (!result.isDone && nextCursor !== cursor) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.migrations.backfillFollowedEventsToPersonalLists
+          .backfillFollowedEventsToPersonalListsBatch,
+        {
+          cursor: nextCursor,
+          batchSize,
+        },
+      );
+    } else if (!result.isDone) {
+      console.error(
+        `backfillFollowedEventsToPersonalListsBatch: cursor stalled at ${cursor} after ${result.page.length} follows - aborting`,
+      );
+    }
+
+    return {
+      processed: result.page.length,
+      linked,
+      nextCursor,
+      isDone: result.isDone,
+    };
+  },
+});
+
+export const backfillFollowedEventsToPersonalLists = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  returns: v.null(),
+  handler: async (ctx, { batchSize }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.migrations.backfillFollowedEventsToPersonalLists
+        .backfillFollowedEventsToPersonalListsBatch,
+      {
+        cursor: null,
+        batchSize: batchSize ?? DEFAULT_BATCH_SIZE,
+      },
+    );
+    return null;
+  },
+});

--- a/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
+++ b/packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
@@ -32,6 +32,7 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
 
     let linked = 0;
     const personalListIdsByUser = new Map<string, string>();
+    const missingUserIds = new Set<string>();
 
     for (const follow of result.page) {
       const event = await ctx.db
@@ -43,8 +44,22 @@ export const backfillFollowedEventsToPersonalListsBatch = internalMutation({
         continue;
       }
 
+      if (missingUserIds.has(follow.userId)) {
+        continue;
+      }
+
       let personalListId = personalListIdsByUser.get(follow.userId);
       if (!personalListId) {
+        const user = await ctx.db
+          .query("users")
+          .withIndex("by_custom_id", (q) => q.eq("id", follow.userId))
+          .first();
+
+        if (!user) {
+          missingUserIds.add(follow.userId);
+          continue;
+        }
+
         const personalList = await getOrCreatePersonalList(ctx, follow.userId);
         personalListId = personalList.id;
         personalListIdsByUser.set(follow.userId, personalListId);

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1024,8 +1024,27 @@ export async function updateEvent(
       lists.filter((l) => l.value).map((l) => l.value),
     );
 
+    // System lists (e.g. each user's personal Soonlist) are managed by
+    // createEvent/followEvent/unfollowEvent and never appear in the client's
+    // `lists` payload. Exclude them from this reconciliation so editing an
+    // event doesn't silently remove it from the creator's or any follower's
+    // personal list.
+    const systemListIds = new Set<string>();
+    for (const listId of existingListIds) {
+      const list = await ctx.db
+        .query("lists")
+        .withIndex("by_custom_id", (q) => q.eq("id", listId))
+        .first();
+      if (list?.isSystemList) {
+        systemListIds.add(listId);
+      }
+    }
+
     // Delete existing list associations that are no longer in the new list
     for (const etl of existingEventToLists) {
+      if (systemListIds.has(etl.listId)) {
+        continue;
+      }
       if (!newListIds.has(etl.listId)) {
         await removeEventFromList(ctx, eventId, etl.listId, userId);
       }

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1259,6 +1259,9 @@ export async function followEvent(
         userId,
         eventId,
       });
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await addEventToList(ctx, eventId, personalList.id, userId);
     }
   }
 
@@ -1294,6 +1297,9 @@ export async function unfollowEvent(
       if (isCreator) {
         return await getEventById(ctx, eventId);
       }
+
+      const personalList = await getOrCreatePersonalList(ctx, userId);
+      await removeEventFromList(ctx, eventId, personalList.id, userId);
 
       const listFollows = await ctx.db
         .query("listFollows")

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1260,6 +1260,8 @@ export async function followEvent(
         eventId,
       });
 
+      // Keep personal list membership in sync with follows so subscribers of
+      // this user's Soonlist see the same public events.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await addEventToList(ctx, eventId, personalList.id, userId);
     }
@@ -1298,6 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
+      // Remove followed events from the user's personal list so list
+      // subscribers lose this source unless the event still exists in another
+      // followed list.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 
@@ -1411,11 +1416,16 @@ export async function addEventToList(
     // paginate efficiently by the userFeeds visibility/hasEnded index.
     await addEventToListFeedInline(ctx, eventId, listId);
 
-    // Add event to followers' feeds
-    await ctx.runMutation(internal.feedHelpers.addEventToListFollowersFeeds, {
-      eventId,
-      listId,
-    });
+    // Add event to followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.feedHelpers.addEventToListFollowersFeeds,
+      {
+        eventId,
+        listId,
+      },
+    );
   }
 }
 
@@ -1480,8 +1490,10 @@ export async function removeEventFromList(
     // followers, mirroring the symmetric write in addEventToList.
     await removeEventFromListFeedInline(ctx, eventId, listId);
 
-    // Remove event from followers' feeds
-    await ctx.runMutation(
+    // Remove event from followers' feeds in a separate transaction to avoid
+    // mutation limits for lists with many followers.
+    await ctx.scheduler.runAfter(
+      0,
       internal.feedHelpers.removeEventFromListFollowersFeeds,
       {
         eventId,

--- a/packages/backend/convex/model/events.ts
+++ b/packages/backend/convex/model/events.ts
@@ -1300,9 +1300,9 @@ export async function unfollowEvent(
         return await getEventById(ctx, eventId);
       }
 
-      // Remove followed events from the user's personal list so list
-      // subscribers lose this source unless the event still exists in another
-      // followed list.
+      // Personal list membership is source-of-truth for a user's Soonlist.
+      // Follow-created entries are not separately tagged from manually-added
+      // entries, so unfollow removes this personal-list link by design.
       const personalList = await getOrCreatePersonalList(ctx, userId);
       await removeEventFromList(ctx, eventId, personalList.id, userId);
 


### PR DESCRIPTION
## Summary

Re-lands PR #1064 (reverted in #1065) with the reconciliation fix included. Syncs direct event follows into each follower's personal Soonlist, adds a backfill migration for existing follows, hardens list-feed fanout, and **excludes system lists from `updateEvent`'s reconciliation loop** so editing an event no longer silently removes it from the creator's or any follower's personal Soonlist.

## Changes

### Features
- `followEvent` adds the event to the follower's personal list (via `getOrCreatePersonalList`), triggering normal list-feed fanout to that user's subscribers.
- `unfollowEvent` removes the event from the follower's personal list. Follow-created links are not distinguished from manually-added ones — unfollow removes the link by design.
- New `migrations/backfillFollowedEventsToPersonalLists` internal mutation: paginates `eventFollows`, creates personal-list links idempotently (guarded by `by_event_and_list`), runs the inline per-user feed write synchronously, and schedules follower-feed fanout separately.

### Bug Fixes / Hardening
- **`updateEvent` now excludes system lists from reconciliation** (`model/events.ts:1012-1052`). Previously the by-event reconciliation loop removed every `eventToLists` entry not in the client-provided `lists` array — including personal-list entries written by `createEvent` and (new here) `followEvent`. The client never sends personal-list IDs, so without this guard every event update would wipe the event from the creator's and all followers' personal Soonlists (and cascade the removal through their subscribers' feeds).
- `addEventToListFollowersFeeds` / `removeEventFromListFollowersFeeds` re-check current `eventToLists` membership before fanning out, so stale scheduled fanout doesn't leave orphaned `followedLists` entries after a reverted write or clear entries when the link was re-added.
- Backfill skips follows whose `userId` has no matching user row (orphaned follows) and caches the missing-user set per batch.
- Backfill aborts if the paginator stalls (non-empty page / cursor unchanged) to avoid infinite reschedules.

### Refactoring
- `addEventToList` and `removeEventFromList` schedule follower-feed fanout via `ctx.scheduler.runAfter(0, ...)` instead of `ctx.runMutation(...)`. Keeps the triggering mutation small and avoids document-read/write limits when a list has many followers.

## Files Changed

- `packages/backend/convex/model/events.ts` — follow/unfollow personal-list sync, system-list guard in `updateEvent` reconciliation, scheduler-based follower-feed fanout.
- `packages/backend/convex/feedHelpers.ts` — current-membership guards on add/remove followers-feeds mutations.
- `packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts` — new paginated, idempotent backfill.
- `packages/backend/convex/_generated/api.d.ts` — regenerated for new migration module.

## Test Plan

- [ ] Follow a public event as user B where user A subscribes to B's Soonlist; confirm it appears in A's feed.
- [ ] Unfollow the same event; confirm it disappears from A's feed and B's personal list.
- [ ] Create event E as user A, follow E as users B & C, then edit E as A; confirm E remains in A's, B's, and C's personal Soonlists (regression test for the reconciliation bug that caused the revert in #1065).
- [ ] Run `backfillFollowedEventsToPersonalLists` against seeded `eventFollows`; verify idempotent, orphaned follows skipped.
- [ ] Exercise a list with many followers to confirm scheduler-based fanout avoids mutation limits.
- [ ] Verify stale scheduled fanout is skipped when membership has since changed (add-then-remove and remove-then-add races).

## Notes

- Supersedes #1064 (merged) and #1065 (revert). The extra commit compared to #1064 is `fix(backend): exclude system lists from updateEvent reconciliation`, which addresses the regression that motivated the revert.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs followed events to each user’s personal Soonlist and makes event edits safe for system lists. Adds a backfill and hardens list-feed fanout to avoid stale writes and mutation limits.

- **Bug Fixes**
  - `updateEvent` excludes system lists from reconciliation so edits don’t remove events from creators’ or followers’ personal Soonlists.
  - Fanout is safer: `internal.feedHelpers.addEventToListFollowersFeeds` and `internal.feedHelpers.removeEventFromListFollowersFeeds` re-check membership to skip stale tasks, and follower fanout is queued via the scheduler to avoid mutation limits.

- **Migration**
  - Run `internal.migrations.backfillFollowedEventsToPersonalLists` to write existing `eventFollows` into personal lists.
  - Idempotent and skips orphaned users; optional `batchSize` (default 50).

<sup>Written for commit c24692ea8ac1e13f681a9d06579619c9d9fc46df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-lands the "sync followed events to personal lists" feature (reverted in #1065) with a critical reconciliation fix: `updateEvent` now excludes system lists from its reconciliation loop, preventing event edits from silently wiping creator and follower personal-list memberships. It also switches follower-feed fanout from inline `ctx.runMutation` calls to `ctx.scheduler.runAfter(0, ...)` to avoid mutation limits on large lists, adds membership guards to stale-fanout paths, and ships an idempotent paginated backfill for existing follows.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 quality/UX suggestions with no blocking correctness issues.

The core reconciliation fix is correct and well-guarded. Fanout scheduling, membership re-checks, and backfill idempotency are all sound. The three flagged items are design trade-offs and minor implementation improvements (sequential reads, stall-guard blind spot on batch 0, and untagged follow/manual list entries), none of which cause data loss or broken user paths under normal operation.

packages/backend/convex/model/events.ts — system-list detection loop and unfollowEvent personal-list removal semantics.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/model/events.ts | Core logic for follow/unfollow personal-list sync and updateEvent reconciliation guard; two P2 concerns: sequential DB reads in system-list detection loop, and unfollow unconditionally removes manually-added entries. |
| packages/backend/convex/feedHelpers.ts | Adds membership guards to add/remove follower-feed fanout mutations to protect against stale scheduled work; logic is correct for all add-then-remove and remove-then-add race orderings. |
| packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts | New idempotent paginated backfill; handles orphaned follows and per-user caching correctly; stall guard has a minor blind spot on batch 0 when cursor is null. |
| packages/backend/convex/_generated/api.d.ts | Auto-generated type declaration updated to expose the new backfill migration module; no issues. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant followEvent
    participant addEventToList
    participant scheduler
    participant addEventToListFollowersFeeds

    Client->>followEvent: follow(userId, eventId)
    followEvent->>followEvent: insert eventFollows
    followEvent->>followEvent: addEventToUserFeed (inline)
    followEvent->>addEventToList: addEventToList(eventId, personalList.id, userId)
    addEventToList->>addEventToList: insert eventToLists
    addEventToList->>addEventToList: addEventToListFeedInline
    addEventToList->>scheduler: runAfter(0, addEventToListFollowersFeeds)
    scheduler-->>addEventToListFollowersFeeds: (async) check membership, fan out to list followers' feeds

    Client->>followEvent: unfollow(userId, eventId)
    followEvent->>followEvent: delete eventFollows
    followEvent->>addEventToList: removeEventFromList(eventId, personalList.id, userId)
    addEventToList->>addEventToList: delete eventToLists
    addEventToList->>addEventToList: removeEventFromListFeedInline
    addEventToList->>scheduler: runAfter(0, removeEventFromListFollowersFeeds)
    scheduler-->>addEventToListFollowersFeeds: (async) check membership absent, remove from followers' feeds
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/model/events.ts
Line: 1322-1326

Comment:
**Unfollow silently removes manually-added personal-list entries**

The comment notes this is intentional, but the implementation does not distinguish between a follow-created link and one the user created by hand. If a user manually adds an event to their Soonlist and later also follows it (or vice-versa), `unfollowEvent` will remove the `eventToLists` link entirely — including any manually-curated intent. This may surprise users who expect their curated list to survive an unfollow action. Consider tracking the origin of each `eventToLists` entry (e.g. a `source` field) so the removal can be conditional on the link being follow-created.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/model/events.ts
Line: 1032-1041

Comment:
**N sequential DB reads per event update for system-list detection**

For each list the event is currently in, a separate `ctx.db.query("lists")` call is issued. For an event in many lists this is O(n) sequential awaits in a single mutation. Since `isSystemList` seldom changes, consider fetching all relevant list documents in one query (e.g. `await Promise.all([...existingListIds].map(...))`) or, better, resolving them from the documents already read earlier in `updateEvent` if they are available.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/backend/convex/migrations/backfillFollowedEventsToPersonalLists.ts
Line: 97-117

Comment:
**Stall guard does not fire on the very first batch when `cursor` is `null`**

The stall guard relies on `nextCursor !== cursor`. On the first call `cursor` is `null` and `nextCursor` is always a non-null string (Convex guarantees a non-null `continueCursor` when `isDone` is false), so the guard can never fire on batch 0. A genuine stall (same page returned repeatedly) will only be detected from the second call onward. In practice the empty-page guard above fires first in all known Convex pathologies, so this is unlikely to cause an infinite reschedule, but the stall detection is less reliable on the initial page than the comment implies.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(backend): exclude system lists from ..."](https://github.com/jaronheard/soonlist-turbo/commit/c24692ea8ac1e13f681a9d06579619c9d9fc46df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29548696)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->