### PR TITLE
fix(expo): restore event image background on QR share screen

### DIFF
--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -1,5 +1,6 @@
-import { Image, Text, TouchableOpacity, View } from "react-native";
+import { Text, TouchableOpacity, View } from "react-native";
 import QRCode from "react-native-qrcode-svg";
+import { Image as ExpoImage } from "expo-image";
 import { router, useLocalSearchParams } from "expo-router";
 import { useQuery } from "convex/react";
 
@@ -20,17 +21,25 @@ export default function QRModal() {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const eventData = event.event as AddToCalendarButtonProps;
   const qrValue = `${Config.apiBaseUrl}/event/${id}`;
-  const eventImage = eventData.images?.[0];
+  const eventImage = eventData.images?.[3];
+  const backgroundUri = eventImage
+    ? `${eventImage}?max-w=1284&fit=contain&f=webp&q=80`
+    : null;
+  const thumbnailUri = eventImage
+    ? `${eventImage}?w=160&h=160&fit=cover&f=webp&q=80`
+    : null;
 
   return (
     <View className="flex-1 bg-interactive-3">
-      {/* Background Image Container */}
-      {eventImage && (
+      {backgroundUri && (
         <View className="absolute inset-0 h-full w-full overflow-hidden">
-          <Image
-            source={{ uri: eventImage }}
-            className="absolute h-full w-full"
-            resizeMode="cover"
+          <ExpoImage
+            source={{ uri: backgroundUri }}
+            placeholder={thumbnailUri ? { uri: thumbnailUri } : undefined}
+            placeholderContentFit="cover"
+            style={{ width: "100%", height: "100%", position: "absolute" }}
+            contentFit="cover"
+            cachePolicy="memory-disk"
             blurRadius={10}
           />
           <View className="absolute inset-0 bg-interactive-1/20" />

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -29,16 +29,11 @@ export default function QRModal() {
         <View className="absolute inset-0 h-full w-full overflow-hidden">
           <Image
             source={{ uri: eventImage }}
-            style={{
-              width: "100%",
-              height: "100%",
-              position: "absolute",
-              opacity: 0.9,
-            }}
+            className="absolute h-full w-full"
             resizeMode="cover"
-            blurRadius={10}
+            blurRadius={20}
           />
-          <View className="absolute inset-0 bg-interactive-3/90" />
+          <View className="absolute inset-0 bg-black/30" />
         </View>
       )}
 

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -33,7 +33,7 @@ export default function QRModal() {
             resizeMode="cover"
             blurRadius={10}
           />
-          <View className="absolute inset-0 bg-black/30" />
+          <View className="absolute inset-0 bg-interactive-1/20" />
         </View>
       )}
 

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -11,6 +11,11 @@ import { X } from "~/components/icons";
 import { Logo } from "~/components/Logo";
 import Config from "~/utils/config";
 
+function appendImageParams(url: string, params: string) {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}${params}`;
+}
+
 export default function QRModal() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
@@ -23,10 +28,10 @@ export default function QRModal() {
   const qrValue = `${Config.apiBaseUrl}/event/${id}`;
   const eventImage = eventData.images?.[3];
   const backgroundUri = eventImage
-    ? `${eventImage}?max-w=1284&fit=contain&f=webp&q=80`
+    ? appendImageParams(eventImage, "max-w=1284&fit=contain&f=webp&q=80")
     : null;
   const thumbnailUri = eventImage
-    ? `${eventImage}?w=160&h=160&fit=cover&f=webp&q=80`
+    ? appendImageParams(eventImage, "w=160&h=160&fit=cover&f=webp&q=80")
     : null;
 
   return (

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -31,7 +31,7 @@ export default function QRModal() {
             source={{ uri: eventImage }}
             className="absolute h-full w-full"
             resizeMode="cover"
-            blurRadius={20}
+            blurRadius={10}
           />
           <View className="absolute inset-0 bg-black/30" />
         </View>


### PR DESCRIPTION
## Summary

The QR share screen was supposed to show the event's image as a blurred backdrop behind the white QR card, but the image was effectively invisible: a `bg-interactive-3/90` overlay (90% opaque light-lavender wash) sat on top of it, washing it out.

This PR restores visibility:

- Replace the `bg-interactive-3/90` overlay with `bg-black/30` — a soft dim that keeps the white QR card legible while letting the blurred image show through.
- Bump `blurRadius` 10 → 20 for a smoother, more app-store-share-card-style backdrop.
- Convert the leftover inline `style={{}}` on `<Image>` to NativeWind `className` (matches the rest of the codebase post-NativeWind migration).

No other behavior changes.

## Test plan

- [ ] Open the iOS app, navigate to an event with an image, tap the QR icon
- [ ] Confirm the event image appears blurred behind the white QR card
- [ ] Confirm the QR code itself remains crisp and scannable
- [ ] Open an event without an image — confirm the screen still falls back to the `bg-interactive-3` solid background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the event image as a visible, blurred backdrop on the QR share screen, and load it instantly from cache. Improves QR card readability and avoids redundant image downloads.

- **Bug Fixes**
  - Replace `bg-interactive-3/90` with `bg-interactive-1/20`; keep `blurRadius` at 10 so the background shows through while the QR stays crisp.
  - Preserve existing query params when appending image transforms to avoid broken backdrops and placeholders.

- **Performance**
  - Switch to `expo-image` and reuse the cached `images[3]` URL (`?max-w=1284&fit=contain&f=webp&q=80`, `cachePolicy="memory-disk"`), with a small thumbnail placeholder for instant paint.

<sup>Written for commit 674ab22faa430745c2329ea04faeac3eedfaeb96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the QR share screen backdrop by replacing a near-opaque `bg-interactive-3/90` overlay with a soft `bg-black/30` dim, allowing the blurred event image to actually show through. It also converts the `<Image>` `style` prop to NativeWind `className` and bumps `blurRadius` from 10 to 20. The no-image fallback (`bg-interactive-3` on the root `<View>`) is unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused visual-only fix with no logic changes and the no-image fallback path intact.

Single-file change with a clear, intentional fix. The NativeWind className conversion is correct (position, width, height all preserved; opacity removal is deliberate). The no-image fallback on the root View is untouched. No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/event/[id]/qr.tsx | Replaces opaque overlay with bg-black/30, bumps blurRadius to 20, converts Image style to NativeWind className; logic is correct and fallback path is unaffected. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QRModal renders] --> B{eventImage exists?}
    B -- No --> C[Root View bg-interactive-3\nshows as solid background]
    B -- Yes --> D[Absolute Image\nclassName: absolute h-full w-full\nblurRadius: 20\nresizeMode: cover]
    D --> E[Overlay View\nbg-black/30\n30% opaque dim]
    E --> F[White QR card\nbg-white/95 on top]
    C --> F
```

<sub>Reviews (1): Last reviewed commit: ["fix(expo): make event image visible behi..."](https://github.com/jaronheard/soonlist-turbo/commit/5db7a92c00dee305c54051645de08bd04f79cc04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746710)</sub>

<!-- /greptile_comment -->