### PR TITLE
feat(expo): anchor share copy on list concept in onboarding

### DIFF
--- a/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
@@ -137,7 +137,7 @@ export default function YourListScreen() {
   return (
     <QuestionContainer
       question="Meet your Soonlist"
-      subtitle="Share all your events in one list."
+      subtitle="All your events in one shareable link."
       currentStep={2}
       totalSteps={totalSteps}
     >

--- a/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
@@ -137,7 +137,7 @@ export default function YourListScreen() {
   return (
     <QuestionContainer
       question="Meet your Soonlist"
-      subtitle="All in one place. Share with just a link."
+      subtitle="Share all your events in one list."
       currentStep={2}
       totalSteps={totalSteps}
     >
@@ -150,15 +150,18 @@ export default function YourListScreen() {
           }}
         >
           {/* Share hint */}
-          <View className="flex-row items-center justify-between bg-interactive-2 px-4 py-2">
+          <View className="flex-row items-center justify-between bg-interactive-2 px-3 py-2">
             <Text className="text-sm font-semibold text-interactive-1">
               soonlist.com/you
             </Text>
-            <SymbolView
-              name="square.and.arrow.up"
-              size={16}
-              tintColor="#5A32FB"
-            />
+            <View className="flex-row items-center gap-1.5 rounded-full bg-interactive-1 px-3 py-1.5">
+              <SymbolView
+                name="square.and.arrow.up"
+                size={14}
+                tintColor="#FFFFFF"
+              />
+              <Text className="text-xs font-bold text-white">Share</Text>
+            </View>
           </View>
           <View style={{ marginLeft: -6, marginRight: 6 }} className="flex-1">
             <UserEventsList

--- a/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
+++ b/apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx
@@ -137,7 +137,7 @@ export default function YourListScreen() {
   return (
     <QuestionContainer
       question="Meet your Soonlist"
-      subtitle="All your events in one shareable link."
+      subtitle="All your events in one shareable list."
       currentStep={2}
       totalSteps={totalSteps}
     >


### PR DESCRIPTION
## Summary
- Subtitle on the "Meet your Soonlist" onboarding screen now anchors on the list concept ("Share all your events in one list.") instead of "All in one place. Share with just a link." — at this point in onboarding, users are first encountering the list idea and the prior copy read as if sharing were event-by-event.
- Promoted the share affordance in the in-screen URL preview from a tiny purple icon next to `soonlist.com/you` to a filled pill button (`Share` label + share glyph on `interactive-1`), so the share CTA is obviously tappable on first read.

## Why
This screen is the user's first introduction to the "Soonlist" — the shareable list of all your events. The previous copy underplayed that and the share icon was easy to miss, so users could leave the screen without internalizing that their whole list is shareable via a single link.

## Test plan
- [ ] Run the Expo app and navigate through onboarding to step 2 ("Meet your Soonlist"); confirm the subtitle reads "Share all your events in one list."
- [ ] Confirm the share button in the demo URL bar reads "Share" with a share glyph on a purple pill, sitting next to `soonlist.com/you`.
- [ ] Confirm the rest of the demo list preview, the referral follow note, and the Continue button are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the "Meet your Soonlist" onboarding step to emphasize that all events live in one shareable list and makes the share action obvious. Updates the subtitle to "All your events in one shareable list." and replaces the tiny share icon with a prominent "Share" pill button next to the URL preview.

<sup>Written for commit 71828f4be9dd4d1f9b812fb018273b531fc0ab9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the "Meet your Soonlist" onboarding screen (step 2) with two focused UI changes: the subtitle copy is revised to emphasize the list concept ("Share all your events in one list."), and the share affordance in the demo URL bar is upgraded from a small bare icon to a clearly-labelled filled pill button. No logic, data, or navigation changes are included.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure UI/copy change with no logic, navigation, or data impact.

Change is limited to copy text and visual styling within a single onboarding screen. No logic, state, navigation, or API code was modified. Hardcoded tintColor="#FFFFFF" is a necessary compromise consistent with the existing borderColor: "#FFFFFF" pattern in the same file (SymbolView cannot accept NativeWind classes). No issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(onboarding)/onboarding/02-your-list.tsx | Subtitle copy updated and share affordance upgraded to a filled pill button using design tokens; change is self-contained with no logic or navigation impact. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[YourListScreen] --> B[QuestionContainer\n subtitle: 'Share all your events in one list.']
    B --> C[Demo list card\n bg-interactive-3]
    C --> D[Share hint bar\n bg-interactive-2]
    D --> E[soonlist.com/you\n text-interactive-1]
    D --> F[Pill button\n bg-interactive-1]
    F --> G[SymbolView\n square.and.arrow.up\n tintColor=#FFFFFF]
    F --> H[Text: 'Share'\n text-white]
    C --> I[UserEventsList\n demoMode=true]
    B --> J[Continue button]
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): anchor share copy on list co..."](https://github.com/jaronheard/soonlist-turbo/commit/3b997e37e55cda1f53e1b3903556cc1344c01a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746478)</sub>

<!-- /greptile_comment -->