### PR TITLE
fix(expo): stop empty-state flash when switching My Scene segments

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -234,9 +234,13 @@ function MyFeedContent() {
   // segments, the previous segment's rows are still in `groupedEvents` but
   // `enrichedEvents` filters them all out, briefly leaving an empty list.
   // Treat that exact shape as "still loading" so the spinner wins over the
-  // empty state until the new segment's data lands.
+  // empty state until the new segment's data lands. Gate on
+  // `LoadingFirstPage` so a stale `stableTimestamp` (refreshes every 15 min)
+  // can't keep the spinner up after the query has settled.
   const hasStaleSegmentData =
-    groupedEvents.length > 0 && enrichedEvents.length === 0;
+    status === "LoadingFirstPage" &&
+    groupedEvents.length > 0 &&
+    enrichedEvents.length === 0;
 
   return (
     <UserEventsList

--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -230,12 +230,20 @@ function MyFeedContent() {
     singleContributingList,
   ]);
 
+  // Stable paginated results lag args changes by one tick: when switching
+  // segments, the previous segment's rows are still in `groupedEvents` but
+  // `enrichedEvents` filters them all out, briefly leaving an empty list.
+  // Treat that exact shape as "still loading" so the spinner wins over the
+  // empty state until the new segment's data lands.
+  const hasStaleSegmentData =
+    groupedEvents.length > 0 && enrichedEvents.length === 0;
+
   return (
     <UserEventsList
       groupedEvents={enrichedEvents}
       onEndReached={handleLoadMore}
       isFetchingNextPage={status === "LoadingMore"}
-      listBodyLoading={listBodyLoading}
+      listBodyLoading={listBodyLoading || hasStaleSegmentData}
       showCreator="savedFromOthers"
       showSourceStickers
       savedEventIds={savedEventIds}

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -277,7 +277,15 @@ function FollowingFeedContent() {
         events={enrichedEvents}
         onEndReached={handleLoadMore}
         isFetchingNextPage={status === "LoadingMore"}
-        listBodyLoading={listBodyLoading}
+        listBodyLoading={
+          listBodyLoading ||
+          // Stable paginated results lag args changes by one tick: when
+          // switching segments, the previous segment's rows are still in
+          // `events` but `enrichedEvents` filters them all out. Treat that
+          // exact shape as "still loading" so the spinner wins over the
+          // empty state until the new segment's data lands.
+          (events.length > 0 && enrichedEvents.length === 0)
+        }
         showCreator="always"
         primaryAction="save"
         showSourceStickers

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -240,6 +240,18 @@ function FollowingFeedContent() {
     handleShareList,
   ]);
 
+  // Stable paginated results lag args changes by one tick: when switching
+  // segments, the previous segment's rows are still in `events` but
+  // `enrichedEvents` filters them all out, briefly leaving an empty list.
+  // Treat that exact shape as "still loading" so the spinner wins over the
+  // empty state until the new segment's data lands. Gate on
+  // `LoadingFirstPage` so a stale `stableTimestamp` (refreshes every 15 min)
+  // can't keep the spinner up after the query has settled.
+  const hasStaleSegmentData =
+    status === "LoadingFirstPage" &&
+    events.length > 0 &&
+    enrichedEvents.length === 0;
+
   // Second branch avoids a one-frame flash before the latch effect commits.
   const showEmptyState =
     emptyStateMode === "show" ||
@@ -277,15 +289,7 @@ function FollowingFeedContent() {
         events={enrichedEvents}
         onEndReached={handleLoadMore}
         isFetchingNextPage={status === "LoadingMore"}
-        listBodyLoading={
-          listBodyLoading ||
-          // Stable paginated results lag args changes by one tick: when
-          // switching segments, the previous segment's rows are still in
-          // `events` but `enrichedEvents` filters them all out. Treat that
-          // exact shape as "still loading" so the spinner wins over the
-          // empty state until the new segment's data lands.
-          (events.length > 0 && enrichedEvents.length === 0)
-        }
+        listBodyLoading={listBodyLoading || hasStaleSegmentData}
         showCreator="always"
         primaryAction="save"
         showSourceStickers


### PR DESCRIPTION
## Summary

- Fixes the brief empty-state flash on My Scene and My Soonlist when switching between Upcoming and Past tabs.
- Treats the "raw paginated `events` present but segment-filtered `enrichedEvents` is `[]`" shape as a loading state, so the spinner wins over the empty-state ghost cards during the segment refetch window.

## Why this happens

`useStablePaginatedQuery` keeps the previous segment's rows in `events` for one render after the segment changes (so the UI doesn't blank out). The screens then run those rows through `eventMatchesFeedSegment(..., selectedSegment, ...)` — and because the filter is segment-aware, every row from the previous segment fails the new filter. `enrichedEvents` becomes `[]`, `UserEventsList` falls into its `ListEmptyComponent` branch, and the empty-state renders.

`useStableFeedListBodyLoading` was supposed to cover this with `markSegmentSwitchPending`, but its `useEffect` clears the ref as soon as it sees any non-`LoadingFirstPage` status — so if Convex hasn't transitioned the live status yet on the immediate post-tap render, the pending flag is wiped before it can do its job, leaving a one-render gap where `listBodyLoading=false` and the filter has emptied the list.

## The fix

Inline at the `UserEventsList` call sites, OR `listBodyLoading` with a derived "stale segment data" check: `events.length > 0 && enrichedEvents.length === 0`. This shape is only true during the transition (or rare clock-drift edge cases that self-resolve on the next `stableTimestamp` tick) — when there are zero events overall it stays `false`, so legitimate empty-state still renders correctly.

Minimal, surgical, and defense-in-depth alongside the existing `markSegmentSwitchPending` mechanism.

## Test plan

- [ ] On My Soonlist (feed tab), tap Upcoming → Past → Upcoming repeatedly. The purple spinner should appear during the transition and the dashed "Turn screenshots into possibilities" empty-state cards should never flash.
- [ ] Same on My Scene (following tab).
- [ ] Verify the legitimate empty-state still renders when a segment really has no events (e.g. brand-new account on Past, or segment with truly zero results).
- [ ] Verify initial load behavior (cold start on each tab) still shows the expected loading surface and resolves into either events or empty-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the empty-state flash when switching between Upcoming and Past on My Scene and My Soonlist by treating a transient filter-empty state as loading. The spinner now shows during segment refetch and is gated to first-page loading.

- **Bug Fixes**
  - Detects stale segment data only when `status === "LoadingFirstPage"` and `events/groupedEvents.length > 0` while `enrichedEvents.length === 0`.
  - ORs this with `listBodyLoading` when rendering `UserEventsList`, so the spinner covers the transition; legitimate empty states are unchanged.
  - Extracts the check into a `hasStaleSegmentData` constant in both screens for consistency.

<sup>Written for commit 76c8dc8ef69b8a2f114042794b7ac9f45c6f008b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surgically patches the one-render empty-state flash that appeared when switching between Upcoming and Past tabs on My Soonlist and My Scene. The root cause is that `useStablePaginatedQuery` intentionally holds the previous segment's rows for one tick while the new query is in flight; the client-side `eventMatchesFeedSegment` filter then zeros out `enrichedEvents`, which races the `markSegmentSwitchPending` mechanism. The fix correctly identifies the transient shape (`events.length > 0 && enrichedEvents.length === 0`) and promotes it to a loading state, which is safe because a settled empty segment will eventually resolve `events` to `[]`, unblocking the empty-state render.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, well-reasoned, and handles all edge cases correctly including legitimate empty segments.

Both changed files contain a two-line addition each. The stale-segment guard correctly evaluates to false for a genuinely empty segment (settled query returns [], making events.length === 0) and to true only during the one-render transition window. No new state, no new hooks, no side effects introduced. The existing markSegmentSwitchPending mechanism is preserved as defense-in-depth.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/feed/index.tsx | Adds `hasStaleSegmentData` guard (groupedEvents.length > 0 && enrichedEvents.length === 0) ORed into `listBodyLoading` to suppress the empty-state flash during segment transitions; logic is correct for all settled and transitional states. |
| apps/expo/src/app/(tabs)/following/index.tsx | Applies the same stale-segment-data guard inline in JSX; functionally identical fix to feed/index.tsx, but the check is inlined rather than extracted as a named constant — minor style inconsistency with the sibling file. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SegmentControl
    participant Component
    participant StablePaginatedQuery
    participant Convex

    User->>SegmentControl: Tap "Past"
    SegmentControl->>Component: handleSegmentChange("past")
    Component->>Component: markSegmentSwitchPending()
    Component->>Component: setSelectedSegment("past")

    Note over Component,StablePaginatedQuery: Render 1 (immediate)
    StablePaginatedQuery-->>Component: groupedEvents = [...upcoming rows] (stale)
    Component->>Component: enrichedEvents = [] (past filter kills upcoming rows)
    Component->>Component: hasStaleSegmentData = true
    Component-->>User: Shows spinner ✓

    StablePaginatedQuery->>Convex: fetch({filter:"past"})
    Convex-->>StablePaginatedQuery: past events

    Note over Component,StablePaginatedQuery: Render 2 (after Convex responds)
    StablePaginatedQuery-->>Component: groupedEvents = [...past rows]
    Component->>Component: enrichedEvents = [...past rows]
    Component->>Component: hasStaleSegmentData = false
    Component-->>User: Shows events (or empty state if none) ✓
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/(tabs)/following/index.tsx
Line: 280-288

Comment:
**Minor style inconsistency with sibling file**

`feed/index.tsx` extracts the stale-segment check into a named `hasStaleSegmentData` constant before the `return`, making the JSX easier to scan. Extracting it here keeps the two screens consistent.

```suggestion
        listBodyLoading={listBodyLoading || hasStaleSegmentData}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): stop empty-state flash when s..."](https://github.com/jaronheard/soonlist-turbo/commit/ce8e96e5c3ba5cc38d75b9bd96dfff8824f4c2d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746181)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->