### PR TITLE
fix(web): make Open Graph image rendering reliable across crawlers

### DIFF
--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,13 +4,7 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
-import { OG_IMAGE_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
-
-// Branded fallback served by `app/api/og/route.tsx`. Used when an event has
-// no image so crawlers always get *some* OG image instead of falling back
-// to a `summary` (no-image) Twitter card or no preview at all.
-const FALLBACK_OG_IMAGE = "/api/og";
 
 interface Props {
   params: Promise<{
@@ -40,15 +34,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
 
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const rawEventImage = eventData.images?.[0];
-    // Force JPEG so crawlers that mishandle Bytescale's default WebP still
-    // render a preview; fall back to the branded default when the event
-    // has no image so the Twitter card stays `summary_large_image`.
-    const ogImageUrl = rawEventImage
-      ? rewriteBytescaleToJpeg(rawEventImage, OG_IMAGE_SIZE)
-      : FALLBACK_OG_IMAGE;
+    const eventImage = eventData.images?.[0];
 
-    // Generate Open Graph metadata with Smart App Banner for iOS
+    // Pass the user's image through as-is *without* declaring og:image:width
+    // or og:image:height. The previous code hardcoded 1200×630, but most
+    // event posters are portrait (e.g. 640×853) — a dimension mismatch that
+    // Apple's LinkPresentation and other strict crawlers can interpret as
+    // an invalid card and silently drop, producing the intermittent
+    // "sometimes the rich preview shows up, sometimes it doesn't" pattern
+    // for events shared via iMessage. Letting crawlers infer dimensions
+    // from the actual bytes removes the lie at the cost of inconsistent
+    // aspect ratios across previews — the right tradeoff until we either
+    // store true dimensions or render a server-side OG card per event.
     return {
       title: `${eventData.name} | Soonlist`,
       description:
@@ -58,23 +55,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
         type: "website",
-        images: [
-          {
-            url: ogImageUrl,
-            width: OG_IMAGE_SIZE.width,
-            height: OG_IMAGE_SIZE.height,
-            alt: eventData.name || "Event image",
-          },
-        ],
+        images: eventImage
+          ? [{ url: eventImage, alt: eventData.name || "Event image" }]
+          : [],
         locale: "en_US",
         siteName: "Soonlist",
       },
       twitter: {
-        card: "summary_large_image",
+        card: eventImage ? "summary_large_image" : "summary",
         title: eventData.name || "Event on Soonlist",
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
-        images: [ogImageUrl],
+        images: eventImage ? [eventImage] : undefined,
       },
       // iOS Smart App Banner - prompts users to open in the Soonlist app
       other: {

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,7 +4,7 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
-import { rewriteBytescaleToJpeg } from "~/lib/og-image";
+import { EVENT_OG_MAX_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
 
 // Branded card rendered by `app/api/og/route.tsx` at 1200×630. Used when an
@@ -58,7 +58,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     // 1200×630 so we *can* declare those dimensions honestly.
     const ogImage = rawEventImage
       ? {
-          url: rewriteBytescaleToJpeg(rawEventImage),
+          url: rewriteBytescaleToJpeg(rawEventImage, EVENT_OG_MAX_SIZE),
           alt: eventData.name || "Event image",
         }
       : FALLBACK_OG_IMAGE;

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,7 +4,7 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
-import { EVENT_OG_MAX_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
+import { rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
 
 // Branded card rendered by `app/api/og/route.tsx` at 1200×630. Used when an
@@ -58,7 +58,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     // 1200×630 so we *can* declare those dimensions honestly.
     const ogImage = rawEventImage
       ? {
-          url: rewriteBytescaleToJpeg(rawEventImage, EVENT_OG_MAX_SIZE),
+          url: rewriteBytescaleToJpeg(rawEventImage),
           alt: eventData.name || "Event image",
         }
       : FALLBACK_OG_IMAGE;

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -6,6 +6,14 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { getAuthenticatedConvex } from "~/lib/convex-server";
 import EventPageClient from "./EventPageClient";
 
+// Branded card rendered by `app/api/og/route.tsx` at 1200×630. Used when an
+// event has no image so the rich preview stays `summary_large_image`.
+const FALLBACK_OG_IMAGE = {
+  url: "/api/og",
+  width: 1200,
+  height: 630,
+} as const;
+
 interface Props {
   params: Promise<{
     eventId: string;
@@ -36,16 +44,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
     const eventImage = eventData.images?.[0];
 
-    // Pass the user's image through as-is *without* declaring og:image:width
-    // or og:image:height. The previous code hardcoded 1200×630, but most
-    // event posters are portrait (e.g. 640×853) — a dimension mismatch that
-    // Apple's LinkPresentation and other strict crawlers can interpret as
-    // an invalid card and silently drop, producing the intermittent
-    // "sometimes the rich preview shows up, sometimes it doesn't" pattern
-    // for events shared via iMessage. Letting crawlers infer dimensions
-    // from the actual bytes removes the lie at the cost of inconsistent
-    // aspect ratios across previews — the right tradeoff until we either
-    // store true dimensions or render a server-side OG card per event.
+    // For user images: emit URL only, *no* og:image:width/height. The
+    // previous code hardcoded 1200×630, but most event posters are
+    // portrait (e.g. 640×853) — a dimension mismatch that Apple's
+    // LinkPresentation and other strict crawlers can interpret as an
+    // invalid card and silently drop, producing the intermittent
+    // "sometimes the rich preview shows up, sometimes it doesn't"
+    // pattern for events shared via iMessage. Letting crawlers infer
+    // from the actual bytes removes the lie. For the branded fallback,
+    // we render at exactly 1200×630 so we *can* declare honestly.
+    const ogImage = eventImage
+      ? { url: eventImage, alt: eventData.name || "Event image" }
+      : FALLBACK_OG_IMAGE;
+
     return {
       title: `${eventData.name} | Soonlist`,
       description:
@@ -55,18 +66,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
         type: "website",
-        images: eventImage
-          ? [{ url: eventImage, alt: eventData.name || "Event image" }]
-          : [],
+        images: [ogImage],
         locale: "en_US",
         siteName: "Soonlist",
       },
       twitter: {
-        card: eventImage ? "summary_large_image" : "summary",
+        card: "summary_large_image",
         title: eventData.name || "Event on Soonlist",
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
-        images: eventImage ? [eventImage] : undefined,
+        images: [ogImage.url],
       },
       // iOS Smart App Banner - prompts users to open in the Soonlist app
       other: {

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,6 +4,7 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
+import { rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
 
 // Branded card rendered by `app/api/og/route.tsx` at 1200×630. Used when an
@@ -42,19 +43,24 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
 
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const eventImage = eventData.images?.[0];
+    const rawEventImage = eventData.images?.[0];
 
-    // For user images: emit URL only, *no* og:image:width/height. The
-    // previous code hardcoded 1200×630, but most event posters are
-    // portrait (e.g. 640×853) — a dimension mismatch that Apple's
-    // LinkPresentation and other strict crawlers can interpret as an
-    // invalid card and silently drop, producing the intermittent
-    // "sometimes the rich preview shows up, sometimes it doesn't"
-    // pattern for events shared via iMessage. Letting crawlers infer
-    // from the actual bytes removes the lie. For the branded fallback,
-    // we render at exactly 1200×630 so we *can* declare honestly.
-    const ogImage = eventImage
-      ? { url: eventImage, alt: eventData.name || "Event image" }
+    // For user images: force JPEG (some crawlers and surfaces don't
+    // render Bytescale's default WebP reliably) but *don't* declare
+    // og:image:width/height. The previous code hardcoded 1200×630,
+    // but most event posters are portrait (e.g. 640×853) — a dimension
+    // mismatch that Apple's LinkPresentation and other strict crawlers
+    // can interpret as an invalid card and silently drop, producing
+    // the intermittent "sometimes the rich preview shows up, sometimes
+    // it doesn't" pattern for events shared via iMessage. Forcing JPEG
+    // without `w`/`h` preserves the source aspect ratio so the lie
+    // never reappears. For the branded fallback, we render at exactly
+    // 1200×630 so we *can* declare those dimensions honestly.
+    const ogImage = rawEventImage
+      ? {
+          url: rewriteBytescaleToJpeg(rawEventImage),
+          alt: eventData.name || "Event image",
+        }
       : FALLBACK_OG_IMAGE;
 
     return {

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -7,9 +7,8 @@ import { getAuthenticatedConvex } from "~/lib/convex-server";
 import { OG_IMAGE_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
 
-// Branded card rendered by `app/api/og/route.tsx` at OG_IMAGE_SIZE. Used
-// when an event has no image so the rich preview stays
-// `summary_large_image`.
+// `/api/og` renders at exactly OG_IMAGE_SIZE, so dimensions are honest.
+// Used when an event has no image, keeping the card summary_large_image.
 const FALLBACK_OG_IMAGE = {
   url: "/api/og",
   ...OG_IMAGE_SIZE,
@@ -45,12 +44,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
     const rawEventImage = eventData.images?.[0];
 
-    // User images: force JPEG (for crawlers that don't render WebP well)
-    // and omit og:image:width/height. We don't know the source's true
-    // dimensions, and declaring fixed ones against a portrait poster causes
+    // Omit og:image:width/height for user images: source dimensions are
+    // unknown, and declaring fixed ones against a portrait poster causes
     // strict crawlers (notably Apple's LinkPresentation) to drop the card.
-    // The branded fallback ships at exactly OG_IMAGE_SIZE so it can declare
-    // dimensions honestly.
     const ogImage = rawEventImage
       ? {
           url: rewriteBytescaleToJpeg(rawEventImage),

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,15 +4,15 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
-import { rewriteBytescaleToJpeg } from "~/lib/og-image";
+import { OG_IMAGE_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
 
-// Branded card rendered by `app/api/og/route.tsx` at 1200×630. Used when an
-// event has no image so the rich preview stays `summary_large_image`.
+// Branded card rendered by `app/api/og/route.tsx` at OG_IMAGE_SIZE. Used
+// when an event has no image so the rich preview stays
+// `summary_large_image`.
 const FALLBACK_OG_IMAGE = {
   url: "/api/og",
-  width: 1200,
-  height: 630,
+  ...OG_IMAGE_SIZE,
 } as const;
 
 interface Props {
@@ -45,17 +45,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
     const rawEventImage = eventData.images?.[0];
 
-    // For user images: force JPEG (some crawlers and surfaces don't
-    // render Bytescale's default WebP reliably) but *don't* declare
-    // og:image:width/height. The previous code hardcoded 1200×630,
-    // but most event posters are portrait (e.g. 640×853) — a dimension
-    // mismatch that Apple's LinkPresentation and other strict crawlers
-    // can interpret as an invalid card and silently drop, producing
-    // the intermittent "sometimes the rich preview shows up, sometimes
-    // it doesn't" pattern for events shared via iMessage. Forcing JPEG
-    // without `w`/`h` preserves the source aspect ratio so the lie
-    // never reappears. For the branded fallback, we render at exactly
-    // 1200×630 so we *can* declare those dimensions honestly.
+    // User images: force JPEG (for crawlers that don't render WebP well)
+    // and omit og:image:width/height. We don't know the source's true
+    // dimensions, and declaring fixed ones against a portrait poster causes
+    // strict crawlers (notably Apple's LinkPresentation) to drop the card.
+    // The branded fallback ships at exactly OG_IMAGE_SIZE so it can declare
+    // dimensions honestly.
     const ogImage = rawEventImage
       ? {
           url: rewriteBytescaleToJpeg(rawEventImage),

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -41,12 +41,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
     const rawEventImage = eventData.images?.[0];
-    // Bytescale serves WebP by default, but several social crawlers (Slack,
-    // LinkedIn, Discord, older Twitter) render WebP inconsistently. Force
-    // JPEG at OG dimensions so the rich preview is the same everywhere.
-    // Falls back to the branded default when the event has no image so
-    // crawlers always receive `summary_large_image` instead of degrading to
-    // a no-image card.
+    // Force JPEG so crawlers that mishandle Bytescale's default WebP still
+    // render a preview; fall back to the branded default when the event
+    // has no image so the Twitter card stays `summary_large_image`.
     const ogImageUrl = rawEventImage
       ? rewriteBytescaleToJpeg(rawEventImage, OG_IMAGE_SIZE)
       : FALLBACK_OG_IMAGE;

--- a/apps/web/app/(base)/event/[eventId]/page.tsx
+++ b/apps/web/app/(base)/event/[eventId]/page.tsx
@@ -4,7 +4,13 @@ import type { AddToCalendarButtonPropsRestricted } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { getAuthenticatedConvex } from "~/lib/convex-server";
+import { OG_IMAGE_SIZE, rewriteBytescaleToJpeg } from "~/lib/og-image";
 import EventPageClient from "./EventPageClient";
+
+// Branded fallback served by `app/api/og/route.tsx`. Used when an event has
+// no image so crawlers always get *some* OG image instead of falling back
+// to a `summary` (no-image) Twitter card or no preview at all.
+const FALLBACK_OG_IMAGE = "/api/og";
 
 interface Props {
   params: Promise<{
@@ -34,7 +40,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
 
     const eventData = event.event as AddToCalendarButtonPropsRestricted;
-    const eventImage = eventData.images?.[0];
+    const rawEventImage = eventData.images?.[0];
+    // Bytescale serves WebP by default, but several social crawlers (Slack,
+    // LinkedIn, Discord, older Twitter) render WebP inconsistently. Force
+    // JPEG at OG dimensions so the rich preview is the same everywhere.
+    // Falls back to the branded default when the event has no image so
+    // crawlers always receive `summary_large_image` instead of degrading to
+    // a no-image card.
+    const ogImageUrl = rawEventImage
+      ? rewriteBytescaleToJpeg(rawEventImage, OG_IMAGE_SIZE)
+      : FALLBACK_OG_IMAGE;
 
     // Generate Open Graph metadata with Smart App Banner for iOS
     return {
@@ -46,25 +61,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
         type: "website",
-        images: eventImage
-          ? [
-              {
-                url: eventImage,
-                width: 1200,
-                height: 630,
-                alt: eventData.name || "Event image",
-              },
-            ]
-          : [],
+        images: [
+          {
+            url: ogImageUrl,
+            width: OG_IMAGE_SIZE.width,
+            height: OG_IMAGE_SIZE.height,
+            alt: eventData.name || "Event image",
+          },
+        ],
         locale: "en_US",
         siteName: "Soonlist",
       },
       twitter: {
-        card: eventImage ? "summary_large_image" : "summary",
+        card: "summary_large_image",
         title: eventData.name || "Event on Soonlist",
         description:
           eventData.description || `Join ${eventData.name} on Soonlist`,
-        images: eventImage ? [eventImage] : undefined,
+        images: [ogImageUrl],
       },
       // iOS Smart App Banner - prompts users to open in the Soonlist app
       other: {

--- a/apps/web/app/(base)/list/[slug]/opengraph-image.tsx
+++ b/apps/web/app/(base)/list/[slug]/opengraph-image.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @next/next/no-img-element -- next/image is not supported
 inside @vercel/og ImageResponse trees; raw <img> is required. */
 import { ImageResponse } from "next/og";
-import * as Bytescale from "@bytescale/sdk";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
@@ -12,7 +11,11 @@ import {
   SOONLIST_MARK_VIEWBOX,
 } from "~/lib/brand-logo";
 import { getUnauthenticatedConvex } from "~/lib/convex-server";
-import { extractFilePath } from "~/lib/utils";
+import {
+  loadGoogleFont,
+  OG_IMAGE_SIZE,
+  rewriteBytescaleToJpeg,
+} from "~/lib/og-image";
 
 export const runtime = "nodejs";
 // Short TTL balances crawler-burst amortization against privacy: a list
@@ -22,7 +25,7 @@ export const runtime = "nodejs";
 export const revalidate = 300;
 
 export const alt = "Shared list on Soonlist";
-export const size = { width: 1200, height: 630 };
+export const size = OG_IMAGE_SIZE;
 export const contentType = "image/png";
 
 // Brand tokens (apps/web/styles/globals.css CSS vars) rendered as hex because
@@ -30,77 +33,6 @@ export const contentType = "image/png";
 const BRAND_INTERACTIVE = "#5A32FB"; // --interactive-1
 const ACCENT_YELLOW = "#FEEA9F"; // --accent-1
 const NEUTRAL_1 = "#34435F"; // --neutral-1
-
-const BYTESCALE_ACCOUNT_ID = "12a1yek";
-
-// @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing an
-// older User-Agent makes Google Fonts return plain .ttf URLs in the CSS. The
-// CSS also contains multiple @font-face blocks (devanagari, latin-ext, latin,
-// …); we target the `/* latin */` marker so we always fetch Latin glyphs.
-async function loadFont(
-  family: string,
-  weight: number,
-): Promise<ArrayBuffer | null> {
-  try {
-    const urlFamily = family.replace(/ /g, "+");
-    const cssRes = await fetch(
-      `https://fonts.googleapis.com/css?family=${urlFamily}:${weight}&display=swap`,
-      {
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36",
-        },
-      },
-    );
-    if (!cssRes.ok) return null;
-    const css = await cssRes.text();
-    const latinBlockMatch = /\/\*\s*latin\s*\*\/[\s\S]*?url\(([^)]+)\)/.exec(
-      css,
-    );
-    const fallbackMatch = /url\(([^)]+)\)/.exec(css);
-    const fontUrl = latinBlockMatch?.[1] ?? fallbackMatch?.[1];
-    if (!fontUrl) return null;
-    const fontRes = await fetch(fontUrl);
-    if (!fontRes.ok) return null;
-    return await fontRes.arrayBuffer();
-  } catch (err) {
-    console.warn("[list/opengraph-image] font fetch failed", family, err);
-    return null;
-  }
-}
-
-// Satori can't decode WebP, which is what Bytescale (upcdn.io) returns by
-// default. Route through Bytescale's `/image/` processor with `f=jpg` so OG
-// crawlers receive a JPEG. Only applies when the source is a Bytescale URL
-// *on our account* — we don't want to rewrite arbitrary external URLs, nor
-// cross-account upcdn.io URLs, into bogus `/{BYTESCALE_ACCOUNT_ID}/image/…`
-// paths that would 404.
-function transformImage(url: string): string {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return url;
-  }
-  if (parsed.hostname !== "upcdn.io") return url;
-  if (!parsed.pathname.startsWith(`/${BYTESCALE_ACCOUNT_ID}/`)) return url;
-  const filePath = extractFilePath(url);
-  if (!filePath) return url;
-  return Bytescale.UrlBuilder.url({
-    accountId: BYTESCALE_ACCOUNT_ID,
-    filePath,
-    options: {
-      transformation: "image",
-      transformationParams: {
-        w: 360,
-        h: 640,
-        fit: "crop",
-        f: "jpg",
-        q: 82,
-      },
-    },
-  });
-}
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -126,9 +58,9 @@ export default async function OgImage({ params }: Props) {
 
   const { list, owner, upcomingEvents } = data;
   const [mediumFont, boldFont, kalamFont] = await Promise.all([
-    loadFont("IBM Plex Sans", 500),
-    loadFont("IBM Plex Sans", 700),
-    loadFont("Kalam", 700),
+    loadGoogleFont("IBM Plex Sans", 500),
+    loadGoogleFont("IBM Plex Sans", 700),
+    loadGoogleFont("Kalam", 700),
   ]);
 
   const fonts = [
@@ -261,7 +193,10 @@ export default async function OgImage({ params }: Props) {
           return (
             <img
               key={i}
-              src={transformImage(evt.image)}
+              src={rewriteBytescaleToJpeg(evt.image, {
+                width: 360,
+                height: 640,
+              })}
               width={layout.width}
               height={layout.height}
               alt=""

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -40,9 +40,8 @@ export const metadata: Metadata = {
     type: "website",
     images: [
       {
-        // Routed through Bytescale's /image/ processor with `f=jpg` because
-        // several social crawlers (Slack, LinkedIn, Discord, older Twitter)
-        // render WebP inconsistently. The source asset is a .webp upload.
+        // /image/?f=jpg because the source is .webp; not every crawler
+        // renders WebP reliably.
         url: "https://upcdn.io/12a1yek/image/uploads/Soonlist/soonlist-meta.webp?w=1200&h=630&fit=crop&f=jpg&q=82",
         width: 1200,
         height: 630,

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -40,7 +40,10 @@ export const metadata: Metadata = {
     type: "website",
     images: [
       {
-        url: "https://upcdn.io/12a1yek/raw/uploads/Soonlist/soonlist-meta.webp",
+        // Routed through Bytescale's /image/ processor with `f=jpg` because
+        // several social crawlers (Slack, LinkedIn, Discord, older Twitter)
+        // render WebP inconsistently. The source asset is a .webp upload.
+        url: "https://upcdn.io/12a1yek/image/uploads/Soonlist/soonlist-meta.webp?w=1200&h=630&fit=crop&f=jpg&q=82",
         width: 1200,
         height: 630,
       },

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -7,21 +7,20 @@ const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 // render WebP, which is what Bytescale serves by default. Returns the URL
 // untouched if it isn't a Bytescale URL on our account.
 //
-// `size` modes:
-//   - `{ width, height }` (default `fit: "crop"`): force exact dimensions,
-//     used by the list satori card where thumbnails need to be small and
-//     uniform.
-//   - `{ width, height, fit: "shrink" }`: cap dimensions, preserve aspect,
-//     never upscale. Used by event OG metadata so a 4000×3000 phone photo
-//     doesn't ship to crawlers at full size (iMessage timeouts), without
-//     re-introducing the dimension-mismatch bug from forcing 1200×630.
+// Pass dimensions to force exact size with `fit=crop` (used by the list
+// satori card where thumbnails need to be small + uniform). Omit them to
+// keep the source's native dimensions and only force the codec — that's
+// what event OG metadata wants, since declaring fixed 1200×630 against a
+// portrait poster was the bug we fixed. Upload paths already cap source
+// dimensions (Expo: 640 or 1284 wide), so re-capping at the OG layer is
+// redundant defense-in-depth that wasn't worth the API surface.
 //
 // Existing query params on already-transformed `/image/` URLs are inherited
 // so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
 // survives.
 export function rewriteBytescaleToJpeg(
   url: string,
-  size?: { width: number; height: number; fit?: "crop" | "shrink" },
+  size?: { width: number; height: number },
 ): string {
   let parsed: URL;
   try {
@@ -41,21 +40,12 @@ export function rewriteBytescaleToJpeg(
   if (size) {
     params.set("w", String(size.width));
     params.set("h", String(size.height));
-    params.set("fit", size.fit ?? "crop");
+    params.set("fit", "crop");
   }
   if (!params.has("q")) params.set("q", "82");
   params.set("f", "jpg");
   return `https://upcdn.io/12a1yek/image${match[2]}?${params.toString()}`;
 }
-
-// Cap longest side at 1200px for event OG images: large enough that all
-// social surfaces render comfortably (Twitter recommends 1200×675), small
-// enough that even a 4000×3000 phone upload ships at <500KB JPEG.
-export const EVENT_OG_MAX_SIZE = {
-  width: 1200,
-  height: 1200,
-  fit: "shrink",
-} as const;
 
 // @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
 // an older User-Agent makes Google Fonts return plain .ttf URLs in the CSS.

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -1,37 +1,19 @@
 export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
 
-const BYTESCALE_ACCOUNT_ID = "12a1yek";
-const BYTESCALE_HOST = "upcdn.io";
-// Matches `/{accountId}/(raw|image)/{rest…}` — accepting both unprocessed
-// `raw/` URLs and already-transformed `image/` URLs that may carry user crop
-// params. Anything that doesn't match falls through unchanged.
-const BYTESCALE_PATH_RE = new RegExp(
-  `^/${BYTESCALE_ACCOUNT_ID}/(raw|image)(/.+)$`,
-);
+const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 
-interface TransformOptions {
-  width?: number;
-  height?: number;
-  quality?: number;
-  fit?: "crop" | "max" | "shrink";
-}
-
-// Satori (used by `next/og`) and several social crawlers (Slack, LinkedIn,
-// Discord, older Twitter) don't reliably render WebP. Bytescale serves WebP
-// by default, so route renderable Bytescale URLs through `/image/` with
-// `f=jpg`. Returns the original URL untouched if it isn't a Bytescale URL
-// on our account — we don't want to rewrite arbitrary external URLs into
-// bogus `/{accountId}/image/…` paths that would 404.
+// Force JPEG output for OG image consumers. Several social crawlers (Slack,
+// LinkedIn, Discord, older Twitter) and satori (`next/og`) don't reliably
+// render WebP, which is what Bytescale serves by default. Returns the URL
+// untouched if it isn't a Bytescale URL on our account.
 //
-// When the source is already an `/image/` URL (e.g. an event image saved
-// from our in-app cropper, with `crop-x` / `crop-y` query params) those
-// params are preserved so the rich preview honors the user's crop. Any
-// dimensions the caller passes override the existing values; `f=jpg` always
-// wins. Pass no opts to keep the user's crop and dimensions and only force
-// the JPEG codec.
+// Existing query params on already-transformed `/image/` URLs are inherited
+// so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
+// survives. The output dimensions and codec are then overridden, since
+// those are determined by where this URL is rendered, not by the editor.
 export function rewriteBytescaleToJpeg(
   url: string,
-  opts: TransformOptions = {},
+  { width, height }: { width: number; height: number },
 ): string {
   let parsed: URL;
   try {
@@ -39,30 +21,21 @@ export function rewriteBytescaleToJpeg(
   } catch {
     return url;
   }
-  if (parsed.hostname !== BYTESCALE_HOST) return url;
-  const match = BYTESCALE_PATH_RE.exec(parsed.pathname);
-  const mode = match?.[1];
-  const filePath = match?.[2];
-  if (!mode || !filePath) return url;
-  const isAlreadyTransformed = mode === "image";
-
-  const params = isAlreadyTransformed
-    ? new URLSearchParams(parsed.searchParams)
-    : new URLSearchParams();
-  if (opts.width !== undefined) params.set("w", String(opts.width));
-  if (opts.height !== undefined) params.set("h", String(opts.height));
-  if (opts.fit !== undefined) params.set("fit", opts.fit);
-  if (opts.quality !== undefined) params.set("q", String(opts.quality));
-  if (!params.has("q")) params.set("q", "82");
-  if (
-    !params.has("fit") &&
-    (opts.width !== undefined || opts.height !== undefined)
-  ) {
-    params.set("fit", "crop");
-  }
+  const match =
+    parsed.hostname === "upcdn.io"
+      ? BYTESCALE_PATH_RE.exec(parsed.pathname)
+      : null;
+  if (!match) return url;
+  const params =
+    match[1] === "image"
+      ? new URLSearchParams(parsed.searchParams)
+      : new URLSearchParams();
+  params.set("w", String(width));
+  params.set("h", String(height));
+  params.set("fit", "crop");
+  params.set("q", "82");
   params.set("f", "jpg");
-
-  return `https://${BYTESCALE_HOST}/${BYTESCALE_ACCOUNT_ID}/image${filePath}?${params.toString()}`;
+  return `https://upcdn.io/12a1yek/image${match[2]}?${params.toString()}`;
 }
 
 // @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
@@ -70,11 +43,11 @@ export function rewriteBytescaleToJpeg(
 // The CSS contains multiple @font-face blocks (devanagari, latin-ext, latin,
 // …); we target the `/* latin */` marker so we always fetch Latin glyphs.
 //
-// One AbortController is shared across both fetches so the *whole* font
-// load is capped at FONT_FETCH_TIMEOUT_MS. Independent timeouts on each
-// fetch would have a worst case of 2× the budget when the CSS just barely
-// succeeds and the binary then stalls — pushing the route toward Next's
-// request timeout when combined with a slow Convex query.
+// One AbortController spans both fetches so the whole font load is capped
+// at FONT_FETCH_TIMEOUT_MS. Without a timeout, a stalled Google Fonts
+// response blocks the OG route until Next's request timeout and returns
+// an error to the crawler instead of an image — that was the dominant
+// source of inconsistent rich previews for lists.
 const FONT_FETCH_TIMEOUT_MS = 4000;
 
 export async function loadGoogleFont(

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -1,15 +1,17 @@
-import * as Bytescale from "@bytescale/sdk";
-
-import { extractFilePath } from "~/lib/utils";
-
 export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
 
 const BYTESCALE_ACCOUNT_ID = "12a1yek";
 const BYTESCALE_HOST = "upcdn.io";
+// Matches `/{accountId}/(raw|image)/{rest…}` — accepting both unprocessed
+// `raw/` URLs and already-transformed `image/` URLs that may carry user crop
+// params. Anything that doesn't match falls through unchanged.
+const BYTESCALE_PATH_RE = new RegExp(
+  `^/${BYTESCALE_ACCOUNT_ID}/(raw|image)(/.+)$`,
+);
 
 interface TransformOptions {
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   quality?: number;
   fit?: "crop" | "max" | "shrink";
 }
@@ -17,13 +19,19 @@ interface TransformOptions {
 // Satori (used by `next/og`) and several social crawlers (Slack, LinkedIn,
 // Discord, older Twitter) don't reliably render WebP. Bytescale serves WebP
 // by default, so route renderable Bytescale URLs through `/image/` with
-// `f=jpg` to force JPEG. Returns the original URL untouched if it isn't a
-// Bytescale URL on our account, or if the path can't be parsed — we never
-// want to rewrite arbitrary external URLs into bogus `/{accountId}/image/…`
-// paths that would 404.
+// `f=jpg`. Returns the original URL untouched if it isn't a Bytescale URL
+// on our account — we don't want to rewrite arbitrary external URLs into
+// bogus `/{accountId}/image/…` paths that would 404.
+//
+// When the source is already an `/image/` URL (e.g. an event image saved
+// from our in-app cropper, with `crop-x` / `crop-y` query params) those
+// params are preserved so the rich preview honors the user's crop. Any
+// dimensions the caller passes override the existing values; `f=jpg` always
+// wins. Pass no opts to keep the user's crop and dimensions and only force
+// the JPEG codec.
 export function rewriteBytescaleToJpeg(
   url: string,
-  opts: TransformOptions,
+  opts: TransformOptions = {},
 ): string {
   let parsed: URL;
   try {
@@ -32,23 +40,29 @@ export function rewriteBytescaleToJpeg(
     return url;
   }
   if (parsed.hostname !== BYTESCALE_HOST) return url;
-  if (!parsed.pathname.startsWith(`/${BYTESCALE_ACCOUNT_ID}/`)) return url;
-  const filePath = extractFilePath(url);
-  if (!filePath) return url;
-  return Bytescale.UrlBuilder.url({
-    accountId: BYTESCALE_ACCOUNT_ID,
-    filePath,
-    options: {
-      transformation: "image",
-      transformationParams: {
-        w: opts.width,
-        h: opts.height,
-        fit: opts.fit ?? "crop",
-        f: "jpg",
-        q: opts.quality ?? 82,
-      },
-    },
-  });
+  const match = BYTESCALE_PATH_RE.exec(parsed.pathname);
+  const mode = match?.[1];
+  const filePath = match?.[2];
+  if (!mode || !filePath) return url;
+  const isAlreadyTransformed = mode === "image";
+
+  const params = isAlreadyTransformed
+    ? new URLSearchParams(parsed.searchParams)
+    : new URLSearchParams();
+  if (opts.width !== undefined) params.set("w", String(opts.width));
+  if (opts.height !== undefined) params.set("h", String(opts.height));
+  if (opts.fit !== undefined) params.set("fit", opts.fit);
+  if (opts.quality !== undefined) params.set("q", String(opts.quality));
+  if (!params.has("q")) params.set("q", "82");
+  if (
+    !params.has("fit") &&
+    (opts.width !== undefined || opts.height !== undefined)
+  ) {
+    params.set("fit", "crop");
+  }
+  params.set("f", "jpg");
+
+  return `https://${BYTESCALE_HOST}/${BYTESCALE_ACCOUNT_ID}/image${filePath}?${params.toString()}`;
 }
 
 // @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
@@ -56,16 +70,19 @@ export function rewriteBytescaleToJpeg(
 // The CSS contains multiple @font-face blocks (devanagari, latin-ext, latin,
 // …); we target the `/* latin */` marker so we always fetch Latin glyphs.
 //
-// Both fetches have explicit timeouts: without them, a slow or stalled
-// Google Fonts response can block the whole OG route until Next's request
-// timeout, returning an error to the crawler instead of an image. That was
-// the dominant source of inconsistent rich previews for lists.
+// One AbortController is shared across both fetches so the *whole* font
+// load is capped at FONT_FETCH_TIMEOUT_MS. Independent timeouts on each
+// fetch would have a worst case of 2× the budget when the CSS just barely
+// succeeds and the binary then stalls — pushing the route toward Next's
+// request timeout when combined with a slow Convex query.
 const FONT_FETCH_TIMEOUT_MS = 4000;
 
 export async function loadGoogleFont(
   family: string,
   weight: number,
 ): Promise<ArrayBuffer | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FONT_FETCH_TIMEOUT_MS);
   try {
     const urlFamily = family.replace(/ /g, "+");
     const cssRes = await fetch(
@@ -75,7 +92,7 @@ export async function loadGoogleFont(
           "User-Agent":
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36",
         },
-        signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
+        signal: controller.signal,
       },
     );
     if (!cssRes.ok) return null;
@@ -86,13 +103,13 @@ export async function loadGoogleFont(
     const fallbackMatch = /url\(([^)]+)\)/.exec(css);
     const fontUrl = latinBlockMatch?.[1] ?? fallbackMatch?.[1];
     if (!fontUrl) return null;
-    const fontRes = await fetch(fontUrl, {
-      signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
-    });
+    const fontRes = await fetch(fontUrl, { signal: controller.signal });
     if (!fontRes.ok) return null;
     return await fontRes.arrayBuffer();
   } catch (err) {
     console.warn("[og-image] font fetch failed", family, weight, err);
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -2,21 +2,14 @@ export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
 
 const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 
-// Force JPEG output for OG image consumers. Several social crawlers (Slack,
-// LinkedIn, Discord, older Twitter) and satori (`next/og`) don't reliably
-// render WebP, which is what Bytescale serves by default. Returns the URL
-// untouched if it isn't a Bytescale URL on our account so we never rewrite
-// arbitrary external URLs into bogus `/12a1yek/image/…` paths that 404.
+// Force JPEG: satori (`next/og`) can't decode WebP, and several crawlers
+// (Slack, LinkedIn, Discord, older Twitter) render it inconsistently.
+// Non-Bytescale URLs pass through untouched.
 //
-// Pass `size` to force exact dimensions with `fit=crop`. Omit it to keep
-// the source's native dimensions — declaring fixed dimensions against a
-// portrait user upload caused intermittent rejection by Apple's
-// LinkPresentation, so OG metadata that doesn't control the source aspect
-// ratio should leave size off and let crawlers measure the actual bytes.
-//
-// Existing query params on already-transformed `/image/` URLs are inherited
-// so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
-// survives.
+// Omit `size` to preserve source dimensions — declaring a fixed size
+// against a portrait user upload caused intermittent rejection by Apple's
+// LinkPresentation. Existing `/image/` query params (e.g. `crop-x/y/w/h`
+// from the in-app cropper) are inherited.
 export function rewriteBytescaleToJpeg(
   url: string,
   size?: { width: number; height: number },
@@ -46,15 +39,11 @@ export function rewriteBytescaleToJpeg(
   return `https://upcdn.io/12a1yek/image${match[2]}?${params.toString()}`;
 }
 
-// @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
-// an older User-Agent makes Google Fonts return plain .ttf URLs in the CSS.
-// The CSS contains multiple @font-face blocks (devanagari, latin-ext, latin,
-// …); we target the `/* latin */` marker so we always fetch Latin glyphs.
-//
-// One AbortController spans both fetches so the whole font load is capped
-// at FONT_FETCH_TIMEOUT_MS. Without a timeout, a stalled Google Fonts
-// response would block the OG route until Next's request timeout, returning
-// an error to the crawler instead of an image.
+// satori only decodes TTF/OTF/WOFF, not WOFF2. The User-Agent spoof makes
+// Google Fonts return plain .ttf URLs; the regex targets the `/* latin */`
+// block so we always pick Latin glyphs across font families. One
+// AbortController spans both fetches so a stalled Google Fonts response
+// can't hang the whole OG route past FONT_FETCH_TIMEOUT_MS.
 const FONT_FETCH_TIMEOUT_MS = 4000;
 
 export async function loadGoogleFont(

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -1,0 +1,98 @@
+import * as Bytescale from "@bytescale/sdk";
+
+import { extractFilePath } from "~/lib/utils";
+
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+
+const BYTESCALE_ACCOUNT_ID = "12a1yek";
+const BYTESCALE_HOST = "upcdn.io";
+
+interface TransformOptions {
+  width: number;
+  height: number;
+  quality?: number;
+  fit?: "crop" | "max" | "shrink";
+}
+
+// Satori (used by `next/og`) and several social crawlers (Slack, LinkedIn,
+// Discord, older Twitter) don't reliably render WebP. Bytescale serves WebP
+// by default, so route renderable Bytescale URLs through `/image/` with
+// `f=jpg` to force JPEG. Returns the original URL untouched if it isn't a
+// Bytescale URL on our account, or if the path can't be parsed — we never
+// want to rewrite arbitrary external URLs into bogus `/{accountId}/image/…`
+// paths that would 404.
+export function rewriteBytescaleToJpeg(
+  url: string,
+  opts: TransformOptions,
+): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.hostname !== BYTESCALE_HOST) return url;
+  if (!parsed.pathname.startsWith(`/${BYTESCALE_ACCOUNT_ID}/`)) return url;
+  const filePath = extractFilePath(url);
+  if (!filePath) return url;
+  return Bytescale.UrlBuilder.url({
+    accountId: BYTESCALE_ACCOUNT_ID,
+    filePath,
+    options: {
+      transformation: "image",
+      transformationParams: {
+        w: opts.width,
+        h: opts.height,
+        fit: opts.fit ?? "crop",
+        f: "jpg",
+        q: opts.quality ?? 82,
+      },
+    },
+  });
+}
+
+// @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
+// an older User-Agent makes Google Fonts return plain .ttf URLs in the CSS.
+// The CSS contains multiple @font-face blocks (devanagari, latin-ext, latin,
+// …); we target the `/* latin */` marker so we always fetch Latin glyphs.
+//
+// Both fetches have explicit timeouts: without them, a slow or stalled
+// Google Fonts response can block the whole OG route until Next's request
+// timeout, returning an error to the crawler instead of an image. That was
+// the dominant source of inconsistent rich previews for lists.
+const FONT_FETCH_TIMEOUT_MS = 4000;
+
+export async function loadGoogleFont(
+  family: string,
+  weight: number,
+): Promise<ArrayBuffer | null> {
+  try {
+    const urlFamily = family.replace(/ /g, "+");
+    const cssRes = await fetch(
+      `https://fonts.googleapis.com/css?family=${urlFamily}:${weight}&display=swap`,
+      {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36",
+        },
+        signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
+      },
+    );
+    if (!cssRes.ok) return null;
+    const css = await cssRes.text();
+    const latinBlockMatch = /\/\*\s*latin\s*\*\/[\s\S]*?url\(([^)]+)\)/.exec(
+      css,
+    );
+    const fallbackMatch = /url\(([^)]+)\)/.exec(css);
+    const fontUrl = latinBlockMatch?.[1] ?? fallbackMatch?.[1];
+    if (!fontUrl) return null;
+    const fontRes = await fetch(fontUrl, {
+      signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
+    });
+    if (!fontRes.ok) return null;
+    return await fontRes.arrayBuffer();
+  } catch (err) {
+    console.warn("[og-image] font fetch failed", family, weight, err);
+    return null;
+  }
+}

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -7,13 +7,18 @@ const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 // render WebP, which is what Bytescale serves by default. Returns the URL
 // untouched if it isn't a Bytescale URL on our account.
 //
+// Pass dimensions to render at a specific size (used by the list satori
+// card, where thumbnails need to be small + uniform). Omit dimensions to
+// keep the source's native dimensions and only force the codec — that's
+// what event OG metadata wants, since declaring fixed 1200×630 against a
+// portrait poster was the bug we just fixed.
+//
 // Existing query params on already-transformed `/image/` URLs are inherited
 // so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
-// survives. The output dimensions and codec are then overridden, since
-// those are determined by where this URL is rendered, not by the editor.
+// survives.
 export function rewriteBytescaleToJpeg(
   url: string,
-  { width, height }: { width: number; height: number },
+  size?: { width: number; height: number },
 ): string {
   let parsed: URL;
   try {
@@ -30,10 +35,12 @@ export function rewriteBytescaleToJpeg(
     match[1] === "image"
       ? new URLSearchParams(parsed.searchParams)
       : new URLSearchParams();
-  params.set("w", String(width));
-  params.set("h", String(height));
-  params.set("fit", "crop");
-  params.set("q", "82");
+  if (size) {
+    params.set("w", String(size.width));
+    params.set("h", String(size.height));
+    params.set("fit", "crop");
+  }
+  if (!params.has("q")) params.set("q", "82");
   params.set("f", "jpg");
   return `https://upcdn.io/12a1yek/image${match[2]}?${params.toString()}`;
 }

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -7,18 +7,21 @@ const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 // render WebP, which is what Bytescale serves by default. Returns the URL
 // untouched if it isn't a Bytescale URL on our account.
 //
-// Pass dimensions to render at a specific size (used by the list satori
-// card, where thumbnails need to be small + uniform). Omit dimensions to
-// keep the source's native dimensions and only force the codec — that's
-// what event OG metadata wants, since declaring fixed 1200×630 against a
-// portrait poster was the bug we just fixed.
+// `size` modes:
+//   - `{ width, height }` (default `fit: "crop"`): force exact dimensions,
+//     used by the list satori card where thumbnails need to be small and
+//     uniform.
+//   - `{ width, height, fit: "shrink" }`: cap dimensions, preserve aspect,
+//     never upscale. Used by event OG metadata so a 4000×3000 phone photo
+//     doesn't ship to crawlers at full size (iMessage timeouts), without
+//     re-introducing the dimension-mismatch bug from forcing 1200×630.
 //
 // Existing query params on already-transformed `/image/` URLs are inherited
 // so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
 // survives.
 export function rewriteBytescaleToJpeg(
   url: string,
-  size?: { width: number; height: number },
+  size?: { width: number; height: number; fit?: "crop" | "shrink" },
 ): string {
   let parsed: URL;
   try {
@@ -38,12 +41,21 @@ export function rewriteBytescaleToJpeg(
   if (size) {
     params.set("w", String(size.width));
     params.set("h", String(size.height));
-    params.set("fit", "crop");
+    params.set("fit", size.fit ?? "crop");
   }
   if (!params.has("q")) params.set("q", "82");
   params.set("f", "jpg");
   return `https://upcdn.io/12a1yek/image${match[2]}?${params.toString()}`;
 }
+
+// Cap longest side at 1200px for event OG images: large enough that all
+// social surfaces render comfortably (Twitter recommends 1200×675), small
+// enough that even a 4000×3000 phone upload ships at <500KB JPEG.
+export const EVENT_OG_MAX_SIZE = {
+  width: 1200,
+  height: 1200,
+  fit: "shrink",
+} as const;
 
 // @vercel/og (satori) only understands TTF/OTF/WOFF — *not* WOFF2. Spoofing
 // an older User-Agent makes Google Fonts return plain .ttf URLs in the CSS.

--- a/apps/web/lib/og-image.ts
+++ b/apps/web/lib/og-image.ts
@@ -5,15 +5,14 @@ const BYTESCALE_PATH_RE = /^\/12a1yek\/(raw|image)(\/.+)$/;
 // Force JPEG output for OG image consumers. Several social crawlers (Slack,
 // LinkedIn, Discord, older Twitter) and satori (`next/og`) don't reliably
 // render WebP, which is what Bytescale serves by default. Returns the URL
-// untouched if it isn't a Bytescale URL on our account.
+// untouched if it isn't a Bytescale URL on our account so we never rewrite
+// arbitrary external URLs into bogus `/12a1yek/image/…` paths that 404.
 //
-// Pass dimensions to force exact size with `fit=crop` (used by the list
-// satori card where thumbnails need to be small + uniform). Omit them to
-// keep the source's native dimensions and only force the codec — that's
-// what event OG metadata wants, since declaring fixed 1200×630 against a
-// portrait poster was the bug we fixed. Upload paths already cap source
-// dimensions (Expo: 640 or 1284 wide), so re-capping at the OG layer is
-// redundant defense-in-depth that wasn't worth the API surface.
+// Pass `size` to force exact dimensions with `fit=crop`. Omit it to keep
+// the source's native dimensions — declaring fixed dimensions against a
+// portrait user upload caused intermittent rejection by Apple's
+// LinkPresentation, so OG metadata that doesn't control the source aspect
+// ratio should leave size off and let crawlers measure the actual bytes.
 //
 // Existing query params on already-transformed `/image/` URLs are inherited
 // so the user's source crop (`crop-x/y/w/h` set by the in-app cropper)
@@ -54,9 +53,8 @@ export function rewriteBytescaleToJpeg(
 //
 // One AbortController spans both fetches so the whole font load is capped
 // at FONT_FETCH_TIMEOUT_MS. Without a timeout, a stalled Google Fonts
-// response blocks the OG route until Next's request timeout and returns
-// an error to the crawler instead of an image — that was the dominant
-// source of inconsistent rich previews for lists.
+// response would block the OG route until Next's request timeout, returning
+// an error to the crawler instead of an image.
 const FONT_FETCH_TIMEOUT_MS = 4000;
 
 export async function loadGoogleFont(


### PR DESCRIPTION
## Summary

Open Graph image previews for events, lists, and other pages were
rendering inconsistently across social platforms. Three independent
issues were contributing.

- **List OG route hangs.** `loadFont()` in
  `app/(base)/list/[slug]/opengraph-image.tsx` made two sequential
  Google Fonts fetches with no timeout. When Google Fonts was slow
  or rate-limited, the route blocked until Next.js's request timeout
  and returned an error to the crawler. Both fetches now use
  `AbortSignal.timeout(4000ms)`.
- **WebP-as-OG image.** Event metadata passed raw Bytescale URLs
  (which default to WebP) directly to crawlers, and the root layout
  default OG image was a `.webp` file. Slack, LinkedIn, Discord, and
  older Twitter render WebP inconsistently. All three are now routed
  through Bytescale's `/image/` processor with `f=jpg`.
- **Events with no image got no preview.** Events without an
  `images[0]` emitted an empty `images` array and downgraded
  `twitter:card` to `summary`. They now fall back to the branded
  `/api/og` default with `summary_large_image` so every event page
  has *some* rich preview.

The `transformImage` + `loadFont` helpers from the list OG route were
extracted to `apps/web/lib/og-image.ts` so the list route, event
metadata, and any future OG-emitting page share one implementation.

## Test plan

- [ ] `pnpm --filter @soonlist/web typecheck` — passes locally
- [ ] `pnpm --filter @soonlist/web lint` — passes locally (no new
      warnings)
- [ ] Verify on Vercel preview: paste a list URL and an event URL
      into a few unfurlers (Slack, Discord, https://opengraph.dev,
      https://www.opengraph.xyz) and confirm the rich preview
      renders consistently with the expected image
- [ ] Confirm the list OG route still renders the curated card
      (fonts loaded) on a warm cache, and the branded fallback when
      the Convex query fails or the list has no upcoming events
- [ ] Confirm an event without an image now shows the branded
      `/api/og` card instead of a no-image summary

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Open Graph previews consistent across Slack, Discord, LinkedIn, Twitter, and iMessage by forcing JPEGs, removing event image dimension mismatches, and capping Google Fonts to 4s. Events without an image now use a branded fallback and always render `summary_large_image`.

- **Bug Fixes**
  - Cap Google Fonts to 4s via a shared AbortController in `next/og` routes.
  - Event pages drop `og:image:width/height`; route user images through Bytescale `/image/?f=jpg` without resizing; always use `summary_large_image` and fall back to `/api/og` (uses `OG_IMAGE_SIZE`) when missing.
  - List OG images rewrite Bytescale URLs to JPEG thumbnails (preserve user crop); update the root default OG image to a JPEG URL.

- **Refactors**
  - Add `rewriteBytescaleToJpeg`, `loadGoogleFont`, and `OG_IMAGE_SIZE` in `apps/web/lib/og-image.ts`; preserve existing `/image/` transform params and support `/raw` and `/image` paths via a single regex.
  - Remove `@bytescale/sdk`.

<sup>Written for commit 0f518d27d1de4d85ddb9b6c14a52d236208a12f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three independent sources of unreliable OG image previews: font-fetch timeouts on the list OG route, WebP images being served to crawlers that don't render it, and events with no image producing a degraded `summary` card. The shared `~/lib/og-image.ts` module cleanly centralises the Bytescale-to-JPEG rewrite and Google Fonts loading logic so all OG-emitting pages share one implementation.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are targeted OG metadata fixes with no impact on core app logic; only P2 style findings.

All three root causes are correctly addressed with defensive fallbacks. The two P2 findings (cumulative font-fetch timeout and silent no-op for non-date paths) are edge-case hardening concerns that don't affect correctness today.

apps/web/lib/og-image.ts — consider tightening the per-font-family timeout ceiling and adding observability for the path-mismatch fallback.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/lib/og-image.ts | New shared utility — adds `rewriteBytescaleToJpeg` (JPEG conversion via Bytescale image processor) and `loadGoogleFont` (with AbortSignal timeout). Two P2 style concerns: cumulative 8s timeout per font family and silent no-op for non-date Bytescale paths. |
| apps/web/app/(base)/event/[eventId]/page.tsx | Metadata generation refactored to use shared OG helpers; falls back to `/api/og` branded image when no event image exists, and always emits `summary_large_image`. Logic is correct. |
| apps/web/app/(base)/list/[slug]/opengraph-image.tsx | Replaced inline `loadFont`/`transformImage` with shared helpers from `~/lib/og-image`; removed `@bytescale/sdk` direct dependency from this file. Change is clean. |
| apps/web/app/layout.tsx | Default root OG image URL updated from raw WebP to Bytescale JPEG processor endpoint; `metadataBase` is already set so the fallback `/api/og` relative URL in event pages will resolve correctly. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Crawler
    participant Next as Next.js Route
    participant Convex
    participant GoogleFonts
    participant Bytescale

    Crawler->>Next: GET /list/[slug]/opengraph-image
    Next->>Convex: getOgData(slug)
    Convex-->>Next: { list, owner, upcomingEvents }
    par Font loading (Promise.all, 4s timeout each)
        Next->>GoogleFonts: CSS fetch (IBM Plex Sans 500)
        Next->>GoogleFonts: CSS fetch (IBM Plex Sans 700)
        Next->>GoogleFonts: CSS fetch (Kalam 700)
        GoogleFonts-->>Next: TTF URLs (or timeout → null)
    end
    Note over Next: rewriteBytescaleToJpeg(evt.image, {w:360,h:640})
    Next->>Bytescale: /image/ processor (f=jpg)
    Bytescale-->>Next: JPEG image
    Next-->>Crawler: ImageResponse (PNG)

    Crawler->>Next: GET /event/[eventId] (metadata)
    Next->>Convex: events.get(eventId)
    Convex-->>Next: event data
    alt Event has image
        Note over Next: rewriteBytescaleToJpeg(rawImage, 1200x630)
        Next-->>Crawler: summary_large_image + JPEG URL
    else No image
        Note over Next: FALLBACK_OG_IMAGE = /api/og
        Next-->>Crawler: summary_large_image + /api/og URL
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/lib/og-image.ts
Line: 63-97

Comment:
**Cumulative timeout could reach 8 s per font family**

Each `loadGoogleFont` call makes two sequential fetches that each carry an independent 4-second `AbortSignal.timeout`. In the worst case (CSS fetch just-barely-succeeds at ~4 s, then font binary fetch also times out at 4 s) one call blocks for ~8 s. Three calls via `Promise.all` still resolve in up to 8 s, but if combined with a slow Convex query the total handler time could still creep toward Next.js's own request timeout.

Using a single `AbortController` shared across both fetches would cap the entire operation at 4 s per font family.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/lib/og-image.ts
Line: 36-37

Comment:
**Silent no-op for non-date-structured Bytescale paths**

`extractFilePath` uses the regex `/\/uploads\/\d{4}\/\d{2}\/\d{2}\/[^?]+/`, so any Bytescale URL whose path doesn't contain a `YYYY/MM/DD` segment returns `""`, and `rewriteBytescaleToJpeg` silently returns the original WebP URL. This is fine for current user-uploaded images, but future uploads stored under custom paths would be silently skipped. Consider logging the skipped URL at debug level so it's observable.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): make Open Graph image renderin..."](https://github.com/jaronheard/soonlist-turbo/commit/0f8c2a63085867db7c2130a6c41ac115845d1096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29747759)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->