### PR TITLE
fix(expo): auto-clear My Scene empty state on tab refocus

### DIFF
--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -9,6 +9,7 @@ import { Share, Text, TouchableOpacity, View } from "react-native";
 import { Redirect } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
+import { useFocusEffect } from "@react-navigation/native";
 import {
   Authenticated,
   AuthLoading,
@@ -88,6 +89,25 @@ function FollowingFeedContent() {
   const handleExitEmptyState = useCallback(() => {
     setEmptyStateMode("dismissed");
   }, []);
+
+  // Read latest values from refs inside useFocusEffect so the callback only
+  // fires on actual focus events, not on state changes while focused. This
+  // preserves the sticky-while-on-tab behavior — subscribing from inside the
+  // empty state keeps it visible so users can pick more lists in one flow —
+  // while still auto-dismissing when the user leaves the tab and returns
+  // (a clear signal they're done picking and want to see their feed, no
+  // extra "View My Scene" tap required).
+  const hasFollowingsRef = useRef(hasFollowings);
+  hasFollowingsRef.current = hasFollowings;
+  const emptyStateModeRef = useRef(emptyStateMode);
+  emptyStateModeRef.current = emptyStateMode;
+  useFocusEffect(
+    useCallback(() => {
+      if (hasFollowingsRef.current && emptyStateModeRef.current === "show") {
+        setEmptyStateMode("dismissed");
+      }
+    }, []),
+  );
 
   // Memoize query args
   const queryArgs = useMemo(() => {

--- a/apps/expo/src/app/(tabs)/following/index.tsx
+++ b/apps/expo/src/app/(tabs)/following/index.tsx
@@ -6,10 +6,9 @@ import React, {
   useState,
 } from "react";
 import { Share, Text, TouchableOpacity, View } from "react-native";
-import { Redirect } from "expo-router";
+import { Redirect, useFocusEffect } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useUser } from "@clerk/clerk-expo";
-import { useFocusEffect } from "@react-navigation/native";
 import {
   Authenticated,
   AuthLoading,


### PR DESCRIPTION
## Summary

Fixes a bug where the "My Scene" empty state required tapping the "View My Scene" button to clear, even after the user navigated away and back. Now the sticky empty state auto-dismisses when the user re-focuses the tab and already has followings.

## What changed

- Added a `useFocusEffect` to `apps/expo/src/app/(tabs)/following/index.tsx` that flips `emptyStateMode` from `"show"` to `"dismissed"` when the My Scene tab gains focus and the user has subscribed to at least one list.
- Reads the latest values from refs so the callback fires only on actual focus events, not on state changes while focused — preserving the existing intentional sticky behavior (subscribing to multiple lists in one flow without the screen flipping mid-flow).

## Behavior matrix

| Scenario | Before | After |
| --- | --- | --- |
| User opens app already-subscribed → My Scene tab | Feed (correct) | Feed (unchanged) |
| User on My Scene empty state, subscribes from inside | Stays sticky for multi-subscribe (correct) | Stays sticky (unchanged) |
| User on My Scene empty state, subscribes, leaves tab, returns | Empty state still shown — must tap "View My Scene" | Empty state auto-dismisses on focus ✓ |
| User unfollows everything | Re-latches to empty state (correct) | Re-latches (unchanged) |

## Test plan

- [ ] Open app, navigate to My Scene tab with no followings → empty state shows
- [ ] Subscribe to a featured list from inside the empty state → empty state stays (sticky for multi-subscribe)
- [ ] Switch to "My Soonlist" tab, then back to "My Scene" → empty state dismisses, feed shows
- [ ] Unfollow all lists → empty state re-appears
- [ ] Subscribe to a list from outside My Scene tab, then navigate to My Scene tab for the first time → feed shows directly

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-dismiss the My Scene empty state when returning to the tab if the user now follows at least one list, so they see their feed without tapping. Keeps the sticky behavior while on the tab for multi-subscribe flows.

- **Bug Fixes**
  - Use `useFocusEffect` from `expo-router` to set `emptyStateMode` to "dismissed" on tab focus when `hasFollowings` is true.
  - Read latest state via refs so the dismissal triggers only on focus events, avoiding mid-flow flips while the tab is already focused.

<sup>Written for commit 3108be2f9288c70941ad2f85c4360a0d725cc1e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `useFocusEffect` to `FollowingFeedContent` that auto-dismisses the "My Scene" empty state when the tab regains focus and the user already has followings. The ref-based approach (`hasFollowingsRef`, `emptyStateModeRef`) correctly reads the latest values on each focus event without recreating the callback on state changes, cleanly preserving the intended sticky behavior during multi-list subscribe flows.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only a P2 import style suggestion present.

The logic is correct and well-reasoned. The ref pattern for `useFocusEffect` is idiomatic and interacts cleanly with the existing `useEffect` state machine. The only finding is a P2 style note about importing from `@react-navigation/native` instead of `expo-router`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/(tabs)/following/index.tsx | Adds a `useFocusEffect` with a ref-based pattern to auto-dismiss the empty state on tab re-focus when the user already has followings; logic is correct, minor style note on import source. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tab gains focus\nuseFocusEffect fires] --> B{hasFollowingsRef\n=== true?}
    B -- No --> C[Do nothing\nempty state stays]
    B -- Yes --> D{emptyStateModeRef\n=== 'show'?}
    D -- No --> E[Do nothing\nalready dismissed or unset]
    D -- Yes --> F[setEmptyStateMode\n'dismissed']
    F --> G[Feed renders\ninstead of empty state]

    H[User unfollows all] --> I[useEffect re-latches\nemptyStateMode → 'show']
    I --> J[Empty state re-appears]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/src/app/(tabs)/following/index.tsx
Line: 12

Comment:
**Import `useFocusEffect` from `expo-router`**

`expo-router` re-exports `useFocusEffect` from `@react-navigation/native`, and all other navigation utilities in this file (e.g. `Redirect`) already come from `expo-router`. Importing directly from `@react-navigation/native` works but is inconsistent with the project's import convention for router-level hooks.

```suggestion
import { Redirect, useFocusEffect } from "expo-router";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): auto-clear My Scene empty sta..."](https://github.com/jaronheard/soonlist-turbo/commit/120320485a09a7c31b5948864b7f42d63b193ab9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746773)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->