### PR TITLE
fix(web): respect EXIF orientation for event images

### DIFF
--- a/apps/web/app/(base)/2024/page.tsx
+++ b/apps/web/app/(base)/2024/page.tsx
@@ -7,6 +7,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { Button } from "@soonlist/ui/button";
 
 import { env } from "~/env";
+import { buildDisplayImageUrl } from "~/lib/utils";
 import EmojiGrid from "./_components/emojiGrid";
 import Section from "./_components/section";
 import WeeklyDistribution from "./_components/weeklyDistribution";
@@ -214,11 +215,14 @@ export default async function Page() {
                 {event.images[0] && (
                   <div className="relative h-24 w-24 flex-shrink-0 overflow-hidden rounded-md">
                     <Image
-                      src={event.images[0]}
+                      src={
+                        buildDisplayImageUrl(event.images[0]) ?? event.images[0]
+                      }
                       alt={event.event_name}
                       fill
                       sizes="(max-width: 768px) 96px, 96px"
                       className="absolute inset-0 object-cover"
+                      style={{ imageOrientation: "from-image" }}
                     />
                   </div>
                 )}

--- a/apps/web/app/(base)/explore/posters/page.tsx
+++ b/apps/web/app/(base)/explore/posters/page.tsx
@@ -11,6 +11,7 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 
 import { UserProfileFlair } from "~/components/UserProfileFlair";
 import { useStableTimestamp } from "~/hooks/useStableQuery";
+import { buildDisplayImageUrl } from "~/lib/utils";
 
 interface PosterEvent {
   id: string;
@@ -124,11 +125,14 @@ export default function PostersPage() {
               <Link href={`/event/${event.id}`} className="block">
                 <div className="relative aspect-square overflow-hidden rounded-lg bg-interactive-3">
                   <Image
-                    src={event.images[0]!}
+                    src={
+                      buildDisplayImageUrl(event.images[0]) ?? event.images[0]!
+                    }
                     alt={event.name}
                     fill
                     className="object-cover object-top transition-transform duration-300 group-hover:scale-105"
                     sizes="(max-width: 640px) 100vw, 50vw"
+                    style={{ imageOrientation: "from-image" }}
                   />
                   {/* Gradient overlay for text readability */}
                   <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/70 to-transparent" />

--- a/apps/web/app/(base)/explore/posters/page.tsx
+++ b/apps/web/app/(base)/explore/posters/page.tsx
@@ -124,16 +124,18 @@ export default function PostersPage() {
             <div key={event.id} className="group relative">
               <Link href={`/event/${event.id}`} className="block">
                 <div className="relative aspect-square overflow-hidden rounded-lg bg-interactive-3">
-                  <Image
-                    src={
-                      buildDisplayImageUrl(event.images[0]) ?? event.images[0]!
-                    }
-                    alt={event.name}
-                    fill
-                    className="object-cover object-top transition-transform duration-300 group-hover:scale-105"
-                    sizes="(max-width: 640px) 100vw, 50vw"
-                    style={{ imageOrientation: "from-image" }}
-                  />
+                  {event.images[0] && (
+                    <Image
+                      src={
+                        buildDisplayImageUrl(event.images[0]) ?? event.images[0]
+                      }
+                      alt={event.name}
+                      fill
+                      className="object-cover object-top transition-transform duration-300 group-hover:scale-105"
+                      sizes="(max-width: 640px) 100vw, 50vw"
+                      style={{ imageOrientation: "from-image" }}
+                    />
+                  )}
                   {/* Gradient overlay for text readability */}
                   <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/70 to-transparent" />
                 </div>

--- a/apps/web/components/EventDisplays.tsx
+++ b/apps/web/components/EventDisplays.tsx
@@ -25,7 +25,7 @@ import type { EventWithUser } from "./EventList";
 import { TimezoneContext } from "~/context/TimezoneContext";
 import { DEFAULT_TIMEZONE } from "~/lib/constants";
 import { getGoogleMapsUrl } from "~/lib/maps";
-import { cn, formatUrlForDisplay } from "~/lib/utils";
+import { buildDisplayImageUrl, cn, formatUrlForDisplay } from "~/lib/utils";
 import { CalendarButton } from "./CalendarButton";
 import { DeleteButton } from "./DeleteButton";
 import { EditButton } from "./EditButton";
@@ -878,7 +878,7 @@ export function EventListItem(props: EventListItemProps) {
           >
             {image ? (
               <Image
-                src={`${image}`}
+                src={buildDisplayImageUrl(image) ?? image}
                 alt=""
                 width={thumbWidth}
                 height={thumbHeight}
@@ -890,6 +890,7 @@ export function EventListItem(props: EventListItemProps) {
                   borderWidth: 3,
                   borderColor: "white",
                   objectPosition: "top",
+                  imageOrientation: "from-image",
                 }}
               />
             ) : (
@@ -1049,10 +1050,11 @@ export function EventListItem(props: EventListItemProps) {
           <div className="relative h-44 w-full grow">
             <Image
               className="rounded-t-xl object-cover"
-              src={image}
+              src={buildDisplayImageUrl(image) ?? image}
               alt=""
               fill
               sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 33vw"
+              style={{ imageOrientation: "from-image" }}
               priority
             />
           </div>

--- a/apps/web/components/LightboxImage/index.tsx
+++ b/apps/web/components/LightboxImage/index.tsx
@@ -8,6 +8,8 @@ import Zoom from "yet-another-react-lightbox/plugins/zoom";
 
 import "yet-another-react-lightbox/styles.css";
 
+import { buildDisplayImageUrl } from "~/lib/utils";
+
 interface LightboxImageProps {
   src: string;
   alt: string;
@@ -30,6 +32,7 @@ export default function LightboxImage({
   sizes,
 }: LightboxImageProps) {
   const [open, setOpen] = useState(false);
+  const displaySrc = buildDisplayImageUrl(src) ?? src;
 
   return (
     <>
@@ -46,12 +49,13 @@ export default function LightboxImage({
         }}
       >
         <Image
-          src={src}
+          src={displaySrc}
           alt={alt}
           width={fill ? undefined : width}
           height={fill ? undefined : height}
           fill={fill}
           className={`object-cover object-top ${className}`}
+          style={{ imageOrientation: "from-image" }}
           priority={priority}
           sizes={sizes}
         />
@@ -66,7 +70,7 @@ export default function LightboxImage({
       <Lightbox
         open={open}
         close={() => setOpen(false)}
-        slides={[{ src }]}
+        slides={[{ src: displaySrc }]}
         plugins={[Zoom]}
         carousel={{ finite: true }}
         animation={{ fade: 300 }}

--- a/apps/web/lib/utils.tsx
+++ b/apps/web/lib/utils.tsx
@@ -74,6 +74,27 @@ export function extractFilePath(url: string) {
   return match ? match[0] : "";
 }
 
+const BYTESCALE_ACCOUNT_ID = "12a1yek";
+
+/**
+ * Convert a Bytescale URL to one served through the image processor, which
+ * auto-applies EXIF orientation. Pass-through for non-Bytescale URLs.
+ */
+export function buildDisplayImageUrl(
+  url: string | null | undefined,
+): string | null {
+  if (!url) return null;
+  if (!url.includes("upcdn.io")) return url;
+
+  const filePath = extractFilePath(url);
+  if (!filePath) return url;
+
+  // Already an image-processor URL — leave query params intact.
+  if (url.includes(`/${BYTESCALE_ACCOUNT_ID}/image/`)) return url;
+
+  return `https://upcdn.io/${BYTESCALE_ACCOUNT_ID}/image${filePath}`;
+}
+
 export function valueToOption(value: string): { value: string; label: string } {
   return { value, label: value };
 }

--- a/apps/web/lib/utils.tsx
+++ b/apps/web/lib/utils.tsx
@@ -84,13 +84,21 @@ export function buildDisplayImageUrl(
   url: string | null | undefined,
 ): string | null {
   if (!url) return null;
-  if (!url.includes("upcdn.io")) return url;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.hostname !== "upcdn.io") return url;
+  if (!parsed.pathname.startsWith(`/${BYTESCALE_ACCOUNT_ID}/`)) return url;
+
+  // Already an image-processor URL — leave query params intact.
+  if (parsed.pathname.startsWith(`/${BYTESCALE_ACCOUNT_ID}/image/`)) return url;
 
   const filePath = extractFilePath(url);
   if (!filePath) return url;
-
-  // Already an image-processor URL — leave query params intact.
-  if (url.includes(`/${BYTESCALE_ACCOUNT_ID}/image/`)) return url;
 
   return `https://upcdn.io/${BYTESCALE_ACCOUNT_ID}/image${filePath}`;
 }


### PR DESCRIPTION
## Summary

- Bug: some event images render sideways on the web (example: https://www.soonlist.com/event/jipgbn0ra3kl)
- Root cause for the EXIF case: Bytescale event-image URLs are stored as `/raw/...` and passed straight to `<Image>`. Next.js Image proxies through `/_next/image`, which uses `sharp` -- `sharp` strips EXIF without baking rotation, so any image with a non-default Orientation tag displays sideways
- Fix: route those URLs through Bytescale `/image/...` (auto-applies EXIF orientation) before handing them to `<Image>`. Add `image-orientation: from-image` as defense-in-depth for the raw `<img>` fallback paths
- Helper: `buildDisplayImageUrl()` in `apps/web/lib/utils.tsx`. Applied at every event-image render point I could find: `LightboxImage`, both `EventDisplays.tsx` thumbnails, the `/explore/posters` grid, and the `/2024` recap page

## Important caveat

**This does NOT fix the example image** (`jipgbn0ra3kl`). Inspecting the stored WEBP shows a plain `VP8 ` chunk (no `VP8X`/EXIF) and 640x480 landscape pixels that visually contain a portrait poster -- meaning the original Expo `ImageManipulator` pipeline (pre-PR #1078) re-encoded the photo and stripped EXIF *without* baking rotation. The orientation information is gone from the bytes; no CDN/CSS/Next change can recover it.

PR #1078 prevents new uploads from landing in this state. This PR makes the web display path correctly honor EXIF for any image that still has it (e.g. anything uploaded via the web file widget, or any future regressions).

### Suggested follow-up (not in this PR)

Add a manual rotate control to the event edit page (`apps/web/components/ImageUpload.tsx`) so users can fix already-broken images without re-uploading. Bytescale supports `rotate=90/180/270` URL params; rotating + re-saving as a new file path would be straightforward.

## Test plan

- [x] `pnpm --filter @soonlist/web typecheck` passes
- [x] `pnpm --filter @soonlist/web lint --fix` reports 0 errors on changed files
- [x] `pnpm --filter @soonlist/web format` clean
- [ ] Manual: upload a portrait JPEG with EXIF Orientation=6 via the event edit page, confirm it displays upright in feed thumbnail, lightbox preview, posters grid, and event detail (live preview not run -- worktree backend needs interactive Convex setup)
- [ ] Manual: confirm `jipgbn0ra3kl` is *still* sideways (expected -- bytes are wrong, see caveat above) and decide whether to re-upload or build the rotate UI

(C)laude generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sideways event images on web by honoring EXIF orientation. Bytescale image URLs now go through the processor, with a CSS fallback, so images render upright.

- **Bug Fixes**
  - Use `buildDisplayImageUrl()` to route `upcdn.io` `/raw/...` URLs under our account to `/image/...` before Next.js re-encodes; non-Bytescale and cross-account URLs pass through unchanged. Add `image-orientation: from-image` as a fallback.
  - Applied in `LightboxImage`, `EventDisplays`, Explore posters grid (now guards empty `images`) and the 2024 recap page. Existing WEBPs without EXIF remain rotated; PR #1078 prevents new cases.

<sup>Written for commit 7eb4ed69f3beabb38d976e8c3d35df903a1db506. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes sideways event images on the web by introducing `buildDisplayImageUrl()` in `apps/web/lib/utils.tsx`, which rewrites Bytescale `/raw/` URLs to `/image/` URLs so that Bytescale's image processor auto-applies EXIF orientation before `sharp` re-encodes the result. The helper is applied consistently across all event-image render points (`LightboxImage`, `EventDisplays`, posters grid, and the 2024 recap page), with `image-orientation: from-image` added as a CSS fallback for any path that bypasses the Next.js image proxy.

<h3>Confidence Score: 4/5</h3>

Safe to merge; fix is correct and well-scoped with only minor P2 observations.

No P0/P1 issues. The URL rewriting logic handles all edge cases (null input, non-Bytescale URLs, already-converted image URLs, unmatched path patterns). Two P2s: a silent pass-through in `extractFilePath` that deserves a comment, and a pre-existing unguarded `event.images[0]!` in the posters page that the refactor surfaces. P2s alone cap at 4/5.

apps/web/app/(base)/explore/posters/page.tsx — unguarded `event.images[0]!` fallback worth addressing.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/lib/utils.tsx | Adds `buildDisplayImageUrl()`: converts Bytescale `/raw/` URLs to `/image/` for EXIF-aware serving; preserves existing `/image/` query params; passes non-Bytescale URLs through unchanged. Logic is sound, edge cases (null input, missing path match, already-converted URL) are all handled. |
| apps/web/components/LightboxImage/index.tsx | Applies `buildDisplayImageUrl` to both the thumbnail `<Image>` and the lightbox `slides` array. Consistent and correct; the `displaySrc` variable avoids calling the helper twice. |
| apps/web/components/EventDisplays.tsx | Applies `buildDisplayImageUrl` at both thumbnail render sites; fallback pattern `?? image` preserves previous behaviour for non-Bytescale or unmatched URLs. |
| apps/web/app/(base)/explore/posters/page.tsx | Applies `buildDisplayImageUrl` to poster grid images; the non-null assertion fallback `event.images[0]!` could still pass `undefined` if images array is empty (pre-existing issue surfaced by refactor). |
| apps/web/app/(base)/2024/page.tsx | Correctly guards image render with `{event.images[0] && ...}` before using `buildDisplayImageUrl`, so the `?? event.images[0]` fallback is safe. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Component
    participant U as buildDisplayImageUrl()
    participant NI as Next.js /_next/image
    participant B as Bytescale /image/

    C->>U: raw URL (upcdn.io/.../raw/...)
    U-->>C: rewritten URL (upcdn.io/.../image/...)
    C->>NI: src=rewritten URL
    NI->>B: fetch /image/ URL
    B-->>NI: pixels with EXIF orientation baked in
    NI-->>C: re-encoded image (sharp strips EXIF, pixels already correct)
    C-->>C: displays upright
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/lib/utils.tsx`, line 72-75 ([link](https://github.com/jaronheard/soonlist-turbo/blob/64738b8334e660e25d102b4a32a18d9f3eb0def3/apps/web/lib/utils.tsx#L72-L75)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`extractFilePath` silently skips non-date-path Bytescale URLs**

   `extractFilePath` only matches `/uploads/YYYY/MM/DD/...` paths. Any Bytescale URL with a different structure (e.g., `/uploads/Soonlist/soonlist-meta.webp`) returns `""`, causing `buildDisplayImageUrl` to fall back to the original `/raw/` URL unchanged, silently bypassing EXIF correction for those images. This is intentional for static assets, but the current code provides no indication this is happening, which could cause confusion if future user-uploaded images land in an unexpected path structure. Consider adding an explanatory comment about the deliberate pass-through.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/lib/utils.tsx
   Line: 72-75

   Comment:
   **`extractFilePath` silently skips non-date-path Bytescale URLs**

   `extractFilePath` only matches `/uploads/YYYY/MM/DD/...` paths. Any Bytescale URL with a different structure (e.g., `/uploads/Soonlist/soonlist-meta.webp`) returns `""`, causing `buildDisplayImageUrl` to fall back to the original `/raw/` URL unchanged, silently bypassing EXIF correction for those images. This is intentional for static assets, but the current code provides no indication this is happening, which could cause confusion if future user-uploaded images land in an unexpected path structure. Consider adding an explanatory comment about the deliberate pass-through.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/lib/utils.tsx
Line: 72-75

Comment:
**`extractFilePath` silently skips non-date-path Bytescale URLs**

`extractFilePath` only matches `/uploads/YYYY/MM/DD/...` paths. Any Bytescale URL with a different structure (e.g., `/uploads/Soonlist/soonlist-meta.webp`) returns `""`, causing `buildDisplayImageUrl` to fall back to the original `/raw/` URL unchanged, silently bypassing EXIF correction for those images. This is intentional for static assets, but the current code provides no indication this is happening, which could cause confusion if future user-uploaded images land in an unexpected path structure. Consider adding an explanatory comment about the deliberate pass-through.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/app/(base)/explore/posters/page.tsx
Line: 126-130

Comment:
**Missing guard for empty images array**

If `event.images` is an empty array, `event.images[0]` is `undefined`, `buildDisplayImageUrl(undefined)` returns `null`, and then `null ?? event.images[0]!` resolves to `undefined` (the `!` only suppresses the type error). This passes `undefined` as the `src` prop of `<Image>`, which will throw at runtime. The 2024 page guards with `{event.images[0] && ...}` — the same pattern would be safer here. (This was a pre-existing issue, but the refactor is a good opportunity to fix it.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): respect EXIF orientation for e..."](https://github.com/jaronheard/soonlist-turbo/commit/64738b8334e660e25d102b4a32a18d9f3eb0def3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29748163)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->