### PR TITLE
chore(claude): add /sim-screenshot, simplify /start-dev (cmux preserved as /cmux-start-dev)

### DIFF
--- a/.claude/commands/cmux-start-dev.md
+++ b/.claude/commands/cmux-start-dev.md
@@ -1,0 +1,44 @@
+---
+name: cmux-start-dev
+allowed-tools: Bash, Read
+description: Start dev servers in separate cmux tabs (cmux required; otherwise use /start-dev)
+---
+
+# Start Development Servers
+
+Start both development server groups in separate cmux terminal tabs so they run independently of Claude and don't get killed by background task timeouts.
+
+## Instructions
+
+Run these steps sequentially using the Bash tool. Do NOT run cmux commands in parallel — each surface must be created, renamed, and started before moving to the next.
+
+1. **Install dependencies** (use absolute path so CWD stays at repo root):
+
+   ```bash
+   WORKTREE_PATH=$(git rev-parse --show-toplevel) && cd "$WORKTREE_PATH" && pnpm install
+   ```
+
+2. **Read the PORT from .env.local**:
+
+   ```bash
+   WORKTREE_PATH=$(git rev-parse --show-toplevel) && PORT=$(grep '^PORT=' "$WORKTREE_PATH/.env.local" 2>/dev/null | cut -d= -f2-) && printf '%s\n' "${PORT:-3000}"
+   ```
+
+   Save the printed value for step 5.
+
+3. **Clean up existing tabs** — close any previously created dev tabs so re-running `/start-dev` is idempotent:
+
+   ```bash
+   for EXISTING in $(cmux tree 2>&1 | grep -E '"(dev:no-expo|dev:expo)"' | grep -o 'surface:[0-9]*'); do cmux close-surface --surface "$EXISTING" 2>/dev/null || true; done
+   ```
+
+4. **Create two terminal tabs and start each server group** — run this as a **single** Bash command chained with `&&`. Never use `set -e` with newlines (orphan tabs on failure) and never split into parallel Bash calls:
+
+   ```bash
+   WORKTREE_PATH=$(git rev-parse --show-toplevel) && PORT=$(grep '^PORT=' "$WORKTREE_PATH/.env.local" 2>/dev/null | cut -d= -f2-) && PORT=${PORT:-3000} && NO_EXPO_COMMAND=$(printf 'cd %q && PORT=%q pnpm dev:no-expo\n' "$WORKTREE_PATH" "$PORT") && NO_EXPO_SURFACE=$(cmux new-surface --type terminal 2>&1 | awk '{print $2}') && cmux rename-tab --surface "$NO_EXPO_SURFACE" "dev:no-expo" && cmux send --surface "$NO_EXPO_SURFACE" "$NO_EXPO_COMMAND" && EXPO_COMMAND=$(printf 'cd %q && pnpm dev:expo\n' "$WORKTREE_PATH") && EXPO_SURFACE=$(cmux new-surface --type terminal 2>&1 | awk '{print $2}') && cmux rename-tab --surface "$EXPO_SURFACE" "dev:expo" && cmux send --surface "$EXPO_SURFACE" "$EXPO_COMMAND"
+   ```
+
+5. **Report immediately** — do NOT wait or verify. Just tell the user:
+   - Launched dev:no-expo and dev:expo in separate cmux tabs
+   - Next.js will be on port [PORT from step 2, or 3000 if not set]
+   - Switch cmux tabs to see each server's logs

--- a/.claude/commands/sim-screenshot.md
+++ b/.claude/commands/sim-screenshot.md
@@ -1,0 +1,24 @@
+---
+name: sim-screenshot
+allowed-tools: Bash
+description: Screenshot this worktree's dedicated iOS sim, deep-linked to its Metro
+---
+
+One sim per worktree (`ws-<dir>`), cloned from a booted iPhone 16e on first run. Run after `/start-dev`, then `Read` the printed path.
+
+```bash
+SIM="ws-$(basename "$PWD")"
+PORT=$(grep ^RCT_METRO_PORT .env.local | cut -d= -f2)
+if ! xcrun simctl list devices | grep -q " $SIM ("; then
+  SRC=$(xcrun simctl list devices booted | grep "iPhone 16e" | head -1 | grep -oE "[0-9A-F-]{36}")
+  xcrun simctl clone "$SRC" "$SIM"
+fi
+xcrun simctl boot "$SIM" 2>/dev/null || true
+xcrun simctl openurl "$SIM" "exp+timetimecc://expo-development-client/?url=http://localhost:$PORT"
+sleep 5
+OUT="/tmp/$SIM-$(date +%s).png"
+xcrun simctl io "$SIM" screenshot "$OUT"
+echo "$OUT"
+```
+
+If the screenshot shows the dev launcher, re-run. To clean up: `xcrun simctl delete "$SIM"`.

--- a/.claude/commands/start-dev.md
+++ b/.claude/commands/start-dev.md
@@ -1,44 +1,14 @@
 ---
 name: start-dev
-allowed-tools: Bash, Read
-description: Start dev servers (Expo + everything else) in separate cmux tabs
+allowed-tools: Bash
+description: Start Expo Metro + the rest in the background
 ---
 
-# Start Development Servers
+```bash
+WT=$(basename "$PWD")
+nohup pnpm dev:expo    > /tmp/${WT}-expo.log 2>&1 &
+nohup pnpm dev:no-expo > /tmp/${WT}-web.log  2>&1 &
+echo "logs: /tmp/${WT}-{expo,web}.log"
+```
 
-Start both development server groups in separate cmux terminal tabs so they run independently of Claude and don't get killed by background task timeouts.
-
-## Instructions
-
-Run these steps sequentially using the Bash tool. Do NOT run cmux commands in parallel — each surface must be created, renamed, and started before moving to the next.
-
-1. **Install dependencies** (use absolute path so CWD stays at repo root):
-
-   ```bash
-   WORKTREE_PATH=$(git rev-parse --show-toplevel) && cd "$WORKTREE_PATH" && pnpm install
-   ```
-
-2. **Read the PORT from .env.local**:
-
-   ```bash
-   WORKTREE_PATH=$(git rev-parse --show-toplevel) && PORT=$(grep '^PORT=' "$WORKTREE_PATH/.env.local" 2>/dev/null | cut -d= -f2-) && printf '%s\n' "${PORT:-3000}"
-   ```
-
-   Save the printed value for step 5.
-
-3. **Clean up existing tabs** — close any previously created dev tabs so re-running `/start-dev` is idempotent:
-
-   ```bash
-   for EXISTING in $(cmux tree 2>&1 | grep -E '"(dev:no-expo|dev:expo)"' | grep -o 'surface:[0-9]*'); do cmux close-surface --surface "$EXISTING" 2>/dev/null || true; done
-   ```
-
-4. **Create two terminal tabs and start each server group** — run this as a **single** Bash command chained with `&&`. Never use `set -e` with newlines (orphan tabs on failure) and never split into parallel Bash calls:
-
-   ```bash
-   WORKTREE_PATH=$(git rev-parse --show-toplevel) && PORT=$(grep '^PORT=' "$WORKTREE_PATH/.env.local" 2>/dev/null | cut -d= -f2-) && PORT=${PORT:-3000} && NO_EXPO_COMMAND=$(printf 'cd %q && PORT=%q pnpm dev:no-expo\n' "$WORKTREE_PATH" "$PORT") && NO_EXPO_SURFACE=$(cmux new-surface --type terminal 2>&1 | awk '{print $2}') && cmux rename-tab --surface "$NO_EXPO_SURFACE" "dev:no-expo" && cmux send --surface "$NO_EXPO_SURFACE" "$NO_EXPO_COMMAND" && EXPO_COMMAND=$(printf 'cd %q && pnpm dev:expo\n' "$WORKTREE_PATH") && EXPO_SURFACE=$(cmux new-surface --type terminal 2>&1 | awk '{print $2}') && cmux rename-tab --surface "$EXPO_SURFACE" "dev:expo" && cmux send --surface "$EXPO_SURFACE" "$EXPO_COMMAND"
-   ```
-
-5. **Report immediately** — do NOT wait or verify. Just tell the user:
-   - Launched dev:no-expo and dev:expo in separate cmux tabs
-   - Next.js will be on port [PORT from step 2, or 3000 if not set]
-   - Switch cmux tabs to see each server's logs
+Run twice → you get duplicates. `pkill -f "expo start"; pkill -f "turbo dev"` to stop.

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -35,33 +35,15 @@ Expo Router provides typed file-based navigation.
 
 ## Verifying UI changes
 
-When you change a screen, verify it on the booted iOS Simulator (iPhone 16e) before reporting the task done — don't refuse with "I can't see the screen."
-
-How the chain works: the `expo-mcp` HTTP server (registered in your `~/.claude.json`) talks to a running Metro, which exposes screenshot, tap, and view-inspection tools because the `expo-mcp` dev dep is installed and the `dev` / `dev:ios` scripts set `EXPO_UNSTABLE_MCP_SERVER=1`. After (re)starting Metro, run `/mcp` in your Claude session to reconnect — Expo's recommendation, since the local capability set changes when the dev server restarts.
-
-### One-time setup (per developer / agent environment)
-
-`~/.claude.json` is per-user, so the MCP registration isn't checked into the repo. Run once from the project root you'll be working in:
-
-```sh
-claude mcp add --transport http --scope local expo-mcp https://mcp.expo.dev/mcp
+```
+/start-dev
+/sim-screenshot
+Read the printed path
 ```
 
-Use `--scope user` instead if you want it registered once across every worktree/project on your machine. After registering, run `/mcp` in a Claude session to OAuth into Expo.
+Each worktree gets a sim named `ws-<dir>`, cloned from your booted iPhone 16e on first run and deep-linked to that worktree's Metro. Multiple worktrees run independent sims in parallel — no shared MCP tunnel, no shared device. Clean up with `xcrun simctl delete ws-<dir>`.
 
-### Per session
-
-1. **Make sure the dev stack is running.** Agent environments often start cold. The agent-friendly launch is two background processes from the repo root:
-   - `pnpm dev:no-expo` — Convex/web/etc. via turbo (no TTY needed).
-   - `pnpm dev:expo:ios` — Metro **plus** auto-launches the iOS simulator. This passes `--ios` to `expo start`, which is what avoids the interactive `i` keypress that the regular `pnpm dev:expo` would otherwise require — agents have no TTY to press keys in.
-2. **Find the Metro port for the environment you're working in.** Each worktree gets its own port pair from [`.claude/worktree-bootstrap.sh`](../../.claude/worktree-bootstrap.sh). Check `.claude/.worktree-ports` (`METRO_PORT=`), `.env.local` (`RCT_METRO_PORT=`), or the SessionStart hook's `metro: http://localhost:<port>` log line. The main checkout defaults to `8081`.
-3. Run `/mcp` to authenticate / reconnect.
-4. Screenshot the affected screen and confirm the change rendered.
-5. Exercise the golden path plus at least one edge case.
-
-If the MCP is genuinely unreachable (auth failed, no booted simulator, Metro down), say so explicitly rather than claiming success. Requires macOS host and Expo SDK ≥ 54.
-
-Humans normally launch `pnpm dev:expo` and press `i` themselves — that flow is unchanged. `pnpm dev:expo:ios` is the agent-only equivalent that skips the keypress.
+For testID-aware tapping the `expo-mcp` server is still available (single-client; needs `/mcp` to reconnect). Not needed for screenshots.
 
 ## Push Notifications
 


### PR DESCRIPTION
## Summary

- Replaces the cmux-bound `/start-dev` with a plain background-process version (`nohup pnpm dev:expo &` + `nohup pnpm dev:no-expo &`) that works on any agent shell. The original cmux-tabs flow is preserved at `/cmux-start-dev` for setups that have cmux installed.
- Adds `/sim-screenshot`: each worktree gets a dedicated `ws-<dir>` iOS simulator, cloned once from the user's booted `iPhone 16e` and deep-linked to that worktree's Metro via `xcrun simctl openurl`. Screenshots are captured by name with `xcrun simctl io`. Sidesteps the single-tracked `expo-mcp` tunnel so multiple worktrees can verify UI changes in parallel.
- Trims `apps/expo/AGENTS.md` "Verifying UI changes" to a 3-line recipe (`/start-dev` → `/sim-screenshot` → `Read` the printed path); demotes optional `expo-mcp` setup.

## Why

Running 5 parallel worktrees exposed two architectural mismatches in the prior dev-loop tooling:

1. **`/start-dev` was cmux-bound** — assumed `cmux` was installed and unconditionally re-ran `pnpm install` (which fails on agent shells where fnm isn't sourced, even though `worktree-bootstrap.sh` already installs deps at SessionStart).
2. **`expo-mcp`'s screenshot tunnel is single-client** — across multiple worktrees only one Metro can hold it; switching requires `/mcp` to reconnect, and the others get "Multiple tunnel clients are not supported." Worktrees are otherwise fully isolated (own ports, own Convex deployment), so screenshots were the last shared resource.

The simctl-based flow gives each worktree an independent simulator and screenshot path — no shared lock, no kill-the-other-worktree's-Expo, no MCP reconnect. Verified end-to-end on this worktree (clone UDID `33C883DB-A82F-4335-A29A-2839B0F668F9` rendered a test edit from Metro on port 8162).

## Test plan

- [ ] Run `/start-dev` on a worktree with no Metro running → both servers come up in the background, log paths printed; rerun is idempotent for the Expo side (port-busy skip).
- [ ] Run `/sim-screenshot` → first call clones `iPhone 16e` to `ws-<worktree>` (~5–10s), boots it, deep-links to localhost:`$RCT_METRO_PORT`, prints `/tmp/ws-<worktree>-<ts>.png`. Subsequent calls reuse the existing clone.
- [ ] Run `/sim-screenshot` from a second worktree concurrently → independent UDIDs, independent Metros, both screenshots succeed without MCP reconnect.
- [ ] `xcrun simctl delete ws-<worktree>` cleans up after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the cmux-bound `/start-dev` with a portable `nohup` background-process version, preserves the original as `/cmux-start-dev`, and adds `/sim-screenshot` — a `simctl`-based flow that gives each worktree its own dedicated iOS simulator so multiple worktrees can take screenshots in parallel without competing for the single-client `expo-mcp` tunnel.

- **`sim-screenshot.md`**: If no iPhone 16e simulator is currently booted, `SRC` resolves to an empty string and `xcrun simctl clone ""` fails with a cryptic OS error while the script continues — the subsequent `boot` and `screenshot` calls operate on a device that was never created. An explicit `[ -n "$SRC" ]` guard is needed.
- **`sim-screenshot.md`**: `PORT` has no fallback; on the main checkout (default port 8081) the `openurl` deep-link becomes `http://localhost:` and silently goes nowhere.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the cmux rename and docs, but sim-screenshot has two P1 failure modes that will silently misfire in common setups.

Two P1 issues in sim-screenshot.md — empty SRC (no booted iPhone 16e) causes a cryptic downstream failure, and missing PORT fallback produces a silently broken deep-link. Both are on the critical path of the new screenshot feature described in the PR test plan.

.claude/commands/sim-screenshot.md requires fixes for the empty-SRC guard and PORT fallback before the command is reliable.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/commands/sim-screenshot.md | New simctl-based screenshot command; two P1 issues: missing guard when SRC (iPhone 16e UDID) is empty and missing PORT fallback for the default 8081 checkout |
| .claude/commands/start-dev.md | Simplified from cmux-based to nohup background processes; no idempotency guard — running twice spawns duplicate servers (P2, documented in file) |
| .claude/commands/cmux-start-dev.md | Old /start-dev preserved verbatim as /cmux-start-dev; no issues |
| apps/expo/AGENTS.md | Documentation trimmed to 3-step recipe; aligns with the new sim-screenshot flow; no issues |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent: /start-dev] --> B[nohup pnpm dev:expo]
    A --> C[nohup pnpm dev:no-expo]
    B --> D[expo log file]
    C --> E[web log file]

    F[Agent: /sim-screenshot] --> G{ws-dir sim exists?}
    G -- No --> H{iPhone 16e booted?}
    H -- No --> I[SRC empty - clone fails silently P1]
    H -- Yes --> J[simctl clone SRC ws-dir]
    J --> K[simctl boot ws-dir]
    G -- Yes --> K
    K --> L{PORT in .env.local?}
    L -- No --> M[empty PORT - malformed deep-link P1]
    L -- Yes --> N[simctl openurl deep-link]
    N --> O[sleep 5]
    O --> P[simctl io screenshot]
    P --> Q[Print screenshot path]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .claude/commands/sim-screenshot.md
Line: 13-14

Comment:
**Silent failure when no booted iPhone 16e**

If no simulator matching "iPhone 16e" is currently booted, `SRC` is set to an empty string. `xcrun simctl clone "" "ws-<dir>"` then exits with a cryptic error like `An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2)`, and execution continues — attempting to boot and screenshot a device that was never created. Add a guard after the clone command to abort early with a helpful message.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/commands/sim-screenshot.md
Line: 11

Comment:
**Missing PORT fallback produces a malformed deep-link**

If `.env.local` doesn't contain `RCT_METRO_PORT` (e.g., in the main checkout that defaults to 8081), `PORT` is empty and the `openurl` call becomes `exp+timetimecc://expo-development-client/?url=http://localhost:` — silently opening the wrong URL. Add a default:

```suggestion
PORT=$(grep ^RCT_METRO_PORT .env.local | cut -d= -f2); PORT=${PORT:-8081}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/commands/start-dev.md
Line: 14

Comment:
**Duplicate processes on re-run, no idempotency guard**

Running `/start-dev` a second time launches four background `nohup` processes instead of two (the old cmux flow closed existing tabs first). The inline note warns about this, but the suggested `pkill` targets are also fairly broad (`turbo dev` would kill other worktrees' servers if they share the same host). A simple port-guard for the web side or a pid-file approach would make reruns safe without reaching for `pkill`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(claude): add /sim-screenshot, simp..."](https://github.com/jaronheard/soonlist-turbo/commit/2208ee40248a5ea9ff6e36723384cc3f888863e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29908407)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-worktree iOS simulator screenshot flow and makes dev startup shell-agnostic. `/start-dev` now runs in the background without `cmux`, and the old `cmux` flow is available as `/cmux-start-dev`.

- **New Features**
  - `/sim-screenshot`: creates/reuses a `ws-<dir>` iOS sim cloned from a booted iPhone 16e, deep-links it to the worktree’s Metro, and saves a screenshot to `/tmp/...png`. Runs in parallel across worktrees and avoids the single-client `expo-mcp` tunnel.
  - `/start-dev`: launches `pnpm dev:expo` and `pnpm dev:no-expo` via `nohup` with logs at `/tmp/<worktree>-{expo,web}.log`. No `cmux` or forced `pnpm install` needed.
  - `/cmux-start-dev`: keeps the previous multi-tab flow for environments with `cmux`.
  - Docs: trims `apps/expo/AGENTS.md` to a 3-step recipe (`/start-dev` → `/sim-screenshot` → read path) and makes `expo-mcp` optional for tapping/inspection.

<sup>Written for commit 2208ee40248a5ea9ff6e36723384cc3f888863e1. Summary will update on new commits. <a href="https://cubic.dev/pr/jaronheard/soonlist-turbo/pull/1085?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

