### PR TITLE
feat(expo): show username in settings

### DIFF
--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -33,6 +33,7 @@ import {
   ShareIcon,
   Sparkles,
   Star,
+  User,
 } from "~/components/icons";
 import { SettingsGroup, SettingsRow } from "~/components/settings/SettingsList";
 import { useCalendar } from "~/hooks/useCalendar";
@@ -470,6 +471,13 @@ export default function AccountScreen() {
           header="YOUR PUBLIC PROFILE"
           footer="This is what people see when you share an event."
         >
+          <SettingsRow
+            icon={User}
+            iconBg={TILE_COLORS.gray}
+            label="Username"
+            value={maybeValue(user?.username)}
+            accessory={{ type: "none" }}
+          />
           <SettingsRow
             icon={PenSquare}
             iconBg={TILE_COLORS.purple}


### PR DESCRIPTION
## Summary

The user's username (Clerk handle) wasn't visible as a clearly labeled field anywhere in the settings screen — it only appeared as a small `@handle` subtitle in the hero, which doesn't make it obvious that's the canonical username.

This adds a read-only **Username** row at the top of the **YOUR PUBLIC PROFILE** group on the Account screen, matching the existing `SettingsRow` pattern.

## Changes

- [apps/expo/src/app/settings/account.tsx](apps/expo/src/app/settings/account.tsx): import `User` icon; render a non-pressable `SettingsRow` showing `user?.username` with a gray icon tile (visually distinguishing the read-only row from editable fields below).

## Test plan

- [ ] Open the app, sign in, navigate to Settings → Account
- [ ] Verify the new "Username" row appears at the top of "Your public profile" with the current username as the value
- [ ] Verify the row is not tappable (no chevron, no press feedback)
- [ ] Verify the existing rows (Display name, Instagram, Website, Email, Phone) still render and behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the user’s username in Settings → Account as a read-only “Username” row at the top of “Your public profile.” This makes the canonical handle easy to find and avoids confusion.

- **New Features**
  - Added a non-pressable `SettingsRow` with `User` icon and gray tile that displays `user?.username`; existing profile fields are unchanged.

<sup>Written for commit 953fe00d3bfb534edac630a249d0b3be7de7b112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a read-only **Username** row at the top of the "YOUR PUBLIC PROFILE" `SettingsGroup` on the Account screen, using the established `SettingsRow` pattern with `accessory={{ type: "none" }}` to suppress tap feedback and chevron. The implementation correctly reuses `maybeValue` for null/undefined safety and references the already-defined `TILE_COLORS.gray`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line UI addition with no logic changes or side effects.

Single, isolated UI addition that follows the established `SettingsRow` pattern exactly. No new data fetching, no state mutations, no edge-case risks; `maybeValue` already handles null/undefined for every other row in the group.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/settings/account.tsx | Adds `User` icon import and a non-pressable `SettingsRow` for username; correctly uses `maybeValue`, `TILE_COLORS.gray`, and `accessory={{ type: "none" }}.` |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User
    participant AccountScreen
    participant Clerk as useUser (Clerk)
    participant SettingsRow

    User->>AccountScreen: Navigate to Settings → Account
    AccountScreen->>Clerk: useUser()
    Clerk-->>AccountScreen: user.username (string | null)
    AccountScreen->>SettingsRow: label="Username" value=maybeValue(user?.username) accessory={type:"none"}
    SettingsRow-->>User: Renders read-only Username row (no chevron, no press)
```

<sub>Reviews (1): Last reviewed commit: ["feat(expo): show username in settings"](https://github.com/jaronheard/soonlist-turbo/commit/953fe00d3bfb534edac630a249d0b3be7de7b112) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746503)</sub>

<!-- /greptile_comment -->