### PR TITLE
refactor(expo): reserve 'subscription' for list subscriptions in settings

### DIFF
--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -340,26 +340,26 @@ export default function AccountScreen() {
     }
   }, []);
 
-  const handleSubscriptionPress = useCallback(() => {
+  const handleProPlanPress = useCallback(() => {
     if (!user) return;
     const hasUnlimited =
       customerInfo?.entitlements.active.unlimited?.isActive ?? false;
-    const stripeSubscription =
+    const isStripePlan =
       customerInfo?.originalPurchaseDate &&
       new Date(customerInfo.originalPurchaseDate) <= new Date(2025, 2, 7);
 
-    if (hasUnlimited && !stripeSubscription) {
+    if (hasUnlimited && !isStripePlan) {
       void Linking.openURL("itms-apps://apps.apple.com/account/subscriptions");
       return;
     }
-    if (hasUnlimited && stripeSubscription) {
+    if (hasUnlimited && isStripePlan) {
       void Linking.openURL("https://www.soonlist.com/account/plans");
       return;
     }
     void showProPaywallIfNeeded();
   }, [user, customerInfo, showProPaywallIfNeeded]);
 
-  const subscriptionValue = (() => {
+  const planValue = (() => {
     const hasUnlimited =
       customerInfo?.entitlements.active.unlimited?.isActive ?? false;
     return hasUnlimited ? "Pro" : "Free plan";
@@ -567,8 +567,8 @@ export default function AccountScreen() {
             icon={Sparkles}
             iconBg={TILE_COLORS.purple}
             label="Upgrade to Pro"
-            value={subscriptionValue}
-            onPress={handleSubscriptionPress}
+            value={planValue}
+            onPress={handleProPlanPress}
           />
           <SettingsRow
             icon={HelpCircle}


### PR DESCRIPTION
## Summary

Reserves the word "subscription" for **list subscriptions** (following other users' lists) by renaming internal paid-tier identifiers in the Account settings screen.

The user-facing copy in [`apps/expo/src/app/settings/account.tsx`](apps/expo/src/app/settings/account.tsx) is already non-conflicting (`"Upgrade to Pro"` / `"Pro"` / `"Free plan"` — changed in #1043), but the underlying identifiers still used `subscription`/`Subscription`, which made the codebase ambiguous between the two concepts.

Renames in `apps/expo/src/app/settings/account.tsx`:

- `handleSubscriptionPress` → `handleProPlanPress`
- `subscriptionValue` → `planValue`
- `stripeSubscription` → `isStripePlan`

Left untouched:

- The literal Apple deep-link `itms-apps://apps.apple.com/account/subscriptions` (Apple's screen is named "Subscriptions").
- All `Subscribe`/`Subscribed`/`SubscribeButton` references — those refer to **list subscriptions** and should keep that naming.
- `SubscriptionGuard`, `RevenueCatProvider`, `getCurrentSubscriptionStatus`, etc. (out of scope; the task targets the settings screen).

## Test plan

- [ ] Open Settings → SOONLIST group → confirm row still reads `Upgrade to Pro` with `Pro` / `Free plan` value
- [ ] Tap the row as a free user → paywall sheet appears
- [ ] Tap the row as a Pro (App Store) user → opens iOS Subscriptions
- [ ] Tap the row as a legacy Stripe Pro user → opens https://www.soonlist.com/account/plans
- [ ] `pnpm typecheck` clean
- [ ] No new lint errors in `account.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed paid-tier identifiers in the Expo Account settings to reserve "subscription" for list subscriptions. No UI or behavior changes; this is a naming clarity refactor.

- **Refactors**
  - handleSubscriptionPress → handleProPlanPress
  - subscriptionValue → planValue
  - stripeSubscription → isStripePlan

<sup>Written for commit 23f1a01da67db696ae598096c230268994fe302a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a pure identifier-rename refactoring in `apps/expo/src/app/settings/account.tsx` — no logic changes. `handleSubscriptionPress` → `handleProPlanPress`, `subscriptionValue` → `planValue`, and `stripeSubscription` → `isStripePlan` to disambiguate paid-tier internals from the list-subscription concept used elsewhere in the app. All three old identifiers are fully replaced with no remaining occurrences.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a rename refactoring with no behavioral changes.

The PR touches a single file with three local identifier renames and zero logic changes. All old identifiers are fully replaced and the diff verifies the behavior is identical to before.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/settings/account.tsx | Pure rename of three internal identifiers (handleSubscriptionPress → handleProPlanPress, subscriptionValue → planValue, stripeSubscription → isStripePlan); no logic changes, no remaining stale references. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps 'Upgrade to Pro' row] --> B{handleProPlanPress}
    B --> C{hasUnlimited?}
    C -- No --> D[showProPaywallIfNeeded]
    C -- Yes --> E{isStripePlan?}
    E -- No --> F[Open itms-apps://…/subscriptions]
    E -- Yes --> G[Open soonlist.com/account/plans]
```

<sub>Reviews (1): Last reviewed commit: ["refactor(expo): rename paid-tier identif..."](https://github.com/jaronheard/soonlist-turbo/commit/23f1a01da67db696ae598096c230268994fe302a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29745982)</sub>

<!-- /greptile_comment -->