### PR TITLE
fix(expo): My Scene tab badge shows true upcoming count

### DIFF
--- a/apps/expo/src/app/(tabs)/feed/index.tsx
+++ b/apps/expo/src/app/(tabs)/feed/index.tsx
@@ -173,13 +173,18 @@ function MyFeedContent() {
     requestShare({ eventCount: upcomingCount });
   }, [posthog, requestShare, upcomingCount]);
 
-  // Update tab badge count based on upcoming events
+  // Drive the badge from a dedicated count query, not the paginated feed.
+  // Paginated `enrichedEvents.length` is segment-locked and stale entries
+  // can linger in the cache after a feed change.
+  const upcomingGroupCount = useQuery(
+    api.feeds.getMyFeedUpcomingGroupCount,
+    {},
+  );
   const setMyListBadgeCount = useAppStore((s) => s.setMyListBadgeCount);
   useEffect(() => {
-    if (selectedSegment === "upcoming") {
-      setMyListBadgeCount(enrichedEvents.length);
-    }
-  }, [enrichedEvents.length, selectedSegment, setMyListBadgeCount]);
+    if (upcomingGroupCount === undefined) return;
+    setMyListBadgeCount(upcomingGroupCount);
+  }, [upcomingGroupCount, setMyListBadgeCount]);
 
   const handleSegmentChange = useCallback(
     (segment: Segment) => {

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -158,13 +158,19 @@ function FollowingFeedContent() {
       }));
   }, [events, stableTimestamp, selectedSegment]);
 
-  // Update tab badge count based on upcoming events
+  // Drive the tab badge from a server-side aggregate count. Paginated
+  // `enrichedEvents.length` undercounts past initialNumItems and stale
+  // entries from a just-unfollowed list linger in the pagination cache,
+  // so the badge drifts up after unfollow instead of down.
+  const upcomingCount = useQuery(
+    api.feeds.getFollowedListsFeedUpcomingCount,
+    {},
+  );
   const setCommunityBadgeCount = useAppStore((s) => s.setCommunityBadgeCount);
   useEffect(() => {
-    if (selectedSegment === "upcoming") {
-      setCommunityBadgeCount(enrichedEvents.length);
-    }
-  }, [enrichedEvents.length, selectedSegment, setCommunityBadgeCount]);
+    if (upcomingCount === undefined) return;
+    setCommunityBadgeCount(upcomingCount);
+  }, [upcomingCount, setCommunityBadgeCount]);
 
   const followedListCount = followedLists?.length ?? 0;
   const singleFollowedList =

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -158,10 +158,9 @@ function FollowingFeedContent() {
       }));
   }, [events, stableTimestamp, selectedSegment]);
 
-  // Drive the tab badge from a server-side aggregate count. Paginated
-  // `enrichedEvents.length` undercounts past initialNumItems and stale
-  // entries from a just-unfollowed list linger in the pagination cache,
-  // so the badge drifts up after unfollow instead of down.
+  // Drive the badge from a dedicated count query, not the paginated feed.
+  // Paginated `enrichedEvents.length` is segment-locked and stale entries
+  // from a just-unfollowed list can linger in the cache.
   const upcomingCount = useQuery(
     api.feeds.getFollowedListsFeedUpcomingCount,
     {},

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -358,30 +358,47 @@ export const getFollowedListsFeed = query({
   },
 });
 
-// Authoritative count for the My Scene tab badge. Paginated feed queries
-// undercount past initialNumItems and can leak entries from a just-
-// unfollowed list while the cache invalidates.
-//
-// The badge can briefly disagree with the rendered feed by up to ~15 min
-// because `hasEnded` is batch-corrected by a cron on the same cadence,
-// matching the client's stableTimestamp bucket. We deliberately do not
-// scan + correct here: that would diverge from the feed's own filter
-// (which uses stableTimestamp, not Date.now) and would pull an unbounded
-// set of "started but not yet flagged ended" entries.
+// Bounded upcoming count for the tab badges. Capped at BADGE_COUNT_CAP —
+// the badge is a glanceable hint, not a precise number, and capping keeps
+// the read cheap. `hasEnded` is the same flag the feed itself filters by
+// (cron-updated every 15 min), so the badge stays consistent with what
+// the feed renders.
+const BADGE_COUNT_CAP = 50;
+
+async function countUpcoming(
+  ctx: QueryCtx,
+  table: "userFeeds" | "userFeedGroups",
+  feedId: string,
+): Promise<number> {
+  const entries = await ctx.db
+    .query(table)
+    .withIndex("by_feed_hasEnded_startTime", (q) =>
+      q.eq("feedId", feedId).eq("hasEnded", false),
+    )
+    .take(BADGE_COUNT_CAP);
+  return entries.length;
+}
+
 export const getFollowedListsFeedUpcomingCount = query({
   args: {},
   returns: v.number(),
   handler: async (ctx) => {
     const userId = await getUserId(ctx);
     if (!userId) return 0;
+    return countUpcoming(ctx, "userFeeds", `followedLists_${userId}`);
+  },
+});
 
-    return userFeedsAggregate.count(ctx, {
-      namespace: `followedLists_${userId}`,
-      bounds: {
-        lower: { key: 0, inclusive: true },
-        upper: { key: 0, inclusive: true },
-      },
-    });
+// My Soonlist counts groups (matches what the feed actually renders —
+// duplicates collapse into one card, so counting raw events would
+// over-report relative to the visible list).
+export const getMyFeedUpcomingGroupCount = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return 0;
+    return countUpcoming(ctx, "userFeedGroups", `user_${userId}`);
   },
 });
 

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -358,6 +358,26 @@ export const getFollowedListsFeed = query({
   },
 });
 
+// Authoritative count for the My Scene tab badge. Paginated feed queries
+// undercount past initialNumItems and can leak entries from a just-
+// unfollowed list while the cache invalidates.
+export const getFollowedListsFeedUpcomingCount = query({
+  args: {},
+  returns: v.number(),
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return 0;
+
+    return userFeedsAggregate.count(ctx, {
+      namespace: `followedLists_${userId}`,
+      bounds: {
+        lower: { key: 0, inclusive: true },
+        upper: { key: 0, inclusive: true },
+      },
+    });
+  },
+});
+
 // Helper query to get followed users feed (events from users you follow)
 export const getFollowedUsersFeed = query({
   args: {

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -362,10 +362,12 @@ export const getFollowedListsFeed = query({
 // undercount past initialNumItems and can leak entries from a just-
 // unfollowed list while the cache invalidates.
 //
-// `hasEnded` is batch-corrected by cron every 15 min, so the aggregate can
-// briefly include entries whose events have actually ended. Subtract those
-// to keep the badge consistent with what the feed renders (the feed
-// re-filters by `eventEndTime` client-side via `eventMatchesFeedSegment`).
+// The badge can briefly disagree with the rendered feed by up to ~15 min
+// because `hasEnded` is batch-corrected by a cron on the same cadence,
+// matching the client's stableTimestamp bucket. We deliberately do not
+// scan + correct here: that would diverge from the feed's own filter
+// (which uses stableTimestamp, not Date.now) and would pull an unbounded
+// set of "started but not yet flagged ended" entries.
 export const getFollowedListsFeedUpcomingCount = query({
   args: {},
   returns: v.number(),
@@ -373,31 +375,13 @@ export const getFollowedListsFeedUpcomingCount = query({
     const userId = await getUserId(ctx);
     if (!userId) return 0;
 
-    const feedId = `followedLists_${userId}`;
-    const now = Date.now();
-
-    const total = await userFeedsAggregate.count(ctx, {
-      namespace: feedId,
+    return userFeedsAggregate.count(ctx, {
+      namespace: `followedLists_${userId}`,
       bounds: {
         lower: { key: 0, inclusive: true },
         upper: { key: 0, inclusive: true },
       },
     });
-
-    // Bounded scan: only entries that have started but are still flagged
-    // upcoming can have actually ended. Entries with future startTime
-    // can't be stale-ended.
-    const startedButFlaggedUpcoming = await ctx.db
-      .query("userFeeds")
-      .withIndex("by_feed_hasEnded_startTime", (q) =>
-        q.eq("feedId", feedId).eq("hasEnded", false).lte("eventStartTime", now),
-      )
-      .collect();
-    const staleEnded = startedButFlaggedUpcoming.filter(
-      (e) => e.eventEndTime < now,
-    ).length;
-
-    return total - staleEnded;
   },
 });
 

--- a/packages/backend/convex/feeds.ts
+++ b/packages/backend/convex/feeds.ts
@@ -361,6 +361,11 @@ export const getFollowedListsFeed = query({
 // Authoritative count for the My Scene tab badge. Paginated feed queries
 // undercount past initialNumItems and can leak entries from a just-
 // unfollowed list while the cache invalidates.
+//
+// `hasEnded` is batch-corrected by cron every 15 min, so the aggregate can
+// briefly include entries whose events have actually ended. Subtract those
+// to keep the badge consistent with what the feed renders (the feed
+// re-filters by `eventEndTime` client-side via `eventMatchesFeedSegment`).
 export const getFollowedListsFeedUpcomingCount = query({
   args: {},
   returns: v.number(),
@@ -368,13 +373,31 @@ export const getFollowedListsFeedUpcomingCount = query({
     const userId = await getUserId(ctx);
     if (!userId) return 0;
 
-    return userFeedsAggregate.count(ctx, {
-      namespace: `followedLists_${userId}`,
+    const feedId = `followedLists_${userId}`;
+    const now = Date.now();
+
+    const total = await userFeedsAggregate.count(ctx, {
+      namespace: feedId,
       bounds: {
         lower: { key: 0, inclusive: true },
         upper: { key: 0, inclusive: true },
       },
     });
+
+    // Bounded scan: only entries that have started but are still flagged
+    // upcoming can have actually ended. Entries with future startTime
+    // can't be stale-ended.
+    const startedButFlaggedUpcoming = await ctx.db
+      .query("userFeeds")
+      .withIndex("by_feed_hasEnded_startTime", (q) =>
+        q.eq("feedId", feedId).eq("hasEnded", false).lte("eventStartTime", now),
+      )
+      .collect();
+    const staleEnded = startedButFlaggedUpcoming.filter(
+      (e) => e.eventEndTime < now,
+    ).length;
+
+    return total - staleEnded;
   },
 });
 


### PR DESCRIPTION
## Summary

- Fixes the "My Scene" tab badge so it reflects the true number of upcoming events from subscribed lists, regardless of pagination, current segment, or recent unfollows.
- Adds a new Convex query `feeds.getFollowedListsFeedUpcomingCount` backed by the existing `userFeedsAggregate` (O(log n)) and points the badge at it.

## Why the count was wrong

The badge was reading `enrichedEvents.length` from the paginated `getFollowedListsFeed` query (initialNumItems=50). That count had three interacting bugs:

1. **Undercount past 50** — never increased beyond what was loaded into the first page.
2. **Stale-pagination drift after unfollow** — entries from a just-unfollowed list lingered in the client's pagination cache, so the badge sometimes drifted **up** after the user unfollowed (matches the reported "21 → 19 → 30" sequence).
3. **Frozen on past segment** — the badge effect only ran when `selectedSegment === "upcoming"`, so switching to past froze the count at whatever it was on entry.

## Fix

- New query `getFollowedListsFeedUpcomingCount` returns `userFeedsAggregate.count(...)` for the user's `followedLists_${userId}` feed with `hasEnded = false`. Returns `0` when unauthenticated. Same aggregate pattern that already powers `getUserStats`.
- `following/index.tsx` now subscribes to that count and writes it to `communityBadgeCount` whenever it changes, regardless of segment. Reactive: a follow/unfollow updates the badge immediately because the aggregate is updated in the same mutation paths in `feedHelpers.ts`.

The "My Soonlist" tab badge in `feed/index.tsx` has the same pattern but uses grouped events (groups vs. events have different semantics) and was not part of the bug report — left alone for a follow-up.

## Test plan

- [ ] Open the app: badge equals total upcoming events in subscribed lists, not paginated count.
- [ ] Subscribe to a list with >50 upcoming events: badge shows full count, not 50.
- [ ] Unfollow a list: badge decreases (does not drift up).
- [ ] Switch to "Past" segment: badge stays accurate (does not freeze on entry value).
- [ ] Sign out: badge clears (existing `globalReset` already zeros it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the My Scene tab badge and unifies both tab badges to use dedicated server counts capped at 50. Counts match the feed’s hasEnded/15‑min cadence and no longer drift with pagination or segment changes.

- **Bug Fixes**
  - Added `feeds.getFollowedListsFeedUpcomingCount` and `feeds.getMyFeedUpcomingGroupCount` using bounded `.take(50)` on `userFeeds`/`userFeedGroups` with `hasEnded=false`; My Soonlist counts groups to match visible cards.
  - Updated `apps/expo/src/app/(tabs)/following/index.tsx` and `apps/expo/src/app/(tabs)/feed/index.tsx` to subscribe to these counts and drop `enrichedEvents.length` + segment gates; badges update correctly on follow/unfollow.

<sup>Written for commit 2ffce69ebb15706759e745611847959d65800c9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the \"My Scene\" tab badge by replacing the paginated `enrichedEvents.length` (which undercounted past 50 items and drifted after unfollow) with a new Convex query that reads the authoritative `userFeedsAggregate` count — the same O(log n) aggregate already used by `getUserStats`. The badge now updates reactively on follow/unfollow regardless of which segment is selected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix using established aggregate patterns with no regressions.

The new query mirrors the exact same `userFeedsAggregate.count` pattern already used by `getUserStats` (same bounds `{key:0}` for upcoming, same namespace convention). The React-side change is minimal and correct: the `undefined` guard prevents a premature badge reset on load, and removing the `selectedSegment` guard fixes the freeze-on-past bug. No security or data integrity concerns.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/backend/convex/feeds.ts | Adds `getFollowedListsFeedUpcomingCount` query using the existing `userFeedsAggregate` with `followedLists_${userId}` namespace and `key: 0` bounds to count upcoming events — matches the established pattern from `getUserStats`. |
| apps/expo/src/app/(tabs)/following/index.tsx | Replaces paginated `enrichedEvents.length` with server-side `upcomingCount` from new query; removes the `selectedSegment` guard so the badge updates on any segment change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as following/index.tsx
    participant CQ as Convex Query getFollowedListsFeedUpcomingCount
    participant Agg as userFeedsAggregate followedLists_userId
    participant Store as Zustand AppStore communityBadgeCount
    participant FH as feedHelpers.ts mutations

    App->>CQ: useQuery(api.feeds.getFollowedListsFeedUpcomingCount, {})
    CQ->>Agg: count(ctx, { namespace, bounds: {key:0} })
    Agg-->>CQ: upcomingCount (upcoming events only)
    CQ-->>App: upcomingCount
    App->>Store: setCommunityBadgeCount(upcomingCount)

    Note over FH,Agg: On follow / unfollow
    FH->>Agg: replaceOrInsert / deleteIfExists
    Agg-->>CQ: Reactive update (Convex live query)
    CQ-->>App: new upcomingCount
    App->>Store: setCommunityBadgeCount(new upcomingCount)
```

<sub>Reviews (1): Last reviewed commit: ["fix(expo): drive My Scene tab badge from..."](https://github.com/jaronheard/soonlist-turbo/commit/cd1ab4e7432a2c17db0da80c9266a2fc875aee98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746763)</sub>

<!-- /greptile_comment -->