### PR TITLE
Add worktree simulator MCP wrapper and auto-install dev client

### DIFF
--- a/.claude/commands/ios-mcp-check.md
+++ b/.claude/commands/ios-mcp-check.md
@@ -29,12 +29,12 @@ printf 'metro: http://localhost:%s\n' "${METRO_PORT:-unknown}"
 printf 'idb: %s\n' "${IDB_PATH:-not found}"
 
 [[ -n "$IDB_PATH" && -x "$IDB_PATH" ]] || { echo "idb is missing or not executable; install idb or set IOS_SIMULATOR_MCP_IDB_PATH" >&2; exit 1; }
-test -f .mcp.json || { echo ".mcp.json is missing; rerun bootstrap or restart Claude Code" >&2; exit 1; }
+test -f .mcp.json || { echo ".mcp.json is missing; the committed MCP wrapper config is required" >&2; exit 1; }
 xcrun simctl list devices available | grep -q "($SIMULATOR_UDID)" || { echo "Simulator UDID does not exist" >&2; exit 1; }
 xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
 
 echo "Shell prerequisites passed."
-echo "If iOS Simulator MCP tools are not available yet, run /mcp reconnect or restart Claude Code from this worktree."
+echo "If iOS Simulator MCP tools are not available in an already-running session, restart Claude Code from this worktree."
 ```
 
 Then verify the MCP server itself:

--- a/.claude/commands/sim-open.md
+++ b/.claude/commands/sim-open.md
@@ -21,8 +21,51 @@ if [[ -z "${SIMULATOR_UDID:-}" || -z "${METRO_PORT:-}" ]]; then
   exit 1
 fi
 
+DEV_CLIENT_BUNDLE_ID=${DEV_CLIENT_BUNDLE_ID:-com.soonlist.app.dev}
+
+dev_client_installed() {
+  xcrun simctl get_app_container "$SIMULATOR_UDID" "$DEV_CLIENT_BUNDLE_ID" app >/dev/null 2>&1
+}
+
+find_installed_dev_client() {
+  while IFS= read -r candidate_udid; do
+    [[ "$candidate_udid" == "$SIMULATOR_UDID" ]] && continue
+    app_path=$(xcrun simctl get_app_container "$candidate_udid" "$DEV_CLIENT_BUNDLE_ID" app 2>/dev/null || true)
+    if [[ -n "$app_path" && -d "$app_path" ]]; then
+      printf '%s\n' "$app_path"
+      return 0
+    fi
+  done < <(xcrun simctl list devices available | awk '/iPhone/ && match($0, /\([0-9A-F-]{36}\)/) { print substr($0, RSTART + 1, RLENGTH - 2) }')
+  return 1
+}
+
+find_built_dev_client() {
+  while IFS= read -r candidate_app; do
+    bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$candidate_app/Info.plist" 2>/dev/null || true)
+    if [[ "$bundle_id" == "$DEV_CLIENT_BUNDLE_ID" ]]; then
+      printf '%s\n' "$candidate_app"
+      return 0
+    fi
+  done < <(find apps/expo/ios -path '*.app' -type d 2>/dev/null)
+  return 1
+}
+
 xcrun simctl boot "$SIMULATOR_UDID" 2>/dev/null || true
-xcrun simctl openurl "$SIMULATOR_UDID" "exp+timetimecc://expo-development-client/?url=http://localhost:$METRO_PORT"
+
+if ! dev_client_installed; then
+  SOURCE_APP=$(find_installed_dev_client || true)
+  SOURCE_APP=${SOURCE_APP:-$(find_built_dev_client || true)}
+  if [[ -n "$SOURCE_APP" ]]; then
+    xcrun simctl install "$SIMULATOR_UDID" "$SOURCE_APP"
+  fi
+fi
+
+if ! xcrun simctl openurl "$SIMULATOR_UDID" "exp+timetimecc://expo-development-client/?url=http://localhost:$METRO_PORT"; then
+  echo "Could not open the Expo dev-client URL." >&2
+  echo "No installed or built ${DEV_CLIENT_BUNDLE_ID} app was found to install automatically." >&2
+  echo "Build the dev client for ${SIMULATOR_NAME:-$SIMULATOR_UDID}, then rerun /sim-open." >&2
+  exit 1
+fi
 
 echo "Opened ${SIMULATOR_NAME:-$SIMULATOR_UDID} on Metro http://localhost:$METRO_PORT"
 echo "Use iOS Simulator MCP for screenshot, ui_view, and ui_describe_all."

--- a/.claude/commands/sim-open.md
+++ b/.claude/commands/sim-open.md
@@ -56,14 +56,21 @@ if ! dev_client_installed; then
   SOURCE_APP=$(find_installed_dev_client || true)
   SOURCE_APP=${SOURCE_APP:-$(find_built_dev_client || true)}
   if [[ -n "$SOURCE_APP" ]]; then
-    xcrun simctl install "$SIMULATOR_UDID" "$SOURCE_APP"
+    if ! xcrun simctl install "$SIMULATOR_UDID" "$SOURCE_APP"; then
+      echo "Found ${DEV_CLIENT_BUNDLE_ID} at ${SOURCE_APP}, but install failed." >&2
+      exit 1
+    fi
   fi
 fi
 
 if ! xcrun simctl openurl "$SIMULATOR_UDID" "exp+timetimecc://expo-development-client/?url=http://localhost:$METRO_PORT"; then
   echo "Could not open the Expo dev-client URL." >&2
-  echo "No installed or built ${DEV_CLIENT_BUNDLE_ID} app was found to install automatically." >&2
-  echo "Build the dev client for ${SIMULATOR_NAME:-$SIMULATOR_UDID}, then rerun /sim-open." >&2
+  if [[ -n "${SOURCE_APP:-}" ]]; then
+    echo "Installed ${DEV_CLIENT_BUNDLE_ID} from ${SOURCE_APP}, but the deep link still failed." >&2
+  else
+    echo "No installed or built ${DEV_CLIENT_BUNDLE_ID} app was found to install automatically." >&2
+    echo "Build the dev client for ${SIMULATOR_NAME:-$SIMULATOR_UDID}, then rerun /sim-open." >&2
+  fi
   exit 1
 fi
 

--- a/.claude/mcp/ios-simulator.sh
+++ b/.claude/mcp/ios-simulator.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Starts iOS Simulator MCP pinned to this worktree's simulator. This script is
+# called by the committed root .mcp.json, so Claude Code can discover the MCP
+# server before SessionStart hooks have generated worktree-local state.
+
+set -uo pipefail
+
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [[ -n "$WORKTREE_ROOT" ]]; then
+  cd "$WORKTREE_ROOT" || exit 1
+fi
+
+BOOTSTRAP_LOG="/tmp/$(basename "${WORKTREE_ROOT:-soonlist}")-mcp-bootstrap.log"
+if [[ -f .claude/worktree-bootstrap.sh ]]; then
+  WORKTREE_BOOTSTRAP_SKIP_INSTALL=1 bash .claude/worktree-bootstrap.sh >"$BOOTSTRAP_LOG" 2>&1 || true
+fi
+
+if [[ -f .claude/.worktree-ports ]]; then
+  # shellcheck disable=SC1091
+  source .claude/.worktree-ports
+fi
+
+if [[ -n "${SIMULATOR_UDID:-}" ]]; then
+  export IDB_UDID="$SIMULATOR_UDID"
+fi
+
+export IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR=${IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR:-/tmp}
+
+if [[ -z "${IOS_SIMULATOR_MCP_IDB_PATH:-}" ]]; then
+  IDB_PATH=$(command -v idb 2>/dev/null || true)
+  if [[ -n "$IDB_PATH" ]]; then
+    export IOS_SIMULATOR_MCP_IDB_PATH="$IDB_PATH"
+  fi
+fi
+
+exec npx -y ios-simulator-mcp

--- a/.claude/mcp/ios-simulator.sh
+++ b/.claude/mcp/ios-simulator.sh
@@ -3,7 +3,7 @@
 # called by the committed root .mcp.json, so Claude Code can discover the MCP
 # server before SessionStart hooks have generated worktree-local state.
 
-set -uo pipefail
+set -euo pipefail
 
 WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 if [[ -n "$WORKTREE_ROOT" ]]; then
@@ -12,7 +12,7 @@ fi
 
 BOOTSTRAP_LOG="/tmp/$(basename "${WORKTREE_ROOT:-soonlist}")-mcp-bootstrap.log"
 if [[ -f .claude/worktree-bootstrap.sh ]]; then
-  WORKTREE_BOOTSTRAP_SKIP_INSTALL=1 bash .claude/worktree-bootstrap.sh >"$BOOTSTRAP_LOG" 2>&1 || true
+  WORKTREE_BOOTSTRAP_SKIP_INSTALL=1 bash .claude/worktree-bootstrap.sh >"$BOOTSTRAP_LOG" 2>&1
 fi
 
 if [[ -f .claude/.worktree-ports ]]; then
@@ -22,6 +22,9 @@ fi
 
 if [[ -n "${SIMULATOR_UDID:-}" ]]; then
   export IDB_UDID="$SIMULATOR_UDID"
+else
+  echo "ios-simulator MCP wrapper could not resolve SIMULATOR_UDID; see $BOOTSTRAP_LOG" >&2
+  exit 1
 fi
 
 export IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR=${IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR:-/tmp}

--- a/.claude/worktree-bootstrap.sh
+++ b/.claude/worktree-bootstrap.sh
@@ -19,7 +19,7 @@ WORKTREE_NAME=$(basename "$WORKTREE_ROOT")
 
 # Determine port assignment. On first run, allocate; on subsequent runs, reuse
 # the persisted ports from .claude/.worktree-ports so dev servers, .env.local,
-# launch.json, simulator assignment, and .mcp.json never drift out of sync.
+# launch.json, and simulator assignment never drift out of sync.
 MARKER=".claude/.worktree-ports"
 
 WEB_PORT=""
@@ -143,11 +143,8 @@ sim_udid_for_name() {
 }
 
 sim_clone_source_udid() {
-  {
-    xcrun simctl list devices booted 2>/dev/null
-    simctl_list_available
-  } | awk '
-    /iPhone/ && match($0, /\([0-9A-F-]{36}\)/) {
+  simctl_list_available | awk '
+    /iPhone/ && /\(Shutdown\)/ && match($0, /\([0-9A-F-]{36}\)/) {
       print substr($0, RSTART + 1, RLENGTH - 2)
       exit
     }
@@ -174,7 +171,7 @@ if simctl_list_available >/dev/null; then
         fi
       else
         SIMULATOR_UDID=""
-        echo "worktree-bootstrap: no iPhone simulator found to clone; skipping simulator allocation" >&2
+        echo "worktree-bootstrap: no shutdown iPhone simulator found to clone; skipping simulator allocation" >&2
       fi
     fi
   else
@@ -238,36 +235,8 @@ if [[ -f .claude/launch.json.example ]]; then
     .claude/launch.json.example > .claude/launch.json
 fi
 
-# Generate a worktree-local Claude Code MCP config. Sessions are launched from
-# the worktree root, so this pins iOS Simulator MCP to the simulator allocated
-# above without relying on global MCP state.
-if [[ -n "$SIMULATOR_UDID" ]]; then
-  IDB_PATH=${IOS_SIMULATOR_MCP_IDB_PATH:-$(command -v idb 2>/dev/null || true)}
-  IDB_PATH_LINE=""
-  if [[ -n "$IDB_PATH" ]]; then
-    IDB_PATH_LINE=",
-        \"IOS_SIMULATOR_MCP_IDB_PATH\": \"${IDB_PATH}\""
-  fi
-  cat > .mcp.json <<EOF
-{
-  "mcpServers": {
-    "ios-simulator": {
-      "command": "npx",
-      "args": ["-y", "ios-simulator-mcp"],
-      "env": {
-        "IDB_UDID": "${SIMULATOR_UDID}",
-        "IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR": "/tmp"${IDB_PATH_LINE}
-      }
-    }
-  }
-}
-EOF
-else
-  rm -f .mcp.json
-fi
-
 # Install deps if missing
-if [[ ! -d node_modules ]]; then
+if [[ ! -d node_modules && "${WORKTREE_BOOTSTRAP_SKIP_INSTALL:-0}" != "1" ]]; then
   echo "worktree-bootstrap: running pnpm install" >&2
   pnpm install >&2 || echo "worktree-bootstrap: pnpm install failed (non-fatal)" >&2
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -72,8 +72,6 @@ docs/brainstorms/
 # claude code
 .claude/worktrees/
 .claude/settings.local.json
-# Generated per-worktree by .claude/worktree-bootstrap.sh; pins iOS Simulator MCP to that worktree's simulator
-.mcp.json
 # Generated per-worktree by .claude/hooks/worktree-init.sh; template is launch.json.example
 .claude/launch.json
 .claude/.worktree-ports

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "ios-simulator": {
+      "command": "./.claude/mcp/ios-simulator.sh"
+    }
+  }
+}

--- a/apps/expo/AGENTS.md
+++ b/apps/expo/AGENTS.md
@@ -49,11 +49,13 @@ SIMULATOR_NAME=...
 SIMULATOR_UDID=...
 ```
 
-The worktree bootstrap also generates root `.mcp.json` so iOS Simulator MCP is pinned to that worktree's `SIMULATOR_UDID`. Use iOS Simulator MCP for screenshots, compressed views, accessibility reads, taps, typing, and swipes. `/sim-open` only boots the simulator and opens this worktree's Expo dev-client URL.
+The committed root `.mcp.json` starts `.claude/mcp/ios-simulator.sh`, which runs bootstrap silently, reads `.claude/.worktree-ports`, and pins iOS Simulator MCP to that worktree's `SIMULATOR_UDID`. Use iOS Simulator MCP for screenshots, compressed views, accessibility reads, taps, typing, and swipes. `/sim-open` only boots the simulator and opens this worktree's Expo dev-client URL.
+
+Fresh simulator clones must have the Soonlist Expo dev client installed before `/sim-open` deep links can resolve. `/sim-open` first tries to install `com.soonlist.app.dev` from another simulator that already has it, then from a local `apps/expo/ios/**/*.app` build artifact. If none exists and `/sim-open` fails with LaunchServices `-10814`, build the dev client for that simulator, then rerun `/sim-open`.
 
 Expo MCP is not the parallel-safe path for simulator automation. It can still be useful for single-client experiments, but screenshot and accessibility testing should use iOS Simulator MCP.
 
-If MCP tools are missing or stale after bootstrap, run `/mcp` reconnect or restart Claude Code from the worktree folder. To clean up a simulator, run `source .claude/.worktree-ports && xcrun simctl delete "$SIMULATOR_UDID"`, then rerun bootstrap or start a new session.
+If MCP tools are missing in a session that was already running before this config existed, restart Claude Code from the worktree folder. To clean up a simulator, run `source .claude/.worktree-ports && xcrun simctl delete "$SIMULATOR_UDID"`, then rerun bootstrap or start a new session.
 
 ## Push Notifications
 


### PR DESCRIPTION
## Summary
- Add a committed root `.mcp.json` that starts a wrapper script to bootstrap the worktree and launch `ios-simulator-mcp` pinned to the allocated simulator
- Keep per-worktree simulator allocation in `.claude/worktree-bootstrap.sh`, with shutdown-only clone sources and persisted UDIDs
- Update `/sim-open` to auto-install the Soonlist dev client from another simulator or a local build artifact before opening the Expo deep link
- Refresh `/ios-mcp-check`, `.gitignore`, and Expo agent docs to match the new flow

## Testing
- Validated shell syntax for `.claude/worktree-bootstrap.sh`, `.claude/mcp/ios-simulator.sh`, `/sim-open`, and `/ios-mcp-check`
- Parsed the committed `.mcp.json` as valid JSON
- Confirmed the wrapper and command flow reflect the new per-worktree simulator setup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jaronheard/soonlist-turbo/pull/1087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per-worktree iOS Simulator isolation using a committed MCP wrapper that pins `ios-simulator-mcp` to the worktree’s simulator and hardens error handling. `/sim-open` now verifies installs, auto-installs the Expo dev client if needed, and deep-links to the correct Metro server.

- **New Features**
  - Committed `.mcp.json` runs `./.claude/mcp/ios-simulator.sh`; the wrapper bootstraps, reads `.claude/.worktree-ports`, sets `IDB_UDID`, auto-detects `idb`, and fails fast with a helpful log if the UDID is missing.
  - Updated `.claude/worktree-bootstrap.sh` to persist per-worktree ports and simulator, stop generating `.mcp.json`, clone from a shutdown iPhone only, and honor `WORKTREE_BOOTSTRAP_SKIP_INSTALL=1`.
  - Improved `/sim-open`: checks if `com.soonlist.app.dev` is installed, finds it from another simulator or a local `.app`, validates `simctl install` exit codes, and shows clearer errors before opening the Expo deep link.
  - `/ios-mcp-check` and docs aligned with the new wrapper; removed `/sim-screenshot` (use iOS Simulator MCP tools).

- **Migration**
  - After `/start-dev`, run `/sim-open`. If it fails due to a missing dev client, build it for that simulator and rerun.
  - If MCP tools are missing in an already-running session, restart your editor from the worktree so the committed MCP config loads.

<sup>Written for commit d1b123ae266101323bf2e8456823fae6995bd83c. Summary will update on new commits. <a href="https://cubic.dev/pr/jaronheard/soonlist-turbo/pull/1087?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a committed `.mcp.json` + `ios-simulator.sh` wrapper that auto-bootstraps a per-worktree iOS simulator and pins `ios-simulator-mcp` to it on Claude Code startup, replacing the old `sim-screenshot` command with a richer `sim-open` flow that also auto-installs the dev client from another simulator or a local build artifact.

- **P1 (`sim-open.md`)**: `xcrun simctl install` is called without checking its exit code, so a failed install is silently swallowed. `openurl` then fails and the user sees "No installed or built app was found to install automatically" — even though a source app was located and install was attempted — making the failure opaque and hard to diagnose.

<h3>Confidence Score: 3/5</h3>

Safe to merge for documentation/tooling, but the silent install-failure in sim-open will confuse developers when auto-install goes wrong.

One P1 finding (silently ignored xcrun simctl install failure with a misleading downstream error message) pulls the score below the P1 ceiling of 4; the additional P2s are not compounding but reinforce the need for a fix pass.

.claude/commands/sim-open.md requires attention for the silent install failure; .claude/worktree-bootstrap.sh warrants a secondary look at the sim_udid_for_name awk pattern.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/commands/sim-open.md | New command that boots a worktree's simulator and auto-installs the dev client; has a P1 silent-install-failure bug and a misleading error message when openurl fails after an install attempt. |
| .claude/worktree-bootstrap.sh | Extended with iOS simulator allocation (clone, name-to-UDID lookup, persistence); logic is mostly sound but sim_udid_for_name relies on exact 4-space indentation from xcrun output. |
| .claude/mcp/ios-simulator.sh | New MCP wrapper that runs bootstrap silently and pins ios-simulator-mcp to the worktree UDID; missing set -e means bootstrap errors are silently swallowed before exec npx. |
| .mcp.json | New committed MCP config pointing to the ios-simulator wrapper script; valid JSON, relative path is correct for repo-root invocation. |
| .claude/commands/ios-mcp-check.md | New diagnostic command that checks prerequisites (UDID, idb, .mcp.json, simctl) and prints worktree state; straightforward and correct. |
| apps/expo/AGENTS.md | Updated developer docs to replace sim-screenshot with sim-open/iOS Simulator MCP workflow; accurate and complete. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CC as Claude Code
    participant MCP as .mcp.json
    participant SH as ios-simulator.sh
    participant BS as worktree-bootstrap.sh
    participant WP as .claude/.worktree-ports
    participant SC as xcrun simctl
    participant NX as ios-simulator-mcp (npx)

    CC->>MCP: read on startup
    MCP->>SH: exec ./.claude/mcp/ios-simulator.sh
    SH->>BS: bash worktree-bootstrap.sh (SKIP_INSTALL=1)
    BS->>WP: read persisted ports + SIMULATOR_UDID
    alt UDID not found or stale
        BS->>SC: simctl list devices available
        SC-->>BS: available simulators
        BS->>SC: simctl clone source_udid ws-dir
        SC-->>BS: new UDID
        BS->>WP: persist_marker (ports + UDID)
    else UDID already valid
        BS->>WP: persist_marker (refresh)
    end
    BS-->>SH: exits
    SH->>WP: source .worktree-ports
    SH->>NX: exec npx ios-simulator-mcp (IDB_UDID=SIMULATOR_UDID)
    NX-->>CC: MCP server ready

    note over CC,NX: /sim-open flow
    CC->>SC: simctl boot SIMULATOR_UDID
    CC->>SC: simctl get_app_container (check installed)
    alt not installed
        CC->>SC: get_app_container other sims / find .app
        CC->>SC: simctl install SIMULATOR_UDID app
    end
    CC->>SC: simctl openurl exp+timetimecc://...
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.claude/worktree-bootstrap.sh`, line 130-140 ([link](https://github.com/jaronheard/soonlist-turbo/blob/eb4801a2a0ad4701eb6f7b54d894f06b277adcd2/.claude/worktree-bootstrap.sh#L130-L140)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Brittle indent-sensitive awk match in `sim_udid_for_name`**

   The pattern `"    " name " ("` (exactly 4 spaces) mirrors today's `xcrun simctl list devices` indentation. Apple has silently reformatted this output before; any change would cause the lookup to return an empty string, causing the worktree to silently clone a new simulator instead of reusing the existing `ws-<dir>` one and accumulating orphaned simulators.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .claude/worktree-bootstrap.sh
   Line: 130-140

   Comment:
   **Brittle indent-sensitive awk match in `sim_udid_for_name`**

   The pattern `"    " name " ("` (exactly 4 spaces) mirrors today's `xcrun simctl list devices` indentation. Apple has silently reformatted this output before; any change would cause the lookup to return an empty string, causing the worktree to silently clone a new simulator instead of reusing the existing `ws-<dir>` one and accumulating orphaned simulators.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .claude/commands/sim-open.md
Line: 55-60

Comment:
**Silent install failure leads to misleading error**

`xcrun simctl install` has no exit-code check, so if the install fails (corrupt bundle, wrong architecture, simulator not fully booted), the script proceeds to `openurl`, which then fails, and the user sees "No installed or built app was found to install automatically" — even though a source app *was* found and install was attempted. This sends developers on a wild goose chase looking for a missing artifact when the real problem is a failed install.

```suggestion
  if [[ -n "$SOURCE_APP" ]]; then
    if ! xcrun simctl install "$SIMULATOR_UDID" "$SOURCE_APP"; then
      echo "Found ${DEV_CLIENT_BUNDLE_ID} at ${SOURCE_APP} but install failed." >&2
      exit 1
    fi
  fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/commands/sim-open.md
Line: 63-66

Comment:
**Error message is unconditionally misleading after a found-but-failed install**

Lines 64–65 say "No installed or built app was found" even when `SOURCE_APP` was non-empty and `xcrun simctl install` was called. The message should distinguish "app not found" from "app found but URL still failed."

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/worktree-bootstrap.sh
Line: 130-140

Comment:
**Brittle indent-sensitive awk match in `sim_udid_for_name`**

The pattern `"    " name " ("` (exactly 4 spaces) mirrors today's `xcrun simctl list devices` indentation. Apple has silently reformatted this output before; any change would cause the lookup to return an empty string, causing the worktree to silently clone a new simulator instead of reusing the existing `ws-<dir>` one and accumulating orphaned simulators.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .claude/mcp/ios-simulator.sh
Line: 6

Comment:
**`set -e` omitted — bootstrap errors are silently swallowed**

`set -uo pipefail` without `set -e` means a failure in the `bash .claude/worktree-bootstrap.sh` sub-call does not abort the script. `exec npx -y ios-simulator-mcp` still runs, but without `IDB_UDID` / `IOS_SIMULATOR_MCP_IDB_PATH` set, leaving the MCP server pointing at whichever simulator it defaults to rather than this worktree's dedicated one. If best-effort behaviour is intentional, a comment should say so; otherwise consider `set -euo pipefail`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add worktree simulator MCP wrapper"](https://github.com/jaronheard/soonlist-turbo/commit/eb4801a2a0ad4701eb6f7b54d894f06b277adcd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29937478)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->