### PR TITLE
feat(expo): iOS 26 tab bar accessory for in-flight captures

### DIFF
--- a/apps/expo/src/app/(tabs)/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/_layout.tsx
@@ -3,7 +3,6 @@ import { NativeTabs } from "expo-router/unstable-native-tabs";
 import { CaptureAccessoryContent } from "~/components/CaptureAccessory";
 import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useAppStore } from "~/store";
-import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 
 // Export Expo Router's error boundary
 export { ErrorBoundary } from "expo-router";
@@ -15,7 +14,7 @@ export const unstable_settings = {
 export default function TabsLayout() {
   const myListBadgeCount = useAppStore((s) => s.myListBadgeCount);
   const communityBadgeCount = useAppStore((s) => s.communityBadgeCount);
-  const accessoryBatchId = useInFlightEventStore((s) => s.accessoryBatchId);
+  const accessoryBatchId = useAppStore((s) => s.accessoryBatchId);
   const showAccessory = SUPPORTS_LIQUID_GLASS && accessoryBatchId !== null;
 
   return (

--- a/apps/expo/src/app/(tabs)/_layout.tsx
+++ b/apps/expo/src/app/(tabs)/_layout.tsx
@@ -1,7 +1,9 @@
 import { NativeTabs } from "expo-router/unstable-native-tabs";
 
+import { CaptureAccessoryContent } from "~/components/CaptureAccessory";
 import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useAppStore } from "~/store";
+import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 
 // Export Expo Router's error boundary
 export { ErrorBoundary } from "expo-router";
@@ -13,6 +15,8 @@ export const unstable_settings = {
 export default function TabsLayout() {
   const myListBadgeCount = useAppStore((s) => s.myListBadgeCount);
   const communityBadgeCount = useAppStore((s) => s.communityBadgeCount);
+  const accessoryBatchId = useInFlightEventStore((s) => s.accessoryBatchId);
+  const showAccessory = SUPPORTS_LIQUID_GLASS && accessoryBatchId !== null;
 
   return (
     <NativeTabs
@@ -22,6 +26,11 @@ export default function TabsLayout() {
         : {})}
       blurEffect="systemChromeMaterialLight" /* interactive-1 */
     >
+      {showAccessory && accessoryBatchId ? (
+        <NativeTabs.BottomAccessory>
+          <CaptureAccessoryContent batchId={accessoryBatchId} />
+        </NativeTabs.BottomAccessory>
+      ) : null}
       <NativeTabs.Trigger name="feed">
         <NativeTabs.Trigger.Label>My Soonlist</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -34,6 +34,7 @@ import { ForceUpdateScreen } from "~/components/ForceUpdateScreen";
 import { PostHogIdentityTracker } from "~/components/PostHogIdentityTracker";
 import { ToastProvider } from "~/components/Toast";
 import { useAppsFlyerDeepLink } from "~/hooks/useAppsFlyerDeepLink";
+import { useCaptureAccessoryLifecycle } from "~/hooks/useCaptureAccessoryLifecycle";
 import { useCaptureCompletionFeedback } from "~/hooks/useCaptureCompletionFeedback";
 import { useForceUpdate } from "~/hooks/useForceUpdate";
 import { useMediaPermissions } from "~/hooks/useMediaPermissions";
@@ -384,6 +385,7 @@ function RootLayoutContent() {
   useAppsFlyerDeepLink();
   usePendingFollow();
   useCaptureCompletionFeedback();
+  useCaptureAccessoryLifecycle();
   const ref = useNavigationContainerRef();
   const pathname = usePathname();
   const params = useGlobalSearchParams();

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -16,7 +16,7 @@ import { useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { useInFlightEventStore } from "~/store/useInFlightEventStore";
+import { useAppStore } from "~/store";
 import Config from "~/utils/config";
 import { logError } from "~/utils/errorLogging";
 import { hapticSelection, hapticSuccess } from "~/utils/feedback";
@@ -37,14 +37,14 @@ interface CaptureAccessoryContentProps {
  * this component are rendered simultaneously — one for the "regular"
  * placement (above the tab bar) and one for "inline" (next to the tab bar
  * when it's minimized). Local state would not be shared between them, so
- * all state lives in `useInFlightEventStore` and the Convex query below
+ * all state lives in `useAppStore` and the Convex query below
  * (deduped across both instances).
  */
 export function CaptureAccessoryContent({
   batchId,
 }: CaptureAccessoryContentProps) {
   const placement = NativeTabs.BottomAccessory.usePlacement();
-  const completedAt = useInFlightEventStore((s) => s.accessoryCompletedAt);
+  const completedAt = useAppStore((s) => s.accessoryCompletedAt);
 
   const status = useQuery(api.eventBatches.getBatchStatus, { batchId });
   const isTerminal =
@@ -86,7 +86,7 @@ export function CaptureAccessoryContent({
 
   const handleDismiss = useCallback(() => {
     void hapticSelection();
-    useInFlightEventStore.getState().dismissAccessoryBatch();
+    useAppStore.getState().dismissAccessoryBatch();
   }, []);
 
   if (placement === "inline") {

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -51,15 +51,12 @@ export function CaptureAccessoryContent({
     status?.status === "completed" || status?.status === "failed";
 
   const handleOpen = useCallback(() => {
-    if (!status) return;
     void hapticSelection();
-    if (!isTerminal) {
-      // While still processing, tap navigates to the batch detail so the
-      // user can watch events stream in.
-      router.navigate(`/batch/${batchId}`);
-      return;
-    }
-    if (status.events.length === 1 && status.events[0]) {
+    // If the single-event path is knowable, prefer it so the tap lands
+    // directly on the event. Otherwise (still loading, still processing,
+    // multi-event batch, or failure), open the batch screen — so a tap
+    // is never dropped just because `getBatchStatus` hasn't resolved.
+    if (isTerminal && status?.events.length === 1 && status.events[0]) {
       router.navigate(`/event/${status.events[0].id}`);
     } else {
       router.navigate(`/batch/${batchId}`);

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -1,0 +1,512 @@
+import type { FunctionReturnType } from "convex/server";
+import React, { useCallback } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  Share,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Image as ExpoImage } from "expo-image";
+import { router } from "expo-router";
+import { NativeTabs } from "expo-router/unstable-native-tabs";
+import { SymbolView } from "expo-symbols";
+import { useQuery } from "convex/react";
+
+import { api } from "@soonlist/backend/convex/_generated/api";
+
+import { useInFlightEventStore } from "~/store/useInFlightEventStore";
+import Config from "~/utils/config";
+import { logError } from "~/utils/errorLogging";
+import { hapticSelection, hapticSuccess } from "~/utils/feedback";
+
+type BatchStatus = FunctionReturnType<typeof api.eventBatches.getBatchStatus>;
+
+const BRAND = "#5A32FB";
+const NEUTRAL_2 = "#627496";
+
+interface CaptureAccessoryContentProps {
+  batchId: string;
+}
+
+/**
+ * CaptureAccessoryContent
+ * -----------------------
+ * Rendered inside `<NativeTabs.BottomAccessory>` (iOS 26+). Two instances of
+ * this component are rendered simultaneously — one for the "regular"
+ * placement (above the tab bar) and one for "inline" (next to the tab bar
+ * when it's minimized). Local state would not be shared between them, so
+ * all state lives in `useInFlightEventStore` and the Convex query below
+ * (deduped across both instances).
+ */
+export function CaptureAccessoryContent({
+  batchId,
+}: CaptureAccessoryContentProps) {
+  const placement = NativeTabs.BottomAccessory.usePlacement();
+  const completedAt = useInFlightEventStore((s) => s.accessoryCompletedAt);
+
+  const status = useQuery(api.eventBatches.getBatchStatus, { batchId });
+  const isTerminal =
+    status?.status === "completed" || status?.status === "failed";
+
+  const handleOpen = useCallback(() => {
+    if (!status) return;
+    void hapticSelection();
+    if (!isTerminal) {
+      // While still processing, tap navigates to the batch detail so the
+      // user can watch events stream in.
+      router.navigate(`/batch/${batchId}`);
+      return;
+    }
+    if (status.events.length === 1 && status.events[0]) {
+      router.navigate(`/event/${status.events[0].id}`);
+    } else if (status.successCount > 0) {
+      router.navigate(`/batch/${batchId}`);
+    } else {
+      router.navigate(`/batch/${batchId}`);
+    }
+  }, [batchId, status, isTerminal]);
+
+  const handleShare = useCallback(async () => {
+    if (!status) return;
+    if (status.events.length !== 1) return;
+    const event = status.events[0];
+    if (!event) return;
+    void hapticSuccess();
+    try {
+      await Share.share({ url: `${Config.apiBaseUrl}/event/${event.id}` });
+    } catch (error) {
+      logError("Error sharing captured event from accessory", error);
+    }
+  }, [status]);
+
+  const handleDismiss = useCallback(() => {
+    void hapticSelection();
+    useInFlightEventStore.getState().dismissAccessoryBatch();
+  }, []);
+
+  if (placement === "inline") {
+    return (
+      <InlineAccessory
+        status={status}
+        isTerminal={isTerminal}
+        onOpen={handleOpen}
+      />
+    );
+  }
+
+  return (
+    <RegularAccessory
+      status={status}
+      isTerminal={isTerminal}
+      completedAt={completedAt}
+      onOpen={handleOpen}
+      onShare={handleShare}
+      onDismiss={handleDismiss}
+    />
+  );
+}
+
+interface RegularAccessoryProps {
+  status: BatchStatus | undefined;
+  isTerminal: boolean;
+  completedAt: number | null;
+  onOpen: () => void;
+  onShare: () => void;
+  onDismiss: () => void;
+}
+
+function RegularAccessory({
+  status,
+  isTerminal,
+  completedAt,
+  onOpen,
+  onShare,
+  onDismiss,
+}: RegularAccessoryProps) {
+  const copy = getAccessoryCopy(status, isTerminal, completedAt);
+  const singleEvent =
+    isTerminal && status?.events.length === 1 ? status.events[0] : null;
+  const imageUrl = singleEvent?.image ?? null;
+
+  return (
+    <View style={styles.regularContainer}>
+      <Pressable
+        onPress={onOpen}
+        accessibilityRole="button"
+        accessibilityLabel={copy.accessibility}
+        accessibilityHint={
+          isTerminal
+            ? "Opens the captured event"
+            : "Opens the batch progress screen"
+        }
+        style={({ pressed }) => [
+          styles.regularPressable,
+          pressed && { opacity: 0.7 },
+        ]}
+      >
+        <AccessoryLeading
+          status={status}
+          isTerminal={isTerminal}
+          imageUrl={imageUrl}
+        />
+        <View style={styles.regularTextColumn}>
+          <Text
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={styles.regularTitle}
+          >
+            {copy.title}
+          </Text>
+          <Text
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={styles.regularSubtitle}
+          >
+            {copy.subtitle}
+          </Text>
+        </View>
+      </Pressable>
+
+      <View style={styles.regularActions}>
+        {isTerminal && singleEvent ? (
+          <Pressable
+            onPress={onShare}
+            accessibilityRole="button"
+            accessibilityLabel="Share event"
+            hitSlop={6}
+            style={({ pressed }) => [
+              styles.actionButton,
+              pressed && { opacity: 0.5 },
+            ]}
+          >
+            <SymbolView
+              name="square.and.arrow.up"
+              size={18}
+              tintColor={BRAND}
+              resizeMode="scaleAspectFit"
+            />
+          </Pressable>
+        ) : null}
+        {isTerminal ? (
+          <Pressable
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel="Dismiss"
+            hitSlop={6}
+            style={({ pressed }) => [
+              styles.actionButton,
+              pressed && { opacity: 0.5 },
+            ]}
+          >
+            <SymbolView
+              name="xmark"
+              size={14}
+              tintColor={NEUTRAL_2}
+              resizeMode="scaleAspectFit"
+            />
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+interface AccessoryLeadingProps {
+  status: BatchStatus | undefined;
+  isTerminal: boolean;
+  imageUrl: string | null;
+}
+
+function AccessoryLeading({
+  status,
+  isTerminal,
+  imageUrl,
+}: AccessoryLeadingProps) {
+  if (!isTerminal || !status) {
+    return (
+      <View style={styles.leading}>
+        <ActivityIndicator color={BRAND} />
+      </View>
+    );
+  }
+  if (status.successCount === 0) {
+    return (
+      <View style={[styles.leading, styles.leadingFailure]}>
+        <SymbolView
+          name="exclamationmark.triangle.fill"
+          size={18}
+          tintColor="#FFFFFF"
+          resizeMode="scaleAspectFit"
+        />
+      </View>
+    );
+  }
+  if (imageUrl) {
+    return (
+      <ExpoImage
+        source={{ uri: `${imageUrl}?w=72&h=72&fit=cover&f=webp&q=80` }}
+        style={styles.leadingImage}
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        transition={120}
+      />
+    );
+  }
+  return (
+    <View style={[styles.leading, styles.leadingSuccess]}>
+      <SymbolView
+        name="checkmark"
+        size={16}
+        tintColor="#FFFFFF"
+        resizeMode="scaleAspectFit"
+      />
+    </View>
+  );
+}
+
+interface InlineAccessoryProps {
+  status: BatchStatus | undefined;
+  isTerminal: boolean;
+  onOpen: () => void;
+}
+
+function InlineAccessory({ status, isTerminal, onOpen }: InlineAccessoryProps) {
+  const label = getInlineLabel(status, isTerminal);
+  return (
+    <Pressable
+      onPress={onOpen}
+      accessibilityRole="button"
+      accessibilityLabel={label ?? "Event capture"}
+      style={({ pressed }) => [
+        styles.inlineContainer,
+        pressed && { opacity: 0.6 },
+      ]}
+      hitSlop={8}
+    >
+      {!isTerminal || !status ? (
+        <ActivityIndicator color={BRAND} />
+      ) : status.successCount === 0 ? (
+        <SymbolView
+          name="exclamationmark.triangle.fill"
+          size={18}
+          tintColor="#B3261E"
+          resizeMode="scaleAspectFit"
+        />
+      ) : (
+        <SymbolView
+          name="checkmark.circle.fill"
+          size={20}
+          tintColor={BRAND}
+          resizeMode="scaleAspectFit"
+        />
+      )}
+      {label ? (
+        <Text numberOfLines={1} style={styles.inlineLabel}>
+          {label}
+        </Text>
+      ) : null}
+    </Pressable>
+  );
+}
+
+interface AccessoryCopy {
+  title: string;
+  subtitle: string;
+  accessibility: string;
+}
+
+function getAccessoryCopy(
+  status: BatchStatus | undefined,
+  isTerminal: boolean,
+  completedAt: number | null,
+): AccessoryCopy {
+  if (!status) {
+    return {
+      title: "Capturing…",
+      subtitle: "Getting things ready",
+      accessibility: "Capturing event",
+    };
+  }
+  const total = status.totalCount;
+  if (!isTerminal) {
+    const plural = total === 1 ? "event" : `${total} events`;
+    return {
+      title: `Capturing ${plural}…`,
+      subtitle:
+        status.progress > 0 ? `${status.progress}% processed` : "Starting up",
+      accessibility: `Capturing ${plural}`,
+    };
+  }
+
+  if (status.successCount === 0) {
+    return {
+      title: "Capture failed",
+      subtitle: total > 1 ? `0 of ${total} events added` : "Tap for details",
+      accessibility: "Capture failed",
+    };
+  }
+
+  if (status.events.length === 1 && status.events[0]) {
+    const event = status.events[0];
+    const name = event.name || "New event";
+    const when = formatWhen(event.startDate, event.startTime);
+    const relative = completedAt ? ` · ${formatRelative(completedAt)}` : "";
+    return {
+      title: name,
+      subtitle: `${when ?? "Event captured"}${relative}`,
+      accessibility: `${name}, captured`,
+    };
+  }
+
+  const successCount = status.successCount;
+  const addedLabel = `${successCount} event${successCount === 1 ? "" : "s"} added`;
+  if (status.failureCount > 0) {
+    return {
+      title: addedLabel,
+      subtitle: `${status.failureCount} didn't capture`,
+      accessibility: `${addedLabel}, ${status.failureCount} failed`,
+    };
+  }
+  return {
+    title: addedLabel,
+    subtitle: "Tap to review",
+    accessibility: addedLabel,
+  };
+}
+
+function getInlineLabel(
+  status: BatchStatus | undefined,
+  isTerminal: boolean,
+): string | null {
+  if (!status || !isTerminal) return null;
+  if (status.successCount === 0) return null;
+  if (status.successCount === 1) return null;
+  return String(status.successCount);
+}
+
+function formatWhen(
+  startDate: string | null,
+  startTime: string | null,
+): string | null {
+  if (!startDate) return null;
+  try {
+    // startDate is an ISO date like "2026-11-22"; build a stable local date
+    // so we render the same calendar day the user saw when capturing.
+    const dateParts = startDate.split("-");
+    const year = dateParts[0] ? parseInt(dateParts[0], 10) : NaN;
+    const month = dateParts[1] ? parseInt(dateParts[1], 10) : NaN;
+    const day = dateParts[2] ? parseInt(dateParts[2], 10) : NaN;
+    if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+      return null;
+    }
+    const date = new Date(year, month - 1, day);
+    const dateLabel = date.toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    if (startTime) {
+      const timeParts = startTime.split(":");
+      const h = timeParts[0] ? parseInt(timeParts[0], 10) : NaN;
+      const m = timeParts[1] ? parseInt(timeParts[1], 10) : NaN;
+      if (!Number.isNaN(h) && !Number.isNaN(m)) {
+        const timed = new Date(date);
+        timed.setHours(h, m, 0, 0);
+        const timeLabel = timed.toLocaleTimeString(undefined, {
+          hour: "numeric",
+          minute: m === 0 ? undefined : "2-digit",
+        });
+        return `${dateLabel} · ${timeLabel}`;
+      }
+    }
+    return dateLabel;
+  } catch {
+    return null;
+  }
+}
+
+function formatRelative(timestampMs: number): string {
+  const deltaSec = Math.max(0, Math.round((Date.now() - timestampMs) / 1000));
+  if (deltaSec < 45) return "just now";
+  const minutes = Math.round(deltaSec / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h ago`;
+}
+
+const styles = StyleSheet.create({
+  regularContainer: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    gap: 8,
+  },
+  regularPressable: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingRight: 4,
+  },
+  regularTextColumn: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  regularTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#0B0B0B",
+  },
+  regularSubtitle: {
+    fontSize: 12,
+    color: NEUTRAL_2,
+    marginTop: 1,
+  },
+  regularActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  actionButton: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 16,
+  },
+  leading: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(90,50,251,0.12)",
+  },
+  leadingSuccess: {
+    backgroundColor: BRAND,
+  },
+  leadingFailure: {
+    backgroundColor: "#B3261E",
+  },
+  leadingImage: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: "#EEE",
+  },
+  inlineContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 4,
+  },
+  inlineLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: BRAND,
+  },
+});

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from "react";
 import {
   ActivityIndicator,
   Pressable,
-  Share,
   StyleSheet,
   Text,
   View,
@@ -17,9 +16,7 @@ import { useQuery } from "convex/react";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { useAppStore } from "~/store";
-import Config from "~/utils/config";
-import { logError } from "~/utils/errorLogging";
-import { hapticSelection, hapticSuccess } from "~/utils/feedback";
+import { hapticSelection } from "~/utils/feedback";
 
 type BatchStatus = FunctionReturnType<typeof api.eventBatches.getBatchStatus>;
 
@@ -71,19 +68,6 @@ export function CaptureAccessoryContent({
     }
   }, [batchId, status, isTerminal]);
 
-  const handleShare = useCallback(async () => {
-    if (!status) return;
-    if (status.events.length !== 1) return;
-    const event = status.events[0];
-    if (!event) return;
-    void hapticSuccess();
-    try {
-      await Share.share({ url: `${Config.apiBaseUrl}/event/${event.id}` });
-    } catch (error) {
-      logError("Error sharing captured event from accessory", error);
-    }
-  }, [status]);
-
   const handleDismiss = useCallback(() => {
     void hapticSelection();
     useAppStore.getState().dismissAccessoryBatch();
@@ -105,7 +89,6 @@ export function CaptureAccessoryContent({
       isTerminal={isTerminal}
       completedAt={completedAt}
       onOpen={handleOpen}
-      onShare={handleShare}
       onDismiss={handleDismiss}
     />
   );
@@ -116,7 +99,6 @@ interface RegularAccessoryProps {
   isTerminal: boolean;
   completedAt: number | null;
   onOpen: () => void;
-  onShare: () => void;
   onDismiss: () => void;
 }
 
@@ -125,14 +107,13 @@ function RegularAccessory({
   isTerminal,
   completedAt,
   onOpen,
-  onShare,
   onDismiss,
 }: RegularAccessoryProps) {
   const copy = getAccessoryCopy(status, isTerminal, completedAt);
   // Only treat this as a single-event capture when the batch was a
   // single-event capture to begin with. Partial-success multi-captures
   // have `events.length === 1` too, but the user needs the batch-level
-  // context, not the single-event Share shortcut.
+  // context — tap opens the batch screen rather than a single event.
   const singleEvent =
     isTerminal && status?.totalCount === 1 && status.events.length === 1
       ? status.events[0]
@@ -178,46 +159,25 @@ function RegularAccessory({
         </View>
       </Pressable>
 
-      <View style={styles.regularActions}>
-        {isTerminal && singleEvent ? (
-          <Pressable
-            onPress={onShare}
-            accessibilityRole="button"
-            accessibilityLabel="Share event"
-            hitSlop={6}
-            style={({ pressed }) => [
-              styles.actionButton,
-              pressed && { opacity: 0.5 },
-            ]}
-          >
-            <SymbolView
-              name="square.and.arrow.up"
-              size={18}
-              tintColor={BRAND}
-              resizeMode="scaleAspectFit"
-            />
-          </Pressable>
-        ) : null}
-        {isTerminal ? (
-          <Pressable
-            onPress={onDismiss}
-            accessibilityRole="button"
-            accessibilityLabel="Dismiss"
-            hitSlop={6}
-            style={({ pressed }) => [
-              styles.actionButton,
-              pressed && { opacity: 0.5 },
-            ]}
-          >
-            <SymbolView
-              name="xmark"
-              size={14}
-              tintColor={NEUTRAL_2}
-              resizeMode="scaleAspectFit"
-            />
-          </Pressable>
-        ) : null}
-      </View>
+      {isTerminal ? (
+        <Pressable
+          onPress={onDismiss}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+          hitSlop={6}
+          style={({ pressed }) => [
+            styles.actionButton,
+            pressed && { opacity: 0.5 },
+          ]}
+        >
+          <SymbolView
+            name="xmark"
+            size={12}
+            tintColor={NEUTRAL_2}
+            resizeMode="scaleAspectFit"
+          />
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -445,52 +405,53 @@ function formatRelative(timestampMs: number): string {
   return `${hours}h ago`;
 }
 
+const LEADING_SIZE = 28;
+
 const styles = StyleSheet.create({
+  // iOS 26 provides the capsule background + vertical padding; our
+  // container only lays out the row. Avoid flex:1 / paddingVertical so
+  // the accessory sizes to its intrinsic content instead of stretching.
   regularContainer: {
-    flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: 8,
-    paddingVertical: 4,
+    paddingHorizontal: 6,
     gap: 8,
   },
   regularPressable: {
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    paddingRight: 4,
+    gap: 8,
+    // Allow the text column to shrink for ellipsis; without minWidth:0
+    // on the flex child, long labels push the dismiss button off-screen.
+    minWidth: 0,
   },
   regularTextColumn: {
     flex: 1,
+    minWidth: 0,
     justifyContent: "center",
   },
   regularTitle: {
-    fontSize: 14,
+    fontSize: 13,
     fontWeight: "600",
     color: "#0B0B0B",
   },
   regularSubtitle: {
-    fontSize: 12,
+    fontSize: 11,
     color: NEUTRAL_2,
     marginTop: 1,
   },
-  regularActions: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-  },
   actionButton: {
-    width: 32,
-    height: 32,
+    width: 28,
+    height: 28,
     alignItems: "center",
     justifyContent: "center",
-    borderRadius: 16,
+    borderRadius: 14,
   },
   leading: {
-    width: 36,
-    height: 36,
-    borderRadius: 10,
+    width: LEADING_SIZE,
+    height: LEADING_SIZE,
+    borderRadius: 8,
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: "rgba(90,50,251,0.12)",
@@ -502,9 +463,9 @@ const styles = StyleSheet.create({
     backgroundColor: "#B3261E",
   },
   leadingImage: {
-    width: 36,
-    height: 36,
-    borderRadius: 10,
+    width: LEADING_SIZE,
+    height: LEADING_SIZE,
+    borderRadius: 8,
     backgroundColor: "#EEE",
   },
   inlineContainer: {

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -52,11 +52,19 @@ export function CaptureAccessoryContent({
 
   const handleOpen = useCallback(() => {
     void hapticSelection();
-    // If the single-event path is knowable, prefer it so the tap lands
-    // directly on the event. Otherwise (still loading, still processing,
-    // multi-event batch, or failure), open the batch screen — so a tap
-    // is never dropped just because `getBatchStatus` hasn't resolved.
-    if (isTerminal && status?.events.length === 1 && status.events[0]) {
+    // Prefer the direct event route only when this was a single-event
+    // capture to begin with. Partial-success multi-captures still have
+    // `events.length === 1` but the user needs to see the batch screen
+    // to review what failed, so gate on totalCount too. Otherwise (still
+    // loading, still processing, multi-event, or failure), fall through
+    // to the batch screen — so a tap is never dropped just because
+    // `getBatchStatus` hasn't resolved.
+    if (
+      isTerminal &&
+      status.totalCount === 1 &&
+      status.events.length === 1 &&
+      status.events[0]
+    ) {
       router.navigate(`/event/${status.events[0].id}`);
     } else {
       router.navigate(`/batch/${batchId}`);
@@ -121,8 +129,14 @@ function RegularAccessory({
   onDismiss,
 }: RegularAccessoryProps) {
   const copy = getAccessoryCopy(status, isTerminal, completedAt);
+  // Only treat this as a single-event capture when the batch was a
+  // single-event capture to begin with. Partial-success multi-captures
+  // have `events.length === 1` too, but the user needs the batch-level
+  // context, not the single-event Share shortcut.
   const singleEvent =
-    isTerminal && status?.events.length === 1 ? status.events[0] : null;
+    isTerminal && status?.totalCount === 1 && status.events.length === 1
+      ? status.events[0]
+      : null;
   const imageUrl = singleEvent?.image ?? null;
 
   return (
@@ -343,7 +357,7 @@ function getAccessoryCopy(
     };
   }
 
-  if (status.events.length === 1 && status.events[0]) {
+  if (total === 1 && status.events.length === 1 && status.events[0]) {
     const event = status.events[0];
     const name = event.name || "New event";
     const when = formatWhen(event.startDate, event.startTime);

--- a/apps/expo/src/components/CaptureAccessory.tsx
+++ b/apps/expo/src/components/CaptureAccessory.tsx
@@ -61,8 +61,6 @@ export function CaptureAccessoryContent({
     }
     if (status.events.length === 1 && status.events[0]) {
       router.navigate(`/event/${status.events[0].id}`);
-    } else if (status.successCount > 0) {
-      router.navigate(`/batch/${batchId}`);
     } else {
       router.navigate(`/batch/${batchId}`);
     }
@@ -331,7 +329,7 @@ function getAccessoryCopy(
   }
   const total = status.totalCount;
   if (!isTerminal) {
-    const plural = total === 1 ? "event" : `${total} events`;
+    const plural = total === 1 ? "1 event" : `${total} events`;
     return {
       title: `Capturing ${plural}…`,
       subtitle:

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -1,3 +1,4 @@
+import type { AppStateStatus } from "react-native";
 import { useEffect, useRef, useState } from "react";
 import { AppState } from "react-native";
 import NetInfo from "@react-native-community/netinfo";
@@ -118,22 +119,41 @@ export function useCaptureAccessoryLifecycle() {
 
   // Convex subscriptions pause while the app is backgrounded or offline,
   // so `lastProgressAt` can appear stale through no fault of the batch.
-  // Give the subscription a fresh window whenever we regain an active
-  // foreground + online state — if the batch really is stuck, the timer
-  // will still fire once the app has been continuously active for
-  // NO_PROGRESS_STUCK_MS without new progress.
+  // Give the subscription a fresh window only when we've regained BOTH
+  // an active foreground state AND network connectivity — bumping on
+  // just one side would reset the timer while Convex is still paused.
+  // If the batch really is stuck, the timer will fire once we've been
+  // continuously active+online for NO_PROGRESS_STUCK_MS without new
+  // progress.
   useEffect(() => {
     if (!accessoryBatchId || accessoryCompletedAt) return;
-    const bumpTimer = () => {
-      if (useAppStore.getState().accessoryBatchId) {
+    let currentAppState: AppStateStatus = AppState.currentState;
+    let isConnected = true;
+    const maybeBumpTimer = () => {
+      if (
+        currentAppState === "active" &&
+        isConnected &&
+        useAppStore.getState().accessoryBatchId
+      ) {
         setLastProgressAt(Date.now());
       }
     };
+    // Seed connectivity from NetInfo so the first AppState change can
+    // make a decision without waiting for a network event.
+    void NetInfo.fetch()
+      .then((state) => {
+        isConnected = state.isConnected === true;
+      })
+      .catch(() => {
+        /* keep the optimistic default */
+      });
     const appStateSub = AppState.addEventListener("change", (state) => {
-      if (state === "active") bumpTimer();
+      currentAppState = state;
+      maybeBumpTimer();
     });
     const netUnsub = NetInfo.addEventListener((state) => {
-      if (state.isConnected) bumpTimer();
+      isConnected = state.isConnected === true;
+      maybeBumpTimer();
     });
     return () => {
       appStateSub.remove();

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -167,12 +167,20 @@ export function useCaptureAccessoryLifecycle() {
   // progress change, so a healthy batch that keeps advancing resets
   // it on every tick and is never dismissed.
   const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isTerminalStatus =
+    batchStatus?.status === "completed" || batchStatus?.status === "failed";
   useEffect(() => {
     if (stuckTimerRef.current) {
       clearTimeout(stuckTimerRef.current);
       stuckTimerRef.current = null;
     }
     if (!accessoryBatchId || accessoryCompletedAt || !lastProgressAt) return;
+    // If the backend has already reported a terminal state, hand off to
+    // the completion effect instead of dismissing. Otherwise a response
+    // that arrives after a long idle (stale lastProgressAt) would fire
+    // the timer before markAccessoryCompleted runs, and the user would
+    // never see the captured accessory with its share/review actions.
+    if (isTerminalStatus) return;
     const remaining = NO_PROGRESS_STUCK_MS - (Date.now() - lastProgressAt);
     if (remaining <= 0) {
       dismiss();
@@ -187,5 +195,11 @@ export function useCaptureAccessoryLifecycle() {
         stuckTimerRef.current = null;
       }
     };
-  }, [accessoryBatchId, accessoryCompletedAt, lastProgressAt, dismiss]);
+  }, [
+    accessoryBatchId,
+    accessoryCompletedAt,
+    lastProgressAt,
+    isTerminalStatus,
+    dismiss,
+  ]);
 }

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -3,6 +3,7 @@ import { useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 
 // How long to keep a finished batch visible in the accessory before
@@ -31,9 +32,15 @@ export function useCaptureAccessoryLifecycle() {
   const markCompleted = useInFlightEventStore((s) => s.markAccessoryCompleted);
   const dismiss = useInFlightEventStore((s) => s.dismissAccessoryBatch);
 
+  // Defense in depth: the accessory only renders on iOS 26+, and
+  // useCreateEvent already gates `setAccessoryBatch` on this flag, but
+  // skipping here keeps the Convex subscription off on older OS versions
+  // even if a batch id ever leaks into the store from another code path.
   const batchStatus = useQuery(
     api.eventBatches.getBatchStatus,
-    accessoryBatchId ? { batchId: accessoryBatchId } : "skip",
+    SUPPORTS_LIQUID_GLASS && accessoryBatchId
+      ? { batchId: accessoryBatchId }
+      : "skip",
   );
 
   // Mark completion the first time the backend reports a terminal state.

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
@@ -11,12 +11,14 @@ import { useAppStore } from "~/store";
 // enough that the accessory doesn't linger into the next session.
 const AUTO_DISMISS_MS = 5 * 60 * 1000;
 
-// Safety net for batches that never reach a terminal state because
-// local preprocessing failed before any image was queued (backend sees
-// 0 / totalCount and can't advance). We only apply this when the
-// backend shows ZERO progress — a healthy long-running batch will have
-// already registered some success/failure, so we trust the backend to
-// terminate on its own rather than force-dismissing.
+// Safety net for batches whose backend progress stalls (never
+// advances to totalCount). Two real-world cases: (1) useCreateEvent
+// threw before any image reached the backend, so progress stays at
+// 0 / N forever; (2) Promise.all in createMultipleEvents rejected
+// part-way, so progress parks at M / N with M < N. We measure
+// staleness from the last observed progress change, so healthy
+// long-running captures (which keep advancing) are never dismissed
+// prematurely, but both stuck cases clear after the same deadline.
 const NO_PROGRESS_STUCK_MS = 10 * 60 * 1000;
 
 /**
@@ -27,11 +29,12 @@ const NO_PROGRESS_STUCK_MS = 10 * 60 * 1000;
  *      "completed" or "failed" (so the accessory can flip from the
  *      "capturing…" UI to the "captured" UI).
  *   2. Auto-dismisses the accessory 5 minutes after completion.
- *   3. Force-dismisses stuck batches (no backend progress after
+ *   3. Force-dismisses stuck batches (no backend progress change for
  *      NO_PROGRESS_STUCK_MS) to recover from local preprocessing
- *      failures that leave the backend unable to reach a terminal state
- *      on its own. Healthy long-running batches — any success/failure
- *      registered — are left alone so we don't dismiss prematurely.
+ *      failures that leave the backend unable to reach a terminal
+ *      state on its own. Tracks "time since last progress" — healthy
+ *      long-running batches keep advancing so they're never dismissed,
+ *      while both 0-of-N and partial-of-N stalls eventually clear.
  *
  * Mounted once at the root, not inside the accessory itself — the
  * accessory renders two instances (regular + inline placements) and
@@ -39,7 +42,6 @@ const NO_PROGRESS_STUCK_MS = 10 * 60 * 1000;
  */
 export function useCaptureAccessoryLifecycle() {
   const accessoryBatchId = useAppStore((s) => s.accessoryBatchId);
-  const accessoryStartedAt = useAppStore((s) => s.accessoryStartedAt);
   const accessoryCompletedAt = useAppStore((s) => s.accessoryCompletedAt);
   const markCompleted = useAppStore((s) => s.markAccessoryCompleted);
   const dismiss = useAppStore((s) => s.dismissAccessoryBatch);
@@ -88,34 +90,43 @@ export function useCaptureAccessoryLifecycle() {
     };
   }, [accessoryBatchId, accessoryCompletedAt, dismiss]);
 
-  // Force-dismiss batches that the backend clearly can't finish: no
-  // progress (0 successes, 0 failures) after NO_PROGRESS_STUCK_MS. This
-  // is the recovery path when useCreateEvent threw before any image
-  // reached the backend. Batches with any registered progress are left
-  // alone — a large batch can legitimately take a long time, and we'd
-  // rather leave it than dismiss a healthy capture.
+  // Track the last moment the backend reported a change in progress.
+  // `null` means "no response yet" — in that state we don't run the
+  // stuck timer (would dismiss a healthy batch whose subscription just
+  // hasn't warmed up). The first response (even 0/N) seeds the clock;
+  // subsequent progress changes reset it.
+  const [lastProgressAt, setLastProgressAt] = useState<number | null>(null);
+  const observedProgressRef = useRef<number | null>(null);
+
+  // Reset progress observation whenever we switch to a new batch.
+  useEffect(() => {
+    observedProgressRef.current = null;
+    setLastProgressAt(null);
+  }, [accessoryBatchId]);
+
+  const progressCount = batchStatus
+    ? batchStatus.successCount + batchStatus.failureCount
+    : null;
+  useEffect(() => {
+    if (progressCount === null) return;
+    if (observedProgressRef.current === progressCount) return;
+    observedProgressRef.current = progressCount;
+    setLastProgressAt(Date.now());
+  }, [progressCount]);
+
+  // Force-dismiss batches whose backend progress has gone stale.
+  // Covers both "never made it to the backend" and "Promise.all
+  // rejected partway" — the timer is measured from the last observed
+  // progress change, so a healthy batch that keeps advancing resets
+  // it on every tick and is never dismissed.
   const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Tri-state:
-  //   undefined → getBatchStatus hasn't responded yet (loading / offline
-  //               / backgrounded) — don't advance the stuck timer,
-  //               otherwise we'd dismiss a healthy batch we just haven't
-  //               subscribed to yet.
-  //   false     → backend confirmed zero progress — run the timer.
-  //   true      → backend confirmed some progress — trust it to finish.
-  const backendProgressKnown: boolean | undefined = batchStatus
-    ? batchStatus.successCount + batchStatus.failureCount > 0
-    : undefined;
   useEffect(() => {
     if (stuckTimerRef.current) {
       clearTimeout(stuckTimerRef.current);
       stuckTimerRef.current = null;
     }
-    if (!accessoryBatchId || !accessoryStartedAt || accessoryCompletedAt) {
-      return;
-    }
-    // Only start the countdown once we've confirmed zero backend progress.
-    if (backendProgressKnown !== false) return;
-    const remaining = NO_PROGRESS_STUCK_MS - (Date.now() - accessoryStartedAt);
+    if (!accessoryBatchId || accessoryCompletedAt || !lastProgressAt) return;
+    const remaining = NO_PROGRESS_STUCK_MS - (Date.now() - lastProgressAt);
     if (remaining <= 0) {
       dismiss();
       return;
@@ -129,11 +140,5 @@ export function useCaptureAccessoryLifecycle() {
         stuckTimerRef.current = null;
       }
     };
-  }, [
-    accessoryBatchId,
-    accessoryStartedAt,
-    accessoryCompletedAt,
-    backendProgressKnown,
-    dismiss,
-  ]);
+  }, [accessoryBatchId, accessoryCompletedAt, lastProgressAt, dismiss]);
 }

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -95,9 +95,16 @@ export function useCaptureAccessoryLifecycle() {
   // alone — a large batch can legitimately take a long time, and we'd
   // rather leave it than dismiss a healthy capture.
   const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasBackendProgress = batchStatus
+  // Tri-state:
+  //   undefined → getBatchStatus hasn't responded yet (loading / offline
+  //               / backgrounded) — don't advance the stuck timer,
+  //               otherwise we'd dismiss a healthy batch we just haven't
+  //               subscribed to yet.
+  //   false     → backend confirmed zero progress — run the timer.
+  //   true      → backend confirmed some progress — trust it to finish.
+  const backendProgressKnown: boolean | undefined = batchStatus
     ? batchStatus.successCount + batchStatus.failureCount > 0
-    : false;
+    : undefined;
   useEffect(() => {
     if (stuckTimerRef.current) {
       clearTimeout(stuckTimerRef.current);
@@ -106,7 +113,8 @@ export function useCaptureAccessoryLifecycle() {
     if (!accessoryBatchId || !accessoryStartedAt || accessoryCompletedAt) {
       return;
     }
-    if (hasBackendProgress) return;
+    // Only start the countdown once we've confirmed zero backend progress.
+    if (backendProgressKnown !== false) return;
     const remaining = NO_PROGRESS_STUCK_MS - (Date.now() - accessoryStartedAt);
     if (remaining <= 0) {
       dismiss();
@@ -125,7 +133,7 @@ export function useCaptureAccessoryLifecycle() {
     accessoryBatchId,
     accessoryStartedAt,
     accessoryCompletedAt,
-    hasBackendProgress,
+    backendProgressKnown,
     dismiss,
   ]);
 }

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import { AppState } from "react-native";
+import NetInfo from "@react-native-community/netinfo";
 import { useQuery } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
@@ -113,6 +115,31 @@ export function useCaptureAccessoryLifecycle() {
     observedProgressRef.current = progressCount;
     setLastProgressAt(Date.now());
   }, [progressCount]);
+
+  // Convex subscriptions pause while the app is backgrounded or offline,
+  // so `lastProgressAt` can appear stale through no fault of the batch.
+  // Give the subscription a fresh window whenever we regain an active
+  // foreground + online state — if the batch really is stuck, the timer
+  // will still fire once the app has been continuously active for
+  // NO_PROGRESS_STUCK_MS without new progress.
+  useEffect(() => {
+    if (!accessoryBatchId || accessoryCompletedAt) return;
+    const bumpTimer = () => {
+      if (useAppStore.getState().accessoryBatchId) {
+        setLastProgressAt(Date.now());
+      }
+    };
+    const appStateSub = AppState.addEventListener("change", (state) => {
+      if (state === "active") bumpTimer();
+    });
+    const netUnsub = NetInfo.addEventListener((state) => {
+      if (state.isConnected) bumpTimer();
+    });
+    return () => {
+      appStateSub.remove();
+      netUnsub();
+    };
+  }, [accessoryBatchId, accessoryCompletedAt]);
 
   // Force-dismiss batches whose backend progress has gone stale.
   // Covers both "never made it to the backend" and "Promise.all

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -11,6 +11,13 @@ import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 // enough that the accessory doesn't linger into the next session.
 const AUTO_DISMISS_MS = 5 * 60 * 1000;
 
+// Safety net for batches that never reach a terminal state — e.g. a
+// local preprocessing error leaves some images un-queued so the backend
+// progress can't advance to 100%. After this much wall-clock time from
+// start, we assume the batch is stuck and clear the accessory so it
+// doesn't sit on "Capturing…" indefinitely.
+const MAX_PROCESSING_MS = 10 * 60 * 1000;
+
 /**
  * useCaptureAccessoryLifecycle
  * ----------------------------
@@ -19,6 +26,9 @@ const AUTO_DISMISS_MS = 5 * 60 * 1000;
  *      "completed" or "failed" (so the accessory can flip from the
  *      "capturing…" UI to the "captured" UI).
  *   2. Auto-dismisses the accessory 5 minutes after completion.
+ *   3. Force-dismisses stuck batches after MAX_PROCESSING_MS to recover
+ *      from local preprocessing failures that leave the backend unable
+ *      to reach a terminal state on its own.
  *
  * Mounted once at the root, not inside the accessory itself — the
  * accessory renders two instances (regular + inline placements) and
@@ -26,6 +36,7 @@ const AUTO_DISMISS_MS = 5 * 60 * 1000;
  */
 export function useCaptureAccessoryLifecycle() {
   const accessoryBatchId = useInFlightEventStore((s) => s.accessoryBatchId);
+  const accessoryStartedAt = useInFlightEventStore((s) => s.accessoryStartedAt);
   const accessoryCompletedAt = useInFlightEventStore(
     (s) => s.accessoryCompletedAt,
   );
@@ -53,11 +64,11 @@ export function useCaptureAccessoryLifecycle() {
   }, [batchStatus, accessoryBatchId, accessoryCompletedAt, markCompleted]);
 
   // Auto-dismiss the accessory some time after completion.
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
     }
     if (!accessoryBatchId || !accessoryCompletedAt) return;
     const remaining = AUTO_DISMISS_MS - (Date.now() - accessoryCompletedAt);
@@ -65,14 +76,44 @@ export function useCaptureAccessoryLifecycle() {
       dismiss();
       return;
     }
-    timerRef.current = setTimeout(() => {
+    dismissTimerRef.current = setTimeout(() => {
       dismiss();
     }, remaining);
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
       }
     };
   }, [accessoryBatchId, accessoryCompletedAt, dismiss]);
+
+  // Force-dismiss batches that have been "processing" too long. Covers
+  // the case where useCreateEvent threw before all images were queued
+  // (so the backend's progress can't reach 100%) — we never dismiss in
+  // those catch blocks to avoid wiping partial-success state, so this
+  // is the single safety net.
+  const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (stuckTimerRef.current) {
+      clearTimeout(stuckTimerRef.current);
+      stuckTimerRef.current = null;
+    }
+    if (!accessoryBatchId || !accessoryStartedAt || accessoryCompletedAt) {
+      return;
+    }
+    const remaining = MAX_PROCESSING_MS - (Date.now() - accessoryStartedAt);
+    if (remaining <= 0) {
+      dismiss();
+      return;
+    }
+    stuckTimerRef.current = setTimeout(() => {
+      dismiss();
+    }, remaining);
+    return () => {
+      if (stuckTimerRef.current) {
+        clearTimeout(stuckTimerRef.current);
+        stuckTimerRef.current = null;
+      }
+    };
+  }, [accessoryBatchId, accessoryStartedAt, accessoryCompletedAt, dismiss]);
 }

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -4,19 +4,20 @@ import { useQuery } from "convex/react";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
-import { useInFlightEventStore } from "~/store/useInFlightEventStore";
+import { useAppStore } from "~/store";
 
 // How long to keep a finished batch visible in the accessory before
 // auto-dismissing it. Long enough to tap in from another tab, short
 // enough that the accessory doesn't linger into the next session.
 const AUTO_DISMISS_MS = 5 * 60 * 1000;
 
-// Safety net for batches that never reach a terminal state — e.g. a
-// local preprocessing error leaves some images un-queued so the backend
-// progress can't advance to 100%. After this much wall-clock time from
-// start, we assume the batch is stuck and clear the accessory so it
-// doesn't sit on "Capturing…" indefinitely.
-const MAX_PROCESSING_MS = 10 * 60 * 1000;
+// Safety net for batches that never reach a terminal state because
+// local preprocessing failed before any image was queued (backend sees
+// 0 / totalCount and can't advance). We only apply this when the
+// backend shows ZERO progress — a healthy long-running batch will have
+// already registered some success/failure, so we trust the backend to
+// terminate on its own rather than force-dismissing.
+const NO_PROGRESS_STUCK_MS = 10 * 60 * 1000;
 
 /**
  * useCaptureAccessoryLifecycle
@@ -26,22 +27,22 @@ const MAX_PROCESSING_MS = 10 * 60 * 1000;
  *      "completed" or "failed" (so the accessory can flip from the
  *      "capturing…" UI to the "captured" UI).
  *   2. Auto-dismisses the accessory 5 minutes after completion.
- *   3. Force-dismisses stuck batches after MAX_PROCESSING_MS to recover
- *      from local preprocessing failures that leave the backend unable
- *      to reach a terminal state on its own.
+ *   3. Force-dismisses stuck batches (no backend progress after
+ *      NO_PROGRESS_STUCK_MS) to recover from local preprocessing
+ *      failures that leave the backend unable to reach a terminal state
+ *      on its own. Healthy long-running batches — any success/failure
+ *      registered — are left alone so we don't dismiss prematurely.
  *
  * Mounted once at the root, not inside the accessory itself — the
  * accessory renders two instances (regular + inline placements) and
  * anything stateful must live outside of it.
  */
 export function useCaptureAccessoryLifecycle() {
-  const accessoryBatchId = useInFlightEventStore((s) => s.accessoryBatchId);
-  const accessoryStartedAt = useInFlightEventStore((s) => s.accessoryStartedAt);
-  const accessoryCompletedAt = useInFlightEventStore(
-    (s) => s.accessoryCompletedAt,
-  );
-  const markCompleted = useInFlightEventStore((s) => s.markAccessoryCompleted);
-  const dismiss = useInFlightEventStore((s) => s.dismissAccessoryBatch);
+  const accessoryBatchId = useAppStore((s) => s.accessoryBatchId);
+  const accessoryStartedAt = useAppStore((s) => s.accessoryStartedAt);
+  const accessoryCompletedAt = useAppStore((s) => s.accessoryCompletedAt);
+  const markCompleted = useAppStore((s) => s.markAccessoryCompleted);
+  const dismiss = useAppStore((s) => s.dismissAccessoryBatch);
 
   // Defense in depth: the accessory only renders on iOS 26+, and
   // useCreateEvent already gates `setAccessoryBatch` on this flag, but
@@ -87,12 +88,16 @@ export function useCaptureAccessoryLifecycle() {
     };
   }, [accessoryBatchId, accessoryCompletedAt, dismiss]);
 
-  // Force-dismiss batches that have been "processing" too long. Covers
-  // the case where useCreateEvent threw before all images were queued
-  // (so the backend's progress can't reach 100%) — we never dismiss in
-  // those catch blocks to avoid wiping partial-success state, so this
-  // is the single safety net.
+  // Force-dismiss batches that the backend clearly can't finish: no
+  // progress (0 successes, 0 failures) after NO_PROGRESS_STUCK_MS. This
+  // is the recovery path when useCreateEvent threw before any image
+  // reached the backend. Batches with any registered progress are left
+  // alone — a large batch can legitimately take a long time, and we'd
+  // rather leave it than dismiss a healthy capture.
   const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasBackendProgress = batchStatus
+    ? batchStatus.successCount + batchStatus.failureCount > 0
+    : false;
   useEffect(() => {
     if (stuckTimerRef.current) {
       clearTimeout(stuckTimerRef.current);
@@ -101,7 +106,8 @@ export function useCaptureAccessoryLifecycle() {
     if (!accessoryBatchId || !accessoryStartedAt || accessoryCompletedAt) {
       return;
     }
-    const remaining = MAX_PROCESSING_MS - (Date.now() - accessoryStartedAt);
+    if (hasBackendProgress) return;
+    const remaining = NO_PROGRESS_STUCK_MS - (Date.now() - accessoryStartedAt);
     if (remaining <= 0) {
       dismiss();
       return;
@@ -115,5 +121,11 @@ export function useCaptureAccessoryLifecycle() {
         stuckTimerRef.current = null;
       }
     };
-  }, [accessoryBatchId, accessoryStartedAt, accessoryCompletedAt, dismiss]);
+  }, [
+    accessoryBatchId,
+    accessoryStartedAt,
+    accessoryCompletedAt,
+    hasBackendProgress,
+    dismiss,
+  ]);
 }

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -133,6 +133,13 @@ export function useCaptureAccessoryLifecycle() {
       if (
         currentAppState === "active" &&
         isConnected &&
+        // Only extend the deadline if we've already seen at least one
+        // backend response. Without this, the AppState/NetInfo handlers
+        // would seed lastProgressAt immediately and arm the stuck
+        // timeout before any getBatchStatus payload has arrived,
+        // defeating the `lastProgressAt === null` safeguard for
+        // loading/offline-recovery.
+        observedProgressRef.current !== null &&
         useAppStore.getState().accessoryBatchId
       ) {
         setLastProgressAt(Date.now());

--- a/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
+++ b/apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "convex/react";
+
+import { api } from "@soonlist/backend/convex/_generated/api";
+
+import { useInFlightEventStore } from "~/store/useInFlightEventStore";
+
+// How long to keep a finished batch visible in the accessory before
+// auto-dismissing it. Long enough to tap in from another tab, short
+// enough that the accessory doesn't linger into the next session.
+const AUTO_DISMISS_MS = 5 * 60 * 1000;
+
+/**
+ * useCaptureAccessoryLifecycle
+ * ----------------------------
+ * Observes the batch tracked by the iOS 26 tab bar bottom accessory and:
+ *   1. Marks it completed the first time the backend reports
+ *      "completed" or "failed" (so the accessory can flip from the
+ *      "capturing…" UI to the "captured" UI).
+ *   2. Auto-dismisses the accessory 5 minutes after completion.
+ *
+ * Mounted once at the root, not inside the accessory itself — the
+ * accessory renders two instances (regular + inline placements) and
+ * anything stateful must live outside of it.
+ */
+export function useCaptureAccessoryLifecycle() {
+  const accessoryBatchId = useInFlightEventStore((s) => s.accessoryBatchId);
+  const accessoryCompletedAt = useInFlightEventStore(
+    (s) => s.accessoryCompletedAt,
+  );
+  const markCompleted = useInFlightEventStore((s) => s.markAccessoryCompleted);
+  const dismiss = useInFlightEventStore((s) => s.dismissAccessoryBatch);
+
+  const batchStatus = useQuery(
+    api.eventBatches.getBatchStatus,
+    accessoryBatchId ? { batchId: accessoryBatchId } : "skip",
+  );
+
+  // Mark completion the first time the backend reports a terminal state.
+  useEffect(() => {
+    if (!accessoryBatchId || accessoryCompletedAt) return;
+    if (!batchStatus) return;
+    if (batchStatus.status === "completed" || batchStatus.status === "failed") {
+      markCompleted();
+    }
+  }, [batchStatus, accessoryBatchId, accessoryCompletedAt, markCompleted]);
+
+  // Auto-dismiss the accessory some time after completion.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!accessoryBatchId || !accessoryCompletedAt) return;
+    const remaining = AUTO_DISMISS_MS - (Date.now() - accessoryCompletedAt);
+    if (remaining <= 0) {
+      dismiss();
+      return;
+    }
+    timerRef.current = setTimeout(() => {
+      dismiss();
+    }, remaining);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [accessoryBatchId, accessoryCompletedAt, dismiss]);
+}

--- a/apps/expo/src/hooks/useCreateEvent.ts
+++ b/apps/expo/src/hooks/useCreateEvent.ts
@@ -58,7 +58,7 @@ export function useCreateEvent() {
   const { setIsImageLoading, addWorkflowId } = useAppStore();
   const setIsCapturing = useInFlightEventStore((s) => s.setIsCapturing);
   const addPendingBatchId = useInFlightEventStore((s) => s.addPendingBatchId);
-  const setAccessoryBatch = useInFlightEventStore((s) => s.setAccessoryBatch);
+  const setAccessoryBatch = useAppStore((s) => s.setAccessoryBatch);
   const { hasNotificationPermission } = useOneSignal();
   const userTimezone = useUserTimezone();
 

--- a/apps/expo/src/hooks/useCreateEvent.ts
+++ b/apps/expo/src/hooks/useCreateEvent.ts
@@ -59,9 +59,6 @@ export function useCreateEvent() {
   const setIsCapturing = useInFlightEventStore((s) => s.setIsCapturing);
   const addPendingBatchId = useInFlightEventStore((s) => s.addPendingBatchId);
   const setAccessoryBatch = useInFlightEventStore((s) => s.setAccessoryBatch);
-  const dismissAccessoryBatch = useInFlightEventStore(
-    (s) => s.dismissAccessoryBatch,
-  );
   const { hasNotificationPermission } = useOneSignal();
   const userTimezone = useUserTimezone();
 
@@ -198,13 +195,11 @@ export function useCreateEvent() {
       } catch (error) {
         logError("Error processing event", error);
         void hapticError();
-        // The accessory only shows a Dismiss control once the batch is
-        // terminal; if we bail before even adding images, the batch would
-        // never complete on the backend and the accessory would be stuck.
-        // Clear it here so the UI can't get stuck.
-        if (SUPPORTS_LIQUID_GLASS) {
-          dismissAccessoryBatch();
-        }
+        // We intentionally don't dismiss the accessory here. An error
+        // can still leave a partially-successful batch on the backend
+        // (e.g. Promise.all rejects after one addImagesToBatch has
+        // already landed), and truly stuck batches are cleaned up by
+        // the max-processing timeout in useCaptureAccessoryLifecycle.
         throw error; // Rethrow to trigger mutation's onError
       } finally {
         // Reset loading state for both routes
@@ -224,7 +219,6 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       setAccessoryBatch,
-      dismissAccessoryBatch,
       userTimezone,
       addWorkflowId,
       eventFromUrl,
@@ -327,12 +321,11 @@ export function useCreateEvent() {
       } catch (error) {
         logError("Error creating events batch", error);
         void hapticError();
-        // Clear the accessory if we never got images queued: the backend
-        // won't transition a zero-image batch to a terminal state, so the
-        // accessory would otherwise stick on "Capturing…" forever.
-        if (SUPPORTS_LIQUID_GLASS) {
-          dismissAccessoryBatch();
-        }
+        // Don't dismiss the accessory on failure. Promise.all can reject
+        // after some images have already landed, and the user still
+        // wants to see whatever partial results the backend produces.
+        // Truly stuck batches (no progress at all) are cleared by the
+        // max-processing timeout in useCaptureAccessoryLifecycle.
         throw error;
       } finally {
         if (!suppressCapturing) {
@@ -348,7 +341,6 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       setAccessoryBatch,
-      dismissAccessoryBatch,
       userTimezone,
       setIsCapturing,
       setIsImageLoading,

--- a/apps/expo/src/hooks/useCreateEvent.ts
+++ b/apps/expo/src/hooks/useCreateEvent.ts
@@ -57,6 +57,7 @@ export function useCreateEvent() {
   const { setIsImageLoading, addWorkflowId } = useAppStore();
   const setIsCapturing = useInFlightEventStore((s) => s.setIsCapturing);
   const addPendingBatchId = useInFlightEventStore((s) => s.addPendingBatchId);
+  const setAccessoryBatch = useInFlightEventStore((s) => s.setAccessoryBatch);
   const { hasNotificationPermission } = useOneSignal();
   const userTimezone = useUserTimezone();
 
@@ -127,6 +128,9 @@ export function useCreateEvent() {
             visibility: DEFAULT_VISIBILITY,
             sendNotification,
           });
+
+          // Surface batch in the iOS 26 tab bar bottom accessory
+          setAccessoryBatch(batchId);
 
           // 2. Optimize image and get base64
           const base64 = await optimizeImage(fileUri);
@@ -204,6 +208,7 @@ export function useCreateEvent() {
       addImagesToBatch,
       hasNotificationPermission,
       addPendingBatchId,
+      setAccessoryBatch,
       userTimezone,
       addWorkflowId,
       eventFromUrl,
@@ -242,6 +247,9 @@ export function useCreateEvent() {
           visibility: "private",
           sendNotification,
         });
+
+        // Surface batch in the iOS 26 tab bar bottom accessory
+        setAccessoryBatch(batchId);
 
         // Step 2: Process and stream images as they're ready
         const imagePromises = tasks.map(async (task, index) => {
@@ -313,6 +321,7 @@ export function useCreateEvent() {
       addImagesToBatch,
       hasNotificationPermission,
       addPendingBatchId,
+      setAccessoryBatch,
       userTimezone,
       setIsCapturing,
       setIsImageLoading,

--- a/apps/expo/src/hooks/useCreateEvent.ts
+++ b/apps/expo/src/hooks/useCreateEvent.ts
@@ -6,6 +6,7 @@ import { useMutation } from "convex/react";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { DEFAULT_VISIBILITY } from "~/constants";
+import { SUPPORTS_LIQUID_GLASS } from "~/hooks/useLiquidGlass";
 import { useOneSignal } from "~/providers/OneSignalProvider";
 import { useAppStore, useUserTimezone } from "~/store";
 import { useInFlightEventStore } from "~/store/useInFlightEventStore";
@@ -58,6 +59,9 @@ export function useCreateEvent() {
   const setIsCapturing = useInFlightEventStore((s) => s.setIsCapturing);
   const addPendingBatchId = useInFlightEventStore((s) => s.addPendingBatchId);
   const setAccessoryBatch = useInFlightEventStore((s) => s.setAccessoryBatch);
+  const dismissAccessoryBatch = useInFlightEventStore(
+    (s) => s.dismissAccessoryBatch,
+  );
   const { hasNotificationPermission } = useOneSignal();
   const userTimezone = useUserTimezone();
 
@@ -129,8 +133,12 @@ export function useCreateEvent() {
             sendNotification,
           });
 
-          // Surface batch in the iOS 26 tab bar bottom accessory
-          setAccessoryBatch(batchId);
+          // Surface batch in the iOS 26 tab bar bottom accessory.
+          // Gated on SUPPORTS_LIQUID_GLASS so pre-iOS-26 sessions don't
+          // subscribe to getBatchStatus for an accessory that can't render.
+          if (SUPPORTS_LIQUID_GLASS) {
+            setAccessoryBatch(batchId);
+          }
 
           // 2. Optimize image and get base64
           const base64 = await optimizeImage(fileUri);
@@ -190,6 +198,13 @@ export function useCreateEvent() {
       } catch (error) {
         logError("Error processing event", error);
         void hapticError();
+        // The accessory only shows a Dismiss control once the batch is
+        // terminal; if we bail before even adding images, the batch would
+        // never complete on the backend and the accessory would be stuck.
+        // Clear it here so the UI can't get stuck.
+        if (SUPPORTS_LIQUID_GLASS) {
+          dismissAccessoryBatch();
+        }
         throw error; // Rethrow to trigger mutation's onError
       } finally {
         // Reset loading state for both routes
@@ -209,6 +224,7 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       setAccessoryBatch,
+      dismissAccessoryBatch,
       userTimezone,
       addWorkflowId,
       eventFromUrl,
@@ -248,8 +264,12 @@ export function useCreateEvent() {
           sendNotification,
         });
 
-        // Surface batch in the iOS 26 tab bar bottom accessory
-        setAccessoryBatch(batchId);
+        // Surface batch in the iOS 26 tab bar bottom accessory.
+        // Gated on SUPPORTS_LIQUID_GLASS so pre-iOS-26 sessions don't
+        // subscribe to getBatchStatus for an accessory that can't render.
+        if (SUPPORTS_LIQUID_GLASS) {
+          setAccessoryBatch(batchId);
+        }
 
         // Step 2: Process and stream images as they're ready
         const imagePromises = tasks.map(async (task, index) => {
@@ -307,6 +327,12 @@ export function useCreateEvent() {
       } catch (error) {
         logError("Error creating events batch", error);
         void hapticError();
+        // Clear the accessory if we never got images queued: the backend
+        // won't transition a zero-image batch to a terminal state, so the
+        // accessory would otherwise stick on "Capturing…" forever.
+        if (SUPPORTS_LIQUID_GLASS) {
+          dismissAccessoryBatch();
+        }
         throw error;
       } finally {
         if (!suppressCapturing) {
@@ -322,6 +348,7 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       setAccessoryBatch,
+      dismissAccessoryBatch,
       userTimezone,
       setIsCapturing,
       setIsImageLoading,

--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -53,6 +53,13 @@ export const useSignOut = () => {
       }
     }
 
+    // Clear in-flight capture state immediately after the Clerk token is
+    // revoked so Convex subscriptions (e.g. getBatchStatus via the tab bar
+    // accessory) stop firing under a stale identity before the rest of the
+    // cleanup runs.
+    useInFlightEventStore.getState().dismissAccessoryBatch();
+    useInFlightEventStore.getState().clearPendingBatchIds();
+
     // Step 3: Clean up local data and third-party sessions.
     // These should not require auth and can run concurrently.
     const logoutResults = await Promise.allSettled([
@@ -94,9 +101,5 @@ export const useSignOut = () => {
       resetForLogout();
     }
     setHasCompletedOnboarding(false);
-    // Clear any lingering tab-bar accessory so we don't query Convex
-    // under the new (signed-out) identity.
-    useInFlightEventStore.getState().dismissAccessoryBatch();
-    useInFlightEventStore.getState().clearPendingBatchIds();
   };
 };

--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -57,7 +57,7 @@ export const useSignOut = () => {
     // revoked so Convex subscriptions (e.g. getBatchStatus via the tab bar
     // accessory) stop firing under a stale identity before the rest of the
     // cleanup runs.
-    useInFlightEventStore.getState().dismissAccessoryBatch();
+    useAppStore.getState().dismissAccessoryBatch();
     useInFlightEventStore.getState().clearPendingBatchIds();
 
     // Step 3: Clean up local data and third-party sessions.

--- a/apps/expo/src/hooks/useSignOut.ts
+++ b/apps/expo/src/hooks/useSignOut.ts
@@ -7,6 +7,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import { useAppStore } from "~/store";
+import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 import { logError } from "~/utils/errorLogging";
 
 interface SignOutOptions {
@@ -93,5 +94,9 @@ export const useSignOut = () => {
       resetForLogout();
     }
     setHasCompletedOnboarding(false);
+    // Clear any lingering tab-bar accessory so we don't query Convex
+    // under the new (signed-out) identity.
+    useInFlightEventStore.getState().dismissAccessoryBatch();
+    useInFlightEventStore.getState().clearPendingBatchIds();
   };
 };

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -181,6 +181,15 @@ interface AppState {
   setMyListBadgeCount: (count: number) => void;
   communityBadgeCount: number;
   setCommunityBadgeCount: (count: number) => void;
+
+  // iOS 26 tab bar bottom accessory (capture mini-player).
+  // Ephemeral — excluded from persist.partialize.
+  accessoryBatchId: string | null;
+  accessoryStartedAt: number | null;
+  accessoryCompletedAt: number | null;
+  setAccessoryBatch: (batchId: string) => void;
+  markAccessoryCompleted: () => void;
+  dismissAccessoryBatch: () => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -411,6 +420,9 @@ export const useAppStore = create<AppState>()(
           pendingFollowUsername: null,
           myListBadgeCount: 0,
           communityBadgeCount: 0,
+          accessoryBatchId: null,
+          accessoryStartedAt: null,
+          accessoryCompletedAt: null,
         }),
 
       // Reset for logout - preserves onboarding state
@@ -463,6 +475,9 @@ export const useAppStore = create<AppState>()(
           pendingFollowUsername: state.pendingFollowUsername,
           myListBadgeCount: 0,
           communityBadgeCount: 0,
+          accessoryBatchId: null,
+          accessoryStartedAt: null,
+          accessoryCompletedAt: null,
         })),
 
       // Stable timestamp for query filtering
@@ -533,14 +548,47 @@ export const useAppStore = create<AppState>()(
       setMyListBadgeCount: (count) => set({ myListBadgeCount: count }),
       communityBadgeCount: 0,
       setCommunityBadgeCount: (count) => set({ communityBadgeCount: count }),
+
+      // iOS 26 tab bar bottom accessory (capture mini-player)
+      accessoryBatchId: null,
+      accessoryStartedAt: null,
+      accessoryCompletedAt: null,
+      setAccessoryBatch: (batchId) =>
+        set({
+          accessoryBatchId: batchId,
+          accessoryStartedAt: Date.now(),
+          accessoryCompletedAt: null,
+        }),
+      markAccessoryCompleted: () =>
+        set((state) =>
+          state.accessoryBatchId && !state.accessoryCompletedAt
+            ? { accessoryCompletedAt: Date.now() }
+            : state,
+        ),
+      dismissAccessoryBatch: () =>
+        set({
+          accessoryBatchId: null,
+          accessoryStartedAt: null,
+          accessoryCompletedAt: null,
+        }),
     }),
     {
       name: "app-storage",
       storage: createJSONStorage(() => AsyncStorage),
-      // Do not persist ephemeral flags like discoverAccessOverride
+      // Do not persist ephemeral flags (discoverAccessOverride, tab bar
+      // accessory capture state).
       partialize: (state) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { discoverAccessOverride, ...rest } = state;
+        const {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          discoverAccessOverride,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          accessoryBatchId,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          accessoryStartedAt,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          accessoryCompletedAt,
+          ...rest
+        } = state;
         return rest;
       },
     },

--- a/apps/expo/src/store/useInFlightEventStore.ts
+++ b/apps/expo/src/store/useInFlightEventStore.ts
@@ -8,17 +8,6 @@ interface InFlightEventState {
   addPendingBatchId: (batchId: string) => void;
   removePendingBatchId: (batchId: string) => void;
   clearPendingBatchIds: () => void;
-
-  // The most recent capture batch surfaced in the iOS 26 tab bar bottom
-  // accessory ("now capturing" mini-player). Independent of pendingBatchIds,
-  // which only drives in-app banners for users without push permission.
-  // Lives in memory only — auto-clears on app restart.
-  accessoryBatchId: string | null;
-  accessoryStartedAt: number | null;
-  accessoryCompletedAt: number | null;
-  setAccessoryBatch: (batchId: string) => void;
-  markAccessoryCompleted: () => void;
-  dismissAccessoryBatch: () => void;
 }
 
 export const useInFlightEventStore = create<InFlightEventState>((set) => ({
@@ -34,26 +23,4 @@ export const useInFlightEventStore = create<InFlightEventState>((set) => ({
       pendingBatchIds: state.pendingBatchIds.filter((id) => id !== batchId),
     })),
   clearPendingBatchIds: () => set({ pendingBatchIds: [] }),
-
-  accessoryBatchId: null,
-  accessoryStartedAt: null,
-  accessoryCompletedAt: null,
-  setAccessoryBatch: (batchId) =>
-    set({
-      accessoryBatchId: batchId,
-      accessoryStartedAt: Date.now(),
-      accessoryCompletedAt: null,
-    }),
-  markAccessoryCompleted: () =>
-    set((state) =>
-      state.accessoryBatchId && !state.accessoryCompletedAt
-        ? { accessoryCompletedAt: Date.now() }
-        : state,
-    ),
-  dismissAccessoryBatch: () =>
-    set({
-      accessoryBatchId: null,
-      accessoryStartedAt: null,
-      accessoryCompletedAt: null,
-    }),
 }));

--- a/apps/expo/src/store/useInFlightEventStore.ts
+++ b/apps/expo/src/store/useInFlightEventStore.ts
@@ -8,6 +8,17 @@ interface InFlightEventState {
   addPendingBatchId: (batchId: string) => void;
   removePendingBatchId: (batchId: string) => void;
   clearPendingBatchIds: () => void;
+
+  // The most recent capture batch surfaced in the iOS 26 tab bar bottom
+  // accessory ("now capturing" mini-player). Independent of pendingBatchIds,
+  // which only drives in-app banners for users without push permission.
+  // Lives in memory only — auto-clears on app restart.
+  accessoryBatchId: string | null;
+  accessoryStartedAt: number | null;
+  accessoryCompletedAt: number | null;
+  setAccessoryBatch: (batchId: string) => void;
+  markAccessoryCompleted: () => void;
+  dismissAccessoryBatch: () => void;
 }
 
 export const useInFlightEventStore = create<InFlightEventState>((set) => ({
@@ -23,4 +34,26 @@ export const useInFlightEventStore = create<InFlightEventState>((set) => ({
       pendingBatchIds: state.pendingBatchIds.filter((id) => id !== batchId),
     })),
   clearPendingBatchIds: () => set({ pendingBatchIds: [] }),
+
+  accessoryBatchId: null,
+  accessoryStartedAt: null,
+  accessoryCompletedAt: null,
+  setAccessoryBatch: (batchId) =>
+    set({
+      accessoryBatchId: batchId,
+      accessoryStartedAt: Date.now(),
+      accessoryCompletedAt: null,
+    }),
+  markAccessoryCompleted: () =>
+    set((state) =>
+      state.accessoryBatchId && !state.accessoryCompletedAt
+        ? { accessoryCompletedAt: Date.now() }
+        : state,
+    ),
+  dismissAccessoryBatch: () =>
+    set({
+      accessoryBatchId: null,
+      accessoryStartedAt: null,
+      accessoryCompletedAt: null,
+    }),
 }));


### PR DESCRIPTION
## Summary

Uses the new iOS 26 `<NativeTabs.BottomAccessory>` to surface the current event-capture batch as a persistent mini-player-style chip above the tab bar — the same slot Apple Music uses for "Now Playing."

- **While capturing:** spinner + "Capturing N events…" with live `%` progress from `getBatchStatus`.
- **When complete (single event):** thumbnail + event title + date subtitle, with inline **Share** and **Dismiss** actions. Tap opens `/event/[id]`.
- **When complete (multi event):** "N events added" summary; tap opens `/batch/[batchId]`.
- **Inline placement** (tab bar minimized on scroll): compact spinner / checkmark-with-count, tap opens the same destination.
- **Auto-dismiss** 5 min after completion so the accessory doesn't linger into the next session.
- **iOS 26 only** — gated on `SUPPORTS_LIQUID_GLASS`; pre-26 iOS is unaffected and keeps the existing banner flow.

## Pattern reference

Mirrors `tabViewBottomAccessory` in SwiftUI (Apple Music / Podcasts mini player). Expo Router surfaces this as `NativeTabs.BottomAccessory` with a `usePlacement()` hook that returns `"regular"` or `"inline"` — two instances render simultaneously so all state is kept outside the component (in `useInFlightEventStore` + the deduped Convex query).

## Implementation notes

- New component: `src/components/CaptureAccessory.tsx` (regular + inline renderers, copy helpers).
- New hook: `src/hooks/useCaptureAccessoryLifecycle.ts` — mounted once in `RootLayoutContent` (needs Convex context); watches batch status, marks completion, runs the auto-dismiss timer. Placed at root because the accessory itself renders twice.
- `useInFlightEventStore` gains `accessoryBatchId` / `accessoryStartedAt` / `accessoryCompletedAt` and `setAccessoryBatch` / `markAccessoryCompleted` / `dismissAccessoryBatch`. Not persisted — clears on cold start.
- `useCreateEvent` now calls `setAccessoryBatch(batchId)` right after the batch row exists in Convex (so the query won't 404), for both single-image and multi-image flows.
- `useSignOut` clears accessory + pending batch state so we don't query Convex under the signed-out identity.
- Tabs layout conditionally mounts `<NativeTabs.BottomAccessory>` only when there's a batch AND `SUPPORTS_LIQUID_GLASS`, so pre-26 iOS gets no accessory slot at all (avoiding an empty capsule).

The existing `CaptureOverlayButton` + `NotificationBanner` / `BatchSummaryBanner` flows are unchanged — the accessory is additive.

## Test plan

- [ ] iOS 26 device/sim: capture 1 photo → accessory shows spinner → flips to thumbnail + title; tap opens event; Share opens native sheet; Dismiss clears.
- [ ] iOS 26: capture 3+ photos → accessory shows "Capturing 3 events… X% processed" → flips to "3 events added · Tap to review"; tap opens `/batch/[batchId]`.
- [ ] iOS 26: scroll the feed → tab bar minimizes → accessory switches to inline variant (spinner / checkmark + count); tap still navigates.
- [ ] iOS 26: wait 5 min after completion → accessory auto-dismisses.
- [ ] iOS 26: partial failure (some successes, some failures) → subtitle shows "N didn't capture".
- [ ] iOS <26: confirm no accessory appears and existing capture banners still fire.
- [ ] Share-extension / `/new` capture path also surfaces in the accessory.
- [ ] Sign out mid-capture → accessory clears immediately, no Convex errors.

https://claude.ai/code/session_01EqFRAoVUdAbgHBkafq6sJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqFRAoVUdAbgHBkafq6sJN)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS 26-only tab bar accessory using `NativeTabs.BottomAccessory` to show in-flight capture status and a recent capture summary. Also tightens the accessory layout and removes the redundant Share button; iOS <26 is unchanged.

- New Features
  - Persistent chip above the tab bar shows progress; switches to an inline variant when the tab bar collapses.
  - While capturing: spinner + “Capturing N events…” with %; single-event copy uses “Capturing 1 event…”.
  - On complete: single = thumbnail + title/date with Dismiss; multi = “N events added”. Tap opens the event or batch.
  - Auto-dismisses 5 minutes after completion; mounted only when `SUPPORTS_LIQUID_GLASS` and a batch is active; state lives in `useAppStore` and is not persisted.

- Bug Fixes
  - Never drop taps while status is loading; default to opening the batch unless a single event is certain. Partial-failure multi-captures with one success now open the batch.
  - Stuck-batch safety net: auto-clear if backend progress hasn’t changed for 10 minutes, starting only after the first status payload; resets on progress; resets only when the app is foreground AND online; skips once a terminal state is reported; never arms before the first backend payload.
  - Don’t dismiss on capture errors; rely on the stuck-batch safety net instead.
  - Gate `setAccessoryBatch` and the `getBatchStatus` subscription on `SUPPORTS_LIQUID_GLASS`; clear accessory and pending batch state immediately on sign-out.
  - Layout fixes: tighter capsule, proper text ellipsis, smaller icons, and removed Share (share from the event screen).

<sup>Written for commit e1697b9db128ec1cd4aadd3bb340d797430f14da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an iOS 26-only "Now Playing"-style mini-player above the tab bar that surfaces the current event-capture batch — showing a live spinner during processing, then a thumbnail/title or multi-event summary on completion, with Share and Dismiss actions. The implementation is clean: all shared state lives in `useInFlightEventStore` (in-memory only), the lifecycle hook is mounted once at the root to avoid dual-instance state drift, Convex queries are correctly skipped when no batch is active, and the auto-dismiss timer handles the app-backgrounded case via the `remaining ≤ 0` path. Only two minor P2 style issues were found in `CaptureAccessory.tsx`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style suggestions that don't affect runtime behavior.

No P0 or P1 issues found. The lifecycle management, timer cleanup, sign-out clearing, and Convex query deduplication are all correctly handled. The two P2 comments (redundant else-if branch and single-event copy text) are cosmetic and non-blocking.

apps/expo/src/components/CaptureAccessory.tsx (two minor P2 style issues)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/CaptureAccessory.tsx | New 512-line component rendering Regular and Inline accessory variants using NativeTabs.BottomAccessory; two minor P2 style issues (dead else-if branch, inconsistent single-event copy). |
| apps/expo/src/hooks/useCaptureAccessoryLifecycle.ts | New hook for marking batch completion and running a 5-min auto-dismiss timer; timer cleanup is correct, remaining-<=0 early-dismiss path is correctly handled. |
| apps/expo/src/store/useInFlightEventStore.ts | Adds accessoryBatchId/accessoryStartedAt/accessoryCompletedAt state with idempotent markAccessoryCompleted guard; in-memory only, correctly resets on setAccessoryBatch. |
| apps/expo/src/hooks/useCreateEvent.ts | Calls setAccessoryBatch(batchId) after awaited batch creation in both single- and multi-image flows, ensuring the batch exists in Convex before the query fires. |
| apps/expo/src/hooks/useSignOut.ts | Correctly clears both dismissAccessoryBatch and clearPendingBatchIds on sign-out to prevent stale Convex queries under a new identity. |
| apps/expo/src/app/(tabs)/_layout.tsx | Conditionally mounts NativeTabs.BottomAccessory only when SUPPORTS_LIQUID_GLASS and accessoryBatchId are truthy; TypeScript narrowing requires the redundant batchId check. |
| apps/expo/src/app/_layout.tsx | Mounts useCaptureAccessoryLifecycle once at the root inside Convex context — correct placement given the dual-instance rendering of the accessory. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant CE as useCreateEvent
    participant Store as useInFlightEventStore
    participant LC as useCaptureAccessoryLifecycle
    participant CX as Convex (getBatchStatus)
    participant AC as CaptureAccessory

    U->>CE: Capture photo(s)
    CE->>CX: createBatch / createBatchAndStartWorkflow
    CX-->>CE: batchId
    CE->>Store: setAccessoryBatch(batchId)
    Store-->>LC: accessoryBatchId set
    Store-->>AC: accessoryBatchId set → mounts BottomAccessory
    LC->>CX: useQuery getBatchStatus (live)
    AC->>CX: useQuery getBatchStatus (deduped)
    CX-->>LC: status = completed
    LC->>Store: markAccessoryCompleted()
    Store-->>AC: accessoryCompletedAt set → flips to terminal UI
    LC->>LC: setTimeout(dismiss, 5min)
    Note over LC: User taps or 5 min elapses
    LC->>Store: dismissAccessoryBatch()
    Store-->>AC: accessoryBatchId = null → unmounts BottomAccessory
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/components/CaptureAccessory.tsx
Line: 64-68

Comment:
**Redundant else-if branch**

Both the `else if (status.successCount > 0)` and the bare `else` branches navigate to the same `/batch/${batchId}` route, so the condition is never meaningful. Simplify to a single fallback:

```suggestion
    } else {
      router.navigate(`/batch/${batchId}`);
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/components/CaptureAccessory.tsx
Line: 334-336

Comment:
**Awkward copy for single-event in-progress state**

When `total === 1`, `plural` is `"event"` and the title becomes `"Capturing event…"` — the only copy variant that omits a count/article. Every other variant (`"3 events added"`, `"Capturing 3 events…"`) includes a number, so this reads oddly alongside them. Consider `"Capturing 1 event…"` or `"Capturing an event…"` for consistency:

```suggestion
    const plural = total === 1 ? "1 event" : `${total} events`;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): iOS 26 tab bar accessory for..."](https://github.com/jaronheard/soonlist-turbo/commit/ddf42128947f75bfd619b9233bc77b60d1dc4afe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29577087)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->