### PR TITLE
fix: use first name only for default Soonlist name

### DIFF
--- a/apps/expo/src/app/[username]/index.tsx
+++ b/apps/expo/src/app/[username]/index.tsx
@@ -32,6 +32,7 @@ import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import { useLoadMoreHandler } from "~/hooks/useUpcomingFeed";
 import { useStableTimestamp } from "~/store";
 import Config from "~/utils/config";
+import { firstNameFromDisplayName } from "~/utils/displayName";
 import { logError } from "~/utils/errorLogging";
 import { toast } from "~/utils/feedback";
 import { eventMatchesFeedSegment } from "~/utils/feedSegment";
@@ -286,7 +287,7 @@ export default function UserProfilePage() {
     if (!targetUser) return "";
     const fromList = personalList?.name?.trim();
     const fromUser = targetUser.publicListName?.trim();
-    const fallback = `${targetUser.displayName?.trim() || targetUser.username}'s Soonlist`;
+    const fallback = `${firstNameFromDisplayName(targetUser.displayName) || targetUser.username}'s Soonlist`;
     return fromList || fromUser || fallback;
   }, [targetUser, personalList]);
 

--- a/apps/expo/src/app/share-setup.tsx
+++ b/apps/expo/src/app/share-setup.tsx
@@ -30,6 +30,7 @@ import { Camera, User } from "~/components/icons";
 import ScenePreviewThreeUp from "~/components/ScenePreviewThreeUp";
 import { useStablePaginatedQuery } from "~/hooks/useStableQuery";
 import Config from "~/utils/config";
+import { firstNameFromDisplayName } from "~/utils/displayName";
 import { logError } from "~/utils/errorLogging";
 
 const INPUT_CLASSES = "rounded-xl bg-interactive-3 text-neutral-1";
@@ -53,7 +54,7 @@ export default function ShareSetupScreen() {
 
   const defaultListName =
     currentUser?.publicListName ||
-    `${currentUser?.displayName ?? user?.firstName ?? "My"}'s Soonlist`;
+    `${user?.firstName ?? firstNameFromDisplayName(currentUser?.displayName) ?? "My"}'s Soonlist`;
 
   const [listName, setListName] = useState(defaultListName);
   const [displayName, setDisplayName] = useState("");
@@ -75,7 +76,7 @@ export default function ShareSetupScreen() {
     seededRef.current = true;
     setListName(
       currentUser.publicListName ||
-        `${currentUser.displayName ?? user?.firstName ?? "My"}'s Soonlist`,
+        `${user?.firstName ?? firstNameFromDisplayName(currentUser.displayName) ?? "My"}'s Soonlist`,
     );
     setDisplayName(currentUser.displayName ?? "");
     setLinks({

--- a/apps/expo/src/app/share-setup.tsx
+++ b/apps/expo/src/app/share-setup.tsx
@@ -54,7 +54,7 @@ export default function ShareSetupScreen() {
 
   const defaultListName =
     currentUser?.publicListName ||
-    `${user?.firstName ?? firstNameFromDisplayName(currentUser?.displayName) ?? "My"}'s Soonlist`;
+    `${firstNameFromDisplayName(currentUser?.displayName) ?? user?.firstName ?? "My"}'s Soonlist`;
 
   const [listName, setListName] = useState(defaultListName);
   const [displayName, setDisplayName] = useState("");
@@ -76,7 +76,7 @@ export default function ShareSetupScreen() {
     seededRef.current = true;
     setListName(
       currentUser.publicListName ||
-        `${user?.firstName ?? firstNameFromDisplayName(currentUser.displayName) ?? "My"}'s Soonlist`,
+        `${firstNameFromDisplayName(currentUser.displayName) ?? user?.firstName ?? "My"}'s Soonlist`,
     );
     setDisplayName(currentUser.displayName ?? "");
     setLinks({

--- a/apps/expo/src/utils/displayName.ts
+++ b/apps/expo/src/utils/displayName.ts
@@ -1,0 +1,8 @@
+export function firstNameFromDisplayName(
+  displayName: string | undefined | null,
+): string | undefined {
+  const trimmed = displayName?.trim();
+  if (!trimmed) return undefined;
+  const [first] = trimmed.split(/\s+/, 1);
+  return first || undefined;
+}

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -18,7 +18,7 @@ import {
 } from "./feedHelpers";
 import { enrichEventsAndFilterNulls } from "./model/events";
 import { getViewableListIds } from "./model/lists";
-import { generatePublicId } from "./utils";
+import { firstNameFromDisplayName, generatePublicId } from "./utils";
 
 type EnrichedEvent = Awaited<
   ReturnType<typeof enrichEventsAndFilterNulls>
@@ -171,13 +171,15 @@ export async function getOrCreatePersonalList(
     .first();
 
   const displayName = user?.displayName || user?.username || "User";
+  const nameForList =
+    firstNameFromDisplayName(user?.displayName) || user?.username || "User";
   const username = user?.username || "user";
   const listId = generatePublicId();
 
   const docId = await ctx.db.insert("lists", {
     id: listId,
     userId,
-    name: `${displayName}'s Soonlist`,
+    name: `${nameForList}'s Soonlist`,
     description: `${displayName}'s Soonlist`,
     visibility: "public",
     isSystemList: true,

--- a/packages/backend/convex/lists.ts
+++ b/packages/backend/convex/lists.ts
@@ -170,7 +170,6 @@ export async function getOrCreatePersonalList(
     .withIndex("by_custom_id", (q) => q.eq("id", userId))
     .first();
 
-  const displayName = user?.displayName || user?.username || "User";
   const nameForList =
     firstNameFromDisplayName(user?.displayName) || user?.username || "User";
   const username = user?.username || "user";
@@ -180,7 +179,7 @@ export async function getOrCreatePersonalList(
     id: listId,
     userId,
     name: `${nameForList}'s Soonlist`,
-    description: `${displayName}'s Soonlist`,
+    description: `${nameForList}'s Soonlist`,
     visibility: "public",
     isSystemList: true,
     systemListType: "personal",

--- a/packages/backend/convex/utils.ts
+++ b/packages/backend/convex/utils.ts
@@ -88,3 +88,12 @@ export function safeStringify(value: unknown): string {
 export function generateNotificationId() {
   return `not_${generatePublicId()}`;
 }
+
+export function firstNameFromDisplayName(
+  displayName: string | undefined | null,
+): string | undefined {
+  const trimmed = displayName?.trim();
+  if (!trimmed) return undefined;
+  const [first] = trimmed.split(/\s+/, 1);
+  return first || undefined;
+}


### PR DESCRIPTION
## Summary

- Default personal Soonlist name now uses first name only — e.g. `Jaron's Soonlist` instead of `Jaron Heard's Soonlist`.
- Same change applied to the Expo fallback name in `share-setup.tsx` and the public profile fallback in `[username]/index.tsx` so they stay aligned with the persisted format.
- Adds a small `firstNameFromDisplayName` helper (in backend `utils.ts` and Expo `utils/displayName.ts`) that splits on the first whitespace. The user record only stores `displayName`, so deriving the first name from it is the only option in the backend.

Existing personal lists keep their stored names — only newly created lists pick up the new default. No backfill.

## Test plan

- [ ] New user signup flow creates a personal list named `${firstName}'s Soonlist`
- [ ] User with single-word `displayName` (e.g. just "Jaron") still gets `Jaron's Soonlist`
- [ ] User with no `displayName` falls back to username (`username's Soonlist`)
- [ ] Existing users with personal lists are unaffected
- [ ] Share-setup screen shows first-name-only default
- [ ] Public profile fallback (no list yet) shows first-name-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Soonlist names and descriptions now use the first name only across backend creation and Expo fallbacks, e.g. "Jaron's Soonlist".
Expo share-setup now prefers `firstNameFromDisplayName(currentUser.displayName)` over Clerk `user.firstName`; the `firstNameFromDisplayName` helper was added in backend and Expo, and existing lists are unchanged.

<sup>Written for commit a071c71bda0016b4412d1cacc098476a4a532eb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the default personal Soonlist name to use first name only (e.g. `Jaron's Soonlist` instead of `Jaron Heard's Soonlist`) by introducing a `firstNameFromDisplayName` helper in both the Convex backend and Expo app. The change is applied consistently across list creation, the share-setup screen, and the public profile fallback display — existing lists are unaffected.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only P2 findings, no regressions on existing data or auth paths.

All findings are P2 (style/consistency). The helper logic is correct, edge cases (null, empty string, single-word name) are handled, and existing lists are untouched.

packages/backend/convex/lists.ts — minor inconsistency between `name` and `description` fields for newly created lists.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/utils.ts | Adds `firstNameFromDisplayName` helper — splits on whitespace, returns undefined for empty input. Logic is correct. |
| packages/backend/convex/lists.ts | Uses `firstNameFromDisplayName` for `name` but keeps full `displayName` for `description`, creating a minor inconsistency on newly-created lists. |
| apps/expo/src/utils/displayName.ts | New Expo-side duplicate of the backend helper — identical logic, P2 duplication concern only. |
| apps/expo/src/app/share-setup.tsx | Reorders priority to prefer Clerk `user.firstName` over derived display name and applies `firstNameFromDisplayName` as the fallback — correct and consistent. |
| apps/expo/src/app/[username]/index.tsx | Applies `firstNameFromDisplayName` to the read-only fallback title — straightforward and correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User signs up / triggers getOrCreatePersonalList] --> B{user.displayName set?}
    B -- Yes --> C[firstNameFromDisplayName displayName]
    B -- No --> D[user.username]
    C --> E{first token found?}
    E -- Yes --> F[firstName]
    E -- No --> D
    F --> G["name: firstName + 's Soonlist'"]
    D --> G
    G --> H[Insert list record]

    subgraph Expo Share Setup
        I[user.firstName from Clerk] --> K{available?}
        K -- Yes --> L[Use Clerk firstName]
        K -- No --> M[firstNameFromDisplayName currentUser.displayName]
        M --> N{available?}
        N -- Yes --> L
        N -- No --> O["'My'"]
        L --> P[listName default]
        O --> P
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/backend/convex/lists.ts
Line: 183

Comment:
**`description` still uses full `displayName`**

The `name` field now uses `nameForList` (first name only), but `description` still uses the full `displayName`. This means a new list could have `name: "Jaron's Soonlist"` and `description: "Jaron Heard's Soonlist"`. If the description is shown to users, the inconsistency may be surprising. Consider aligning them unless the full name is intentional for the description.

```suggestion
    description: `${nameForList}'s Soonlist`,
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/src/utils/displayName.ts
Line: 1-8

Comment:
**Duplicated helper across packages**

`firstNameFromDisplayName` is identical in `packages/backend/convex/utils.ts` and `apps/expo/src/utils/displayName.ts`. If the splitting logic ever changes (e.g. to handle hyphens or middle names), both copies need to be updated in sync. Consider whether a shared `packages/utils` (or similar) package could host this helper, or at least add a comment pointing to the sibling copy.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use first name only for default Soo..."](https://github.com/jaronheard/soonlist-turbo/commit/15d80cd403187f96b81d240b6d02fe9c8a668cce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746052)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->