### PR TITLE
chore(expo): enable expo-mcp local capabilities for UI verification

### DIFF
--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -39,10 +39,11 @@ When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) bef
 
 The `expo-mcp` HTTP server is registered for this project in `~/.claude.json`. The local `expo-mcp` dev dependency (in `apps/expo`) plus `EXPO_UNSTABLE_MCP_SERVER=1` (already set by the `dev` and `dev:ios` scripts) makes Metro expose screenshot, tap, and view-inspection tools through that MCP. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
 
-1. `pnpm dev:expo` from the repo root (Metro defaults to port 8081; check the Metro log line if overridden).
-2. Run `/mcp` to authenticate / reconnect.
-3. Screenshot the affected screen and confirm the change rendered.
-4. Exercise the golden path plus at least one edge case.
+1. **Make sure Metro is running.** Agent environments often start with no dev servers up; launch with `pnpm dev:expo` from the repo root if needed.
+2. **Find the Metro port for the environment you're working in.** Each worktree gets its own port pair from [`.claude/worktree-bootstrap.sh`](../../.claude/worktree-bootstrap.sh). Check `.claude/.worktree-ports` (`METRO_PORT=`), `.env.local` (`RCT_METRO_PORT=`), or the SessionStart hook's `metro: http://localhost:<port>` log line. The main checkout defaults to `8081`.
+3. Run `/mcp` to authenticate / reconnect.
+4. Screenshot the affected screen and confirm the change rendered.
+5. Exercise the golden path plus at least one edge case.
 
 If the MCP is genuinely unreachable (auth failed, no booted simulator, Metro down), say so explicitly rather than claiming success. Requires macOS host and Expo SDK ≥ 54.
 

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -39,7 +39,7 @@ When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) bef
 
 The `expo-mcp` HTTP server is registered for this project in `~/.claude.json`. The local `expo-mcp` dev dependency (in `apps/expo`) plus `EXPO_UNSTABLE_MCP_SERVER=1` (already set by the `dev` and `dev:ios` scripts) makes Metro expose screenshot, tap, and view-inspection tools through that MCP. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
 
-1. `pnpm dev:expo` from the repo root (Metro at `http://localhost:8154`).
+1. `pnpm dev:expo` from the repo root (Metro defaults to port 8081; check the Metro log line if overridden).
 2. Run `/mcp` to authenticate / reconnect.
 3. Screenshot the affected screen and confirm the change rendered.
 4. Exercise the golden path plus at least one edge case.

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -39,13 +39,17 @@ When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) bef
 
 The `expo-mcp` HTTP server is registered for this project in `~/.claude.json`. The local `expo-mcp` dev dependency (in `apps/expo`) plus `EXPO_UNSTABLE_MCP_SERVER=1` (already set by the `dev` and `dev:ios` scripts) makes Metro expose screenshot, tap, and view-inspection tools through that MCP. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
 
-1. **Make sure Metro is running.** Agent environments often start with no dev servers up; launch with `pnpm dev:expo` from the repo root if needed.
+1. **Make sure the dev stack is running.** Agent environments often start cold. The agent-friendly launch is two background processes from the repo root:
+   - `pnpm dev:no-expo` — Convex/web/etc. via turbo (no TTY needed).
+   - `pnpm dev:expo:ios` — Metro **plus** auto-launches the iOS simulator. This passes `--ios` to `expo start`, which is what avoids the interactive `i` keypress that the regular `pnpm dev:expo` would otherwise require — agents have no TTY to press keys in.
 2. **Find the Metro port for the environment you're working in.** Each worktree gets its own port pair from [`.claude/worktree-bootstrap.sh`](../../.claude/worktree-bootstrap.sh). Check `.claude/.worktree-ports` (`METRO_PORT=`), `.env.local` (`RCT_METRO_PORT=`), or the SessionStart hook's `metro: http://localhost:<port>` log line. The main checkout defaults to `8081`.
 3. Run `/mcp` to authenticate / reconnect.
 4. Screenshot the affected screen and confirm the change rendered.
 5. Exercise the golden path plus at least one edge case.
 
 If the MCP is genuinely unreachable (auth failed, no booted simulator, Metro down), say so explicitly rather than claiming success. Requires macOS host and Expo SDK ≥ 54.
+
+Humans normally launch `pnpm dev:expo` and press `i` themselves — that flow is unchanged. `pnpm dev:expo:ios` is the agent-only equivalent that skips the keypress.
 
 ## Push Notifications
 

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -33,6 +33,19 @@ Expo Router provides typed file-based navigation.
 - E2E tests use Maestro (`.maestro/` directory)
 - Run tests: `pnpm test`
 
+## Verifying UI changes
+
+When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) before reporting the task done — don't refuse with "I can't see the screen."
+
+The `expo-mcp` HTTP server is registered for this project in `~/.claude.json`. The local `expo-mcp` dev dependency (in `apps/expo`) plus `EXPO_UNSTABLE_MCP_SERVER=1` (already set by the `dev` and `dev:ios` scripts) makes Metro expose screenshot, tap, and view-inspection tools through that MCP. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
+
+1. `pnpm dev:expo` from the repo root (Metro at `http://localhost:8154`).
+2. Run `/mcp` to authenticate / reconnect.
+3. Screenshot the affected screen and confirm the change rendered.
+4. Exercise the golden path plus at least one edge case.
+
+If the MCP is genuinely unreachable (auth failed, no booted simulator, Metro down), say so explicitly rather than claiming success. Requires macOS host and Expo SDK ≥ 54.
+
 ## Push Notifications
 
 OneSignal handles push notifications.

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -37,7 +37,19 @@ Expo Router provides typed file-based navigation.
 
 When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) before reporting the task done — don't refuse with "I can't see the screen."
 
-The `expo-mcp` HTTP server is registered for this project in `~/.claude.json`. The local `expo-mcp` dev dependency (in `apps/expo`) plus `EXPO_UNSTABLE_MCP_SERVER=1` (already set by the `dev` and `dev:ios` scripts) makes Metro expose screenshot, tap, and view-inspection tools through that MCP. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
+How the chain works: the `expo-mcp` HTTP server (registered in your `~/.claude.json`) talks to a running Metro, which exposes screenshot, tap, and view-inspection tools because the `expo-mcp` dev dep is installed and the `dev` / `dev:ios` scripts set `EXPO_UNSTABLE_MCP_SERVER=1`. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
+
+### One-time setup (per developer / agent environment)
+
+`~/.claude.json` is per-user, so the MCP registration isn't checked into the repo. Run once from the project root you'll be working in:
+
+```sh
+claude mcp add --transport http --scope local expo-mcp https://mcp.expo.dev/mcp
+```
+
+Use `--scope user` instead if you want it registered once across every worktree/project on your machine. After registering, run `/mcp` in a Claude session to OAuth into Expo.
+
+### Per session
 
 1. **Make sure the dev stack is running.** Agent environments often start cold. The agent-friendly launch is two background processes from the repo root:
    - `pnpm dev:no-expo` — Convex/web/etc. via turbo (no TTY needed).

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -7,8 +7,8 @@
     "clean": "git clean -xdf .cache .expo .turbo ios node_modules dist",
     "debug.eas": "open 'rndebugger://set-debugger-loc?host=localhost&port=8081'",
     "debug": "open 'rndebugger://set-debugger-loc?host=localhost&port=19000'",
-    "dev:ios": "pnpm with-env expo start --ios",
-    "dev": "pnpm with-env expo start --clear",
+    "dev:ios": "EXPO_UNSTABLE_MCP_SERVER=1 pnpm with-env expo start --ios",
+    "dev": "EXPO_UNSTABLE_MCP_SERVER=1 pnpm with-env expo start --clear",
     "dev:tunnel": "pnpm with-env expo start --tunnel --clear",
     "dev:prod": "pnpm with-env expo start --tunnel --no-dev --minify --clear",
     "test": "pnpm with-env maestro test .maestro/local/",
@@ -131,6 +131,7 @@
     "eslint": "catalog:",
     "eslint-plugin-react-compiler": "catalog:",
     "expo-atlas": "catalog:",
+    "expo-mcp": "^0.2.4",
     "prettier": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -131,7 +131,7 @@
     "eslint": "catalog:",
     "eslint-plugin-react-compiler": "catalog:",
     "expo-atlas": "catalog:",
-    "expo-mcp": "^0.2.4",
+    "expo-mcp": "catalog:",
     "prettier": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "turbo dev --parallel",
     "dev:backend": "pnpm -F @soonlist/backend dev",
     "dev:expo": "pnpm -F @soonlist/expo dev",
+    "dev:expo:ios": "pnpm -F @soonlist/expo dev:ios",
     "dev:expo:tunnel": "pnpm -F @soonlist/expo dev:tunnel",
     "dev:expo:prod": "pnpm -F @soonlist/expo dev:prod",
     "dev:no-expo": "turbo dev --filter=!@soonlist/expo",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,7 +635,7 @@ importers:
         version: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       convex-helpers:
         specifier: 'catalog:'
-        version: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+        version: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
       expo:
         specifier: 'catalog:'
         version: 55.0.0-preview.12(@babel/core@7.28.5)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(bufferutil@4.1.0)(expo-router@55.0.0-preview.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -865,6 +865,9 @@ importers:
       expo-atlas:
         specifier: 'catalog:'
         version: 0.4.3(expo@55.0.0-preview.12)
+      expo-mcp:
+        specifier: ^0.2.4
+        version: 0.2.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       prettier:
         specifier: 'catalog:'
         version: 3.7.4
@@ -1078,10 +1081,10 @@ importers:
         version: 0.2.9(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
       '@convex-dev/workflow':
         specifier: 'catalog:'
-        version: 0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
       '@convex-dev/workpool':
         specifier: 'catalog:'
-        version: 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+        version: 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
       '@js-temporal/polyfill':
         specifier: 'catalog:'
         version: 0.4.4
@@ -2687,6 +2690,11 @@ packages:
       react: 19.2.0
       react-native: '*'
 
+  '@expo/mcp-tunnel@0.2.4':
+    resolution: {integrity: sha512-hxFzqdUNKCt+8pbGV3oGcd/aBNA1mmhwh3DSeXoHReypxzsiLYLITJs1OctglaPecfMA9qFb+6z/RIkRSf5S4g==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.26.0
+
   '@expo/metro-config@55.0.7':
     resolution: {integrity: sha512-YnGHm3uPwkzBiBdU1vBxSaFyi2eH7C4W+YEVnXZ/HFo+jex4Rzyu6JQe2qw3NVI16tkORYt+Wmj8vvxbUbdV/w==}
     peerDependencies:
@@ -2891,6 +2899,12 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@3.10.0':
     resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
     peerDependencies:
@@ -3054,6 +3068,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@isaacs/ttlcache@1.4.1':
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
@@ -3136,6 +3154,16 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
       react: 19.2.0
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@next/env@15.1.9':
     resolution: {integrity: sha512-Te1wbiJ//I40T7UePOUG8QBwh+VVMCc0OTuqesOcD3849TVOVOyX4Hdrkx7wcpLpy/LOABIcGyLX5P/SzzXhFA==}
@@ -5240,6 +5268,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -5318,6 +5350,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -5611,6 +5651,10 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -5943,6 +5987,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -5994,6 +6042,10 @@ packages:
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -6023,6 +6075,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -6659,6 +6715,14 @@ packages:
     resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
     engines: {node: '>=14.18'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -6851,6 +6915,10 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-mcp@0.2.4:
+    resolution: {integrity: sha512-rBomlm+085wNa+UF9YC3bXGZR6LlYPfOlUXwKBB5R7+dnASk0VjWFETuxyApdtXw9OItmOsAXolUxrAlEYfqSA==}
+    hasBin: true
+
   expo-modules-autolinking@55.0.7:
     resolution: {integrity: sha512-SA2XKDWE7bVmr3j9EZs7gBnUdr9s2opk14TXHgm1piC46Pi99hBz8Zown66a5bEE5J7S9pW7/pBGb4SzhHOSrQ==}
     hasBin: true
@@ -7003,9 +7071,19 @@ packages:
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -7109,6 +7187,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
@@ -7155,6 +7237,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -7253,6 +7339,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
@@ -7376,6 +7468,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -7416,6 +7512,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.1:
@@ -7620,6 +7720,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -7720,6 +7823,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jayson@4.3.0:
     resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
     engines: {node: '>=8'}
@@ -7772,6 +7879,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -7816,6 +7926,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -8238,6 +8351,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -8246,6 +8363,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -8420,6 +8541,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
@@ -8547,6 +8672,10 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -8859,6 +8988,9 @@ packages:
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -8902,6 +9034,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -9196,6 +9332,10 @@ packages:
   raw-body@2.5.3:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -9617,6 +9757,10 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.3.3:
     resolution: {integrity: sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==}
 
@@ -9708,6 +9852,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   sentence-case@2.1.1:
     resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
 
@@ -9731,6 +9879,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
@@ -10357,6 +10509,10 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -10780,6 +10936,10 @@ packages:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
 
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
@@ -10916,6 +11076,11 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  zx@8.8.5:
+    resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
 
 snapshots:
 
@@ -12138,17 +12303,17 @@ snapshots:
     dependencies:
       convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
 
-  '@convex-dev/workflow@0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/workflow@0.2.7(@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)))(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
     dependencies:
-      '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
+      '@convex-dev/workpool': 0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))
       async-channel: 0.2.0
       convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
 
-  '@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
+  '@convex-dev/workpool@0.2.19(convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76))(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))':
     dependencies:
       convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
-      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
+      convex-helpers: 0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -12605,6 +12770,16 @@ snapshots:
       react-native: 0.83.2(@babel/core@7.28.5)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
 
+  '@expo/mcp-tunnel@0.2.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@expo/metro-config@55.0.7(bufferutil@4.1.0)(expo@55.0.0-preview.12)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/code-frame': 7.28.6
@@ -12867,6 +13042,10 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@hookform/resolvers@3.10.0(react-hook-form@7.70.0(react@19.2.0))':
     dependencies:
       react-hook-form: 7.70.0(react@19.2.0)
@@ -12992,6 +13171,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -13139,6 +13320,28 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@next/env@15.1.9': {}
 
@@ -15615,6 +15818,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-import-attributes@1.9.5(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -15683,6 +15891,10 @@ snapshots:
       zod: 3.25.76
 
   ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 
@@ -16045,6 +16257,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16436,16 +16662,19 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
-  convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(react@19.2.0)(typescript@5.9.3)(zod@3.25.76):
+  convex-helpers@0.1.109(convex@1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0))(hono@4.12.15)(react@19.2.0)(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       convex: 1.31.2(@clerk/clerk-react@5.59.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
     optionalDependencies:
+      hono: 4.12.15
       react: 19.2.0
       typescript: 5.9.3
       zod: 3.25.76
@@ -16459,6 +16688,8 @@ snapshots:
       react: 19.2.0
 
   cookie-signature@1.0.7: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -16483,6 +16714,11 @@ snapshots:
   core-js@3.47.0: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -17247,6 +17483,12 @@ snapshots:
 
   eventsource-parser@1.1.2: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -17482,6 +17724,24 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-mcp@0.2.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@expo/mcp-tunnel': 0.2.4(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      debug: 4.4.3
+      glob: 11.1.0
+      jimp-compact: 0.16.1
+      resolve-from: 5.0.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      xml2js: 0.6.2
+      zod: 3.25.76
+      zx: 8.8.5
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   expo-modules-autolinking@55.0.7(typescript@5.9.3):
     dependencies:
       '@expo/require-utils': 55.0.1(typescript@5.9.3)
@@ -17694,6 +17954,11 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -17726,6 +17991,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17834,6 +18132,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-root@1.1.0: {}
 
   find-up@4.1.0:
@@ -17873,6 +18182,8 @@ snapshots:
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -17983,6 +18294,15 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.1
 
   glob@13.0.0:
     dependencies:
@@ -18165,6 +18485,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono@4.12.15: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -18216,6 +18538,10 @@ snapshots:
       safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -18421,6 +18747,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -18529,6 +18857,10 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@types/connect': 3.4.38
@@ -18629,6 +18961,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.2.2: {}
+
   js-base64@3.7.8: {}
 
   js-cookie@3.0.5: {}
@@ -18661,6 +18995,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -19070,11 +19406,15 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
 
   memoize-one@6.0.0: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -19480,6 +19820,10 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@1.6.0: {}
 
   mime@2.6.0: {}
@@ -19583,6 +19927,8 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -19966,6 +20312,8 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   periscopic@3.1.0:
@@ -19999,6 +20347,8 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   plist@3.1.0:
     dependencies:
@@ -20219,6 +20569,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.1
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -20765,6 +21122,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.3.3:
     dependencies:
       '@swc/helpers': 0.5.18
@@ -20867,6 +21234,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   sentence-case@2.1.1:
     dependencies:
       no-case: 2.3.2
@@ -20890,6 +21273,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21552,6 +21944,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -22034,6 +22432,11 @@ snapshots:
       sax: 1.4.4
       xmlbuilder: 11.0.1
 
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.4.4
+      xmlbuilder: 11.0.1
+
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@14.0.0: {}
@@ -22138,3 +22541,5 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.0)
 
   zwitch@2.0.4: {}
+
+  zx@8.8.5: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ catalogs:
     expo-location:
       specifier: ~55.1.6
       version: 55.1.6
+    expo-mcp:
+      specifier: ^0.2.4
+      version: 0.2.4
     expo-notifications:
       specifier: ~55.0.9
       version: 55.0.9
@@ -866,7 +869,7 @@ importers:
         specifier: 'catalog:'
         version: 0.4.3(expo@55.0.0-preview.12)
       expo-mcp:
-        specifier: ^0.2.4
+        specifier: 'catalog:'
         version: 0.2.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       prettier:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -188,6 +188,7 @@ catalog:
   "eslint-plugin-tailwindcss": ^3.14.0
   "eslint-plugin-react-compiler": 19.1.0-rc.1
   "expo-atlas": ^0.4.3
+  "expo-mcp": ^0.2.4
 
   # ESLint plugins
   "@next/eslint-plugin-next": ^14.2.0


### PR DESCRIPTION
## Summary
- Install `expo-mcp` (^0.2.4) as an `apps/expo` dev dependency.
- Set `EXPO_UNSTABLE_MCP_SERVER=1` on `dev` and `dev:ios` so Metro exposes screenshot, tap, and view-inspection tools to the official Expo MCP server.
- Add a "Verifying UI changes" section to [apps/expo/AGENTS.md](apps/expo/AGENTS.md) so future Claude Code sessions actually verify UI work on the booted iOS Simulator instead of refusing.

## Why
Today, agent sessions can't see the simulator and tend to skip visual verification of UI changes. Following Expo's own docs ([docs.expo.dev/eas/ai/mcp](https://docs.expo.dev/eas/ai/mcp/)), the local capability set (screenshots, etc.) requires both the `expo-mcp` dev dep installed and the `EXPO_UNSTABLE_MCP_SERVER=1` env var when starting Metro. The HTTP MCP at `https://mcp.expo.dev/mcp` then surfaces those tools to Claude.

## Reviewer notes
- The flag is `UNSTABLE_` — Expo SDK 55 (preview) is on the supported track (>=54). If a future Metro version moves it to a stable name, we will need to re-baseline.
- `dev:tunnel` and `dev:prod` deliberately untouched — local MCP is only useful for local sim work.
- Ngrok, lefthook, and other dev workflows are unaffected.
- The matching `~/.claude.json` MCP registration lives outside the repo (it's per-developer config) and is not part of this PR. Devs who want it can run `claude mcp add --transport http --scope local expo-mcp https://mcp.expo.dev/mcp` from the repo root, then `/mcp` in a Claude session to OAuth.

## Test plan
- [ ] `pnpm dev:expo` starts Metro with the env var set (check Metro logs for the MCP server line).
- [ ] After registering the MCP and authenticating via `/mcp`, the Expo MCP exposes simulator screenshot tools.
- [ ] `pnpm dev:tunnel` and `pnpm dev:prod` behave unchanged.
- [ ] No type or lint regressions: `pnpm lint:fix && pnpm check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables local UI verification in Expo by integrating `expo-mcp` and enabling Metro’s local MCP server in dev runs so agents can screenshot and tap the iOS Simulator. Adds a root `dev:expo:ios` alias and updates the guide with correct ports and a one-time MCP registration step.

- **New Features**
  - Integrated `expo-mcp@^0.2.4` via `catalog:` and set `EXPO_UNSTABLE_MCP_SERVER=1` in `dev` and `dev:ios`.
  - Added root `dev:expo:ios` to auto-launch the simulator; `dev:tunnel` and `dev:prod` unchanged.

- **Bug Fixes**
  - AGENTS guide: fixed Metro default port (8081), documented per-worktree ports (`.claude/.worktree-ports`, `.env.local` `RCT_METRO_PORT`, SessionStart log).
  - Added one-time MCP registration (`claude mcp add …`), clarified `/mcp` reconnect after Metro restarts, and recommended the agent flow (`pnpm dev:no-expo` + `pnpm dev:expo:ios`).

<sup>Written for commit 2573f1bd79e69379f4ddb988d8072fd93e23c5b3. Summary will update on new commits. <a href="https://cubic.dev/pr/jaronheard/soonlist-turbo/pull/1084?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up `expo-mcp` so that Claude Code sessions can take simulator screenshots and interact with the running iOS Simulator during UI work. The changes are limited to the Expo app: a new dev dependency, `EXPO_UNSTABLE_MCP_SERVER=1` prefixed on the `dev` / `dev:ios` scripts, and an updated `AGENTS.md` guide.

- The port `http://localhost:8154` cited in `AGENTS.md` does not match any configured Metro port in the project; the default Expo Metro port is 8081, and no `--port` flag or env var overrides it anywhere in the chain. Agents following this guide will fail to reach the dev server at that address.

<h3>Confidence Score: 3/5</h3>

Safe for runtime but the AGENTS.md port reference appears incorrect and will mislead agents trying to use the MCP tooling.

One P1 finding (wrong port in AGENTS.md instruction) and one P2 (catalog bypass) prevent a higher score. The app code itself is unaffected, but the agent guidance doc—the primary deliverable of this PR—contains a port that isn't defined anywhere in the project config.

apps/expo/AGENTS.md — verify or correct the Metro/MCP port 8154 reference

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/expo/AGENTS.md | Adds "Verifying UI changes" workflow section; references `http://localhost:8154` for Metro, which does not match the project's default Metro port (8081) and is unconfigured anywhere in the codebase. |
| apps/expo/package.json | Adds `EXPO_UNSTABLE_MCP_SERVER=1` to `dev` and `dev:ios` scripts and installs `expo-mcp`; the package bypasses the project's catalog system unlike every other dev dependency. |
| pnpm-lock.yaml | Lockfile updated to reflect `expo-mcp@0.2.4` and its transitive deps (`@expo/mcp-tunnel`, `@modelcontextprotocol/sdk`, `hono`, etc.); no issues found here. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer / Claude Agent
    participant Metro as Metro (expo start)
    participant MCP as Expo MCP (mcp.expo.dev)
    participant Sim as iOS Simulator

    Dev->>Metro: pnpm dev:expo (EXPO_UNSTABLE_MCP_SERVER=1)
    Metro->>Metro: starts MCP sidecar (local capabilities)
    Dev->>MCP: /mcp — OAuth & reconnect
    MCP->>Metro: forwards tool calls (screenshot, tap, inspect)
    Metro->>Sim: takes screenshot / sends tap event
    Sim-->>Metro: response
    Metro-->>MCP: tool result
    MCP-->>Dev: screenshot / result returned to Claude session
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/expo/AGENTS.md`, line 15 ([link](https://github.com/jaronheard/soonlist-turbo/blob/cf14448f6744874a5ef12891dc9a821f3a78a8b8/apps/expo/AGENTS.md#L15)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Metro port 8154 not reflected anywhere in the project config**

   The `dev` and `dev:ios` scripts run `expo start` without a `--port` flag, and `metro.config.js` sets no custom port, so Metro will bind to its default (8081). Port 8154 only appears in this instruction line — agents following this guide will fail to reach Metro or the MCP server at that address. If 8154 is the MCP tunnel sidecar port rather than Metro's bundler port, the instruction should clarify that distinction (e.g., "MCP sidecar at `http://localhost:8154`; Metro bundler at `http://localhost:8081`").

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/expo/AGENTS.md
   Line: 15

   Comment:
   **Metro port 8154 not reflected anywhere in the project config**

   The `dev` and `dev:ios` scripts run `expo start` without a `--port` flag, and `metro.config.js` sets no custom port, so Metro will bind to its default (8081). Port 8154 only appears in this instruction line — agents following this guide will fail to reach Metro or the MCP server at that address. If 8154 is the MCP tunnel sidecar port rather than Metro's bundler port, the instruction should clarify that distinction (e.g., "MCP sidecar at `http://localhost:8154`; Metro bundler at `http://localhost:8081`").

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/expo/package.json
Line: 134

Comment:
**`expo-mcp` bypasses the catalog system**

Every other dev dependency in this file uses `catalog:`, but `expo-mcp` is pinned inline with `^0.2.4`. Per the project's package-management rule, new dependencies should go through the catalog so version resolution stays centralised. Even though this package is only used here, the pattern is to add it to `pnpm-workspace.yaml` first and then reference it as `catalog:`.

```suggestion
    "expo-mcp": "catalog:",
```

**Rule Used:** Maintain consistency in package management by usin... ([source](https://app.greptile.com/review/custom-context?memory=56c3c834-ef4e-4173-adf2-7e53633398fa))

**Learned From**
[jaronheard/soonlist-turbo#580](https://github.com/jaronheard/soonlist-turbo/pull/580)
[jaronheard/soonlist-turbo#578](https://github.com/jaronheard/soonlist-turbo/pull/578)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/expo/AGENTS.md
Line: 15

Comment:
**Metro port 8154 not reflected anywhere in the project config**

The `dev` and `dev:ios` scripts run `expo start` without a `--port` flag, and `metro.config.js` sets no custom port, so Metro will bind to its default (8081). Port 8154 only appears in this instruction line — agents following this guide will fail to reach Metro or the MCP server at that address. If 8154 is the MCP tunnel sidecar port rather than Metro's bundler port, the instruction should clarify that distinction (e.g., "MCP sidecar at `http://localhost:8154`; Metro bundler at `http://localhost:8081`").

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(expo): enable expo-mcp local capab..."](https://github.com/jaronheard/soonlist-turbo/commit/cf14448f6744874a5ef12891dc9a821f3a78a8b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29800840)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Maintain consistency in package management by usin... ([source](https://app.greptile.com/review/custom-context?memory=56c3c834-ef4e-4173-adf2-7e53633398fa))

**Learned From**
[jaronheard/soonlist-turbo#580](https://github.com/jaronheard/soonlist-turbo/pull/580)
[jaronheard/soonlist-turbo#578](https://github.com/jaronheard/soonlist-turbo/pull/578)

<!-- /greptile_comment -->