### PR TITLE
fix(calendar): link past events to event page, upcoming to curator's Soonlist

### DIFF
--- a/apps/expo/src/hooks/useCalendar.ts
+++ b/apps/expo/src/hooks/useCalendar.ts
@@ -6,6 +6,7 @@ import { Temporal } from "@js-temporal/polyfill";
 
 import type { api } from "@soonlist/backend/convex/_generated/api";
 import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
+import { isEventInPast } from "@soonlist/cal";
 
 import type { CalendarAppInfo } from "~/utils/calendarAppDetection";
 import { usePreferredCalendarApp, useSetPreferredCalendarApp } from "~/store";
@@ -109,17 +110,25 @@ export function useCalendar() {
 
       const calendarEvent = event.event as AddToCalendarButtonPropsRestricted;
 
-      // Build enriched description (used for Google Calendar as well)
+      // For upcoming events, link to the curator's Soonlist; for past events,
+      // link to the event page since the curator's upcoming list won't have it.
       const baseUrlForDesc = Config.apiBaseUrl;
-      const eventUrlForDesc =
+      const eventIsPast = isEventInPast(
+        calendarEvent.endDate,
+        calendarEvent.endTime,
+        calendarEvent.timeZone,
+      );
+      const linkUrlForDesc =
         event.userName && event.id && baseUrlForDesc
-          ? `${baseUrlForDesc}/event/${event.id}`
+          ? eventIsPast
+            ? `${baseUrlForDesc}/event/${event.id}`
+            : `${baseUrlForDesc}/${event.userName}/upcoming`
           : baseUrlForDesc;
       const displayNameForDesc =
         event.user?.displayName || (event.userName ? `@${event.userName}` : "");
       const additionalTextForDesc =
         event.userName && event.id && baseUrlForDesc
-          ? `Captured by ${displayNameForDesc} on Soonlist. \nFull details: ${eventUrlForDesc}`
+          ? `Captured by ${displayNameForDesc} on Soonlist. \nFull details: ${linkUrlForDesc}`
           : baseUrlForDesc
             ? `Captured on Soonlist\n(${baseUrlForDesc})`
             : "Captured on Soonlist";
@@ -239,14 +248,20 @@ export function useCalendar() {
         throw new Error("EXPO_PUBLIC_API_BASE_URL is not defined");
       }
 
-      const eventUrl =
+      const eventPageUrl =
         event.userName && event.id ? `${baseUrl}/event/${event.id}` : baseUrl;
+      const linkUrl =
+        event.userName && event.id
+          ? eventIsPast
+            ? eventPageUrl
+            : `${baseUrl}/${event.userName}/upcoming`
+          : baseUrl;
 
       const displayName =
         event.user?.displayName || (event.userName ? `@${event.userName}` : "");
       const additionalText =
         event.userName && event.id
-          ? `Captured by ${displayName} on Soonlist. \nFull details: ${eventUrl}`
+          ? `Captured by ${displayName} on Soonlist. \nFull details: ${linkUrl}`
           : `Captured on Soonlist\n(${baseUrl})`;
 
       const fullDescription = `${calendarEvent.description}\n\n${additionalText}`;
@@ -258,7 +273,7 @@ export function useCalendar() {
         location: calendarEvent.location,
         notes: fullDescription,
         timeZone: eventTimezone,
-        url: eventUrl, // iOS only, but included for platforms that support it
+        url: eventPageUrl, // iOS only, but included for platforms that support it
       };
 
       const result = await Calendar.createEventInCalendarAsync(eventDetails);

--- a/apps/web/components/CalendarButton.tsx
+++ b/apps/web/components/CalendarButton.tsx
@@ -4,6 +4,7 @@ import { atcb_action } from "add-to-calendar-button-react";
 import { CalendarPlus } from "lucide-react";
 
 import type { ATCBActionEventConfig } from "@soonlist/cal/types";
+import { isEventInPast } from "@soonlist/cal";
 import { Button } from "@soonlist/ui/button";
 
 import { env } from "~/env";
@@ -21,10 +22,22 @@ export function CalendarButton(props: CalendarButtonProps) {
   const eventForCalendar = { ...props.event };
   const displayName =
     props.userDisplayName || (props.username ? `@${props.username}` : "");
+  const baseUrl = env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
+  const eventIsPast = isEventInPast(
+    props.event.endDate,
+    props.event.endTime,
+    props.event.timeZone,
+  );
+  const linkUrl =
+    props.username && props.id
+      ? eventIsPast
+        ? `${baseUrl}/event/${props.id}`
+        : `${baseUrl}/${props.username}/upcoming`
+      : baseUrl;
   const additionalText =
     props.username && props.id
-      ? `Captured by [url]${env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}/${props.username}/events|${displayName}[/url] on [url]${env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}/event/${props.id}|Soonlist[/url]`
-      : `Captured on [url]${env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}|Soonlist[/url]`;
+      ? `Captured by ${displayName} on [url]${linkUrl}|Soonlist[/url]`
+      : `Captured on [url]${linkUrl}|Soonlist[/url]`;
   eventForCalendar.description = `${props.event.description}[br][br]${additionalText}`;
   eventForCalendar.options = [
     "Apple",

--- a/packages/cal/src/utils.ts
+++ b/packages/cal/src/utils.ts
@@ -218,6 +218,35 @@ export function getDateInfoUTC(dateString: string): DateInfo | null {
   return { month, monthName, day, year, dayOfWeek, hour, minute };
 }
 
+export function isEventInPast(
+  endDate?: string,
+  endTime?: string,
+  timeZone?: string,
+): boolean {
+  if (!endDate) return false;
+  try {
+    const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+    if (!datePattern.test(endDate)) return false;
+
+    let timeString = endTime ?? "";
+    const timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$/;
+    if (!timePattern.test(timeString)) {
+      timeString = "23:59:59";
+    } else if (timeString.length === 5) {
+      timeString = `${timeString}:00`;
+    }
+
+    const tz =
+      timeZone && timeZone !== "unknown" ? timeZone : Temporal.Now.timeZoneId();
+    const endZdt = Temporal.ZonedDateTime.from(
+      `${endDate}T${timeString}[${tz}]`,
+    );
+    return Temporal.Now.instant().epochMilliseconds > endZdt.epochMilliseconds;
+  } catch {
+    return false;
+  }
+}
+
 export function endsNextDayBeforeMorning(
   startDateInfo: DateInfo | null,
   endDateInfo: DateInfo | null,

--- a/packages/cal/src/utils.ts
+++ b/packages/cal/src/utils.ts
@@ -218,15 +218,18 @@ export function getDateInfoUTC(dateString: string): DateInfo | null {
   return { month, monthName, day, year, dayOfWeek, hour, minute };
 }
 
+// Returns true when the event has ended. When the end date is missing, we
+// default to true so callers fall back to the canonical event-page URL rather
+// than a curator's upcoming list that won't include the event.
 export function isEventInPast(
   endDate?: string,
   endTime?: string,
   timeZone?: string,
 ): boolean {
-  if (!endDate) return false;
+  if (!endDate) return true;
   try {
     const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-    if (!datePattern.test(endDate)) return false;
+    if (!datePattern.test(endDate)) return true;
 
     let timeString = endTime ?? "";
     const timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9])?$/;
@@ -243,7 +246,7 @@ export function isEventInPast(
     );
     return Temporal.Now.instant().epochMilliseconds > endZdt.epochMilliseconds;
   } catch {
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary

- Calendar event descriptions now point to a single URL chosen by whether the event is past or upcoming.
- **Upcoming**: link to `/<username>/upcoming` (the curator's Soonlist) so attendees can discover more of their events.
- **Past**: link to `/event/<id>` since the curator's upcoming list no longer includes it.
- Adds a shared `isEventInPast` helper in `@soonlist/cal` (timezone-aware via Temporal) so web and Expo share the same logic.

Web also drops a long-broken `/<username>/events` link that has redirected to `/` since [next.config.js:85](apps/web/next.config.js).

### Changed

- [packages/cal/src/utils.ts](packages/cal/src/utils.ts) — new `isEventInPast(endDate?, endTime?, timeZone?)`.
- [apps/web/components/CalendarButton.tsx](apps/web/components/CalendarButton.tsx) — pick `linkUrl` from past/upcoming.
- [apps/expo/src/hooks/useCalendar.ts](apps/expo/src/hooks/useCalendar.ts) — same logic for both Google Calendar and native iOS Calendar paths. The native `url` metadata field still points to the event page (a stable canonical reference); only the description link changes.

## Test plan

- [ ] Web: open an upcoming event, click "Add to calendar" — description includes `Captured by <name> on Soonlist` linking to `/<username>/upcoming`.
- [ ] Web: open a past event, click "Add to calendar" — description link goes to `/event/<id>`.
- [ ] iOS (Apple Calendar): same behavior, plain-text URL after `Full details:`.
- [ ] iOS (Google Calendar): same description with the chosen URL.
- [ ] Events without `endDate`/`endTime` (or all-day events ending today) treat as upcoming until end-of-day in their timezone.
- [ ] Anonymous capture (no `userName`/`id`) still links to the site root as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes calendar description links so upcoming events point to the curator’s Soonlist (`/<username>/upcoming`) and past events point to the event page (`/event/<id>`). Adds a shared, timezone-aware `isEventInPast` helper in `@soonlist/cal` used by web and Expo.

- **Bug Fixes**
  - Replaced the broken `/<username>/events` link; now pick a single URL based on whether the event has ended.
  - Default missing `endDate` to past so we link to the event page; missing/invalid `endTime` falls back to end-of-day.
  - Web and iOS/Google Calendar descriptions include the chosen link; iOS event metadata `url` still points to the event page.

- **Refactors**
  - Introduced `isEventInPast(endDate?, endTime?, timeZone?)` in `@soonlist/cal` (using Temporal) to centralize the decision across platforms.

<sup>Written for commit b445657428e4aaac0879fe872b7b514418015572. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes calendar event descriptions so that upcoming events link to `/<username>/upcoming` (for discoverability) and past events link to `/event/<id>` (since the curator's upcoming list no longer contains them). A shared `isEventInPast` Temporal-based helper is extracted into `@soonlist/cal` and applied consistently across web and Expo (both Google Calendar and native Apple Calendar paths).

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 style issues with no runtime-breaking behaviour.

Only P2 findings — a missing-endDate design trade-off and an unmemoized render-time call — neither of which causes incorrect behaviour in normal usage.

packages/cal/src/utils.ts — the !endDate → false return value is a design decision worth confirming

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cal/src/utils.ts | Adds `isEventInPast` timezone-aware helper using Temporal; handles edge cases gracefully, but missing-endDate unconditionally returns false (upcoming), which may produce the wrong link for undated past events. |
| apps/web/components/CalendarButton.tsx | Replaces the broken `/events` link with a single smart link; `isEventInPast` called in render body without memoization (minor style issue only). |
| apps/expo/src/hooks/useCalendar.ts | Applies the same past/upcoming link logic to both Google Calendar and native Apple Calendar paths; `url` metadata field correctly remains the stable event-page URL. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Add to Calendar clicked] --> B{username & id present?}
    B -- No --> C[linkUrl = baseUrl\nCaptured on Soonlist]
    B -- Yes --> D[isEventInPast\nendDate · endTime · timeZone]
    D -- no endDate --> E[return false\ntreat as upcoming]
    D -- parse error --> E
    D -- past --> F[linkUrl = /event/id]
    D -- upcoming --> G[linkUrl = /username/upcoming]
    E --> G
    F --> H[Description: Captured by … Full details: linkUrl]
    G --> H
    H --> I{Platform / app?}
    I -- Web --> J[atcb_action with ATCB markup]
    I -- Expo Google --> K[createGoogleCalendarLink]
    I -- Expo Apple --> L[Calendar.createEventInCalendarAsync\nurl = /event/id canonical]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cal/src/utils.ts
Line: 226

Comment:
**Missing-endDate silently treats event as upcoming**

When `endDate` is absent the function returns `false` (i.e., upcoming), so the description link will point to `/<username>/upcoming` even for events that are clearly in the past. There is no way for callers to distinguish "we don't know" from "it is upcoming". If an event was captured without an end date long after it occurred, the upcoming link will lead to a page that no longer shows it.

Consider returning `null` (or an explicit `"unknown"` state) so callers can fall back to the event-page URL rather than the upcoming list.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/components/CalendarButton.tsx
Line: 26-30

Comment:
**`isEventInPast` called on every render without memoization**

`isEventInPast` calls `Temporal.Now.instant()` synchronously on every render. While the cost is small, the result is also not stable between renders — a re-render triggered milliseconds after an event ends could flip from upcoming to past mid-session. Wrapping this in `useMemo` makes the value stable for the component's lifetime and documents the dependency clearly.

```suggestion
  const eventIsPast = useMemo(
    () =>
      isEventInPast(
        props.event.endDate,
        props.event.endTime,
        props.event.timeZone,
      ),
    [props.event.endDate, props.event.endTime, props.event.timeZone],
  );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(calendar): link past events to event..."](https://github.com/jaronheard/soonlist-turbo/commit/bbe83f64a65c136611f3da7ae544db668b06ea5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29746792)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->