### PR TITLE
feat(ui): Public/Private visibility (PR 1)

### DIFF
--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -37,7 +37,6 @@ import { HeaderLogo } from "~/components/HeaderLogo";
 import {
   CalendarPlus,
   EyeOff,
-  Globe2,
   Heart,
   Instagram,
   MapPinned,
@@ -57,7 +56,6 @@ import { AF_EVENTS, trackAFEvent } from "~/utils/appsflyerEvents";
 import { formatEventDateRange } from "~/utils/dates";
 import { getEventCache } from "~/utils/eventCache";
 import { eventFollowsToSavers } from "~/utils/eventFollows";
-import { getPlanStatusFromUser } from "~/utils/plan";
 import { formatUrlForDisplay } from "../../../utils/links";
 
 // Helper to get platform URL for mentions
@@ -126,9 +124,6 @@ function EventDetail({ id }: { id: string }) {
   const insets = useSafeAreaInsets();
   const { user: currentUser } = useUser();
   const navigation = useNavigation();
-  const showDiscover = currentUser
-    ? getPlanStatusFromUser(currentUser).showDiscover
-    : false;
 
   // Check if we can go back in the navigation stack
   const canGoBack = navigation.canGoBack();
@@ -423,10 +418,9 @@ function EventDetail({ id }: { id: string }) {
             </Text>
           </View>
 
-          {/* Meta rows (venue + visibility) */}
-          {(eventData.location || (showDiscover && isCurrentUserEvent)) && (
-            <View className="mt-4 flex flex-col gap-2">
-              {/* Location link */}
+          {/* Meta rows */}
+          {(eventData.location || event.visibility === "private") && (
+            <View className="mt-4 flex-col gap-3">
               {eventData.location && (
                 <Link
                   href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
@@ -444,23 +438,12 @@ function EventDetail({ id }: { id: string }) {
                   </Pressable>
                 </Link>
               )}
-
-              {/* Visibility (owner-only info). Attribution now lives in the
-                  "From these Soonlists" section below. */}
-              {showDiscover && isCurrentUserEvent && (
-                <View className="flex-row items-center gap-2">
-                  {event.visibility === "public" ? (
-                    <Globe2 size={16} color="#627496" />
-                  ) : (
-                    <EyeOff size={16} color="#627496" />
-                  )}
-                  <Text className="text-sm text-neutral-2">
-                    {event.visibility === "public"
-                      ? "Discoverable"
-                      : "Not discoverable"}
-                  </Text>
+              {event.visibility === "private" ? (
+                <View className="flex-row items-center">
+                  <EyeOff size={16} color="#627496" />
+                  <Text className="ml-1 text-neutral-2">Private</Text>
                 </View>
-              )}
+              ) : null}
             </View>
           )}
 

--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -148,10 +148,7 @@ export function EventMenu({
 
       if (showDiscover) {
         items.push({
-          title:
-            event.visibility === "public"
-              ? "Make not discoverable"
-              : "Make discoverable",
+          title: event.visibility === "public" ? "Make Private" : "Make public",
           lucideIcon: event.visibility === "public" ? EyeOff : Globe2,
           systemIcon: event.visibility === "public" ? "eye.slash" : "globe",
         });
@@ -199,8 +196,8 @@ export function EventMenu({
       case "Add to calendar":
         void handleAddToCal();
         break;
-      case "Make not discoverable":
-      case "Make discoverable": {
+      case "Make Private":
+      case "Make public": {
         const newVisibility =
           event.visibility === "public" ? "private" : "public";
         void handleToggleVisibility(newVisibility);

--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -148,7 +148,7 @@ export function EventMenu({
 
       if (showDiscover) {
         items.push({
-          title: event.visibility === "public" ? "Make Private" : "Make Public",
+          title: event.visibility === "public" ? "Make private" : "Make public",
           lucideIcon: event.visibility === "public" ? EyeOff : Globe2,
           systemIcon: event.visibility === "public" ? "eye.slash" : "globe",
         });
@@ -196,7 +196,7 @@ export function EventMenu({
       case "Add to calendar":
         void handleAddToCal();
         break;
-      case "Make Private":
+      case "Make private":
       case "Make public": {
         const newVisibility =
           event.visibility === "public" ? "private" : "public";

--- a/apps/expo/src/components/EventMenu.tsx
+++ b/apps/expo/src/components/EventMenu.tsx
@@ -148,7 +148,7 @@ export function EventMenu({
 
       if (showDiscover) {
         items.push({
-          title: event.visibility === "public" ? "Make Private" : "Make public",
+          title: event.visibility === "public" ? "Make Private" : "Make Public",
           lucideIcon: event.visibility === "public" ? EyeOff : Globe2,
           systemIcon: event.visibility === "public" ? "eye.slash" : "globe",
         });

--- a/apps/expo/src/components/PrivateVisibilityBadge.tsx
+++ b/apps/expo/src/components/PrivateVisibilityBadge.tsx
@@ -1,0 +1,18 @@
+import { Text, View } from "react-native";
+
+import { EyeOff } from "~/components/icons";
+import { cn } from "~/utils/cn";
+
+export function PrivateVisibilityBadge({ className }: { className?: string }) {
+  return (
+    <View
+      className={cn(
+        "flex-row items-center gap-1 rounded-full bg-neutral-4/70 px-2 py-0.5",
+        className,
+      )}
+    >
+      <EyeOff size={12} color="#627496" />
+      <Text className="text-xs font-medium text-neutral-2">Private</Text>
+    </View>
+  );
+}

--- a/apps/expo/src/components/UserEventsList.tsx
+++ b/apps/expo/src/components/UserEventsList.tsx
@@ -34,6 +34,7 @@ import {
   ShareIcon,
 } from "~/components/icons";
 import { OverflowPill } from "~/components/OverflowPill";
+import { PrivateVisibilityBadge } from "~/components/PrivateVisibilityBadge";
 import { SavedByModal } from "~/components/SavedByModal";
 import { useAddEventFlow } from "~/hooks/useAddEventFlow";
 import { useEventActions } from "~/hooks/useEventActions";
@@ -274,6 +275,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
       : () => router.push(`/list/${sourceListSlug}`);
 
   const isOwner = demoMode || isCurrentUser;
+  const isPrivate = event.visibility === "private";
 
   // Get emoji and background color based on event type/category
   const { emoji, bgColor } = getEventEmoji(event);
@@ -377,12 +379,14 @@ export function UserEventListItem(props: UserEventListItemProps) {
                 </Text>
               </View>
               {isOwner && !ActionButton && similarEventsCount ? (
-                <View className="flex-row items-center gap-1 opacity-60">
-                  <View className="flex-row items-center gap-0.5 rounded-full bg-neutral-4/70 px-1 py-0.5">
-                    <Copy size={iconSize * 0.7} color="#627496" />
-                    <Text className="text-xs text-neutral-2">
-                      {similarEventsCount}
-                    </Text>
+                <View className="flex-row items-center gap-1">
+                  <View className="flex-row items-center gap-1 opacity-60">
+                    <View className="flex-row items-center gap-0.5 rounded-full bg-neutral-4/70 px-1 py-0.5">
+                      <Copy size={iconSize * 0.7} color="#627496" />
+                      <Text className="text-xs text-neutral-2">
+                        {similarEventsCount}
+                      </Text>
+                    </View>
                   </View>
                 </View>
               ) : null}
@@ -515,6 +519,7 @@ export function UserEventListItem(props: UserEventListItemProps) {
                   </EventMenu>
                 </>
               )}
+              {isPrivate ? <PrivateVisibilityBadge /> : null}
             </View>
           </View>
           {shouldShowCreator ? (

--- a/apps/web/components/EventCard.tsx
+++ b/apps/web/components/EventCard.tsx
@@ -31,6 +31,7 @@ export default function EventCard(props: {
   deleteButton?: React.ReactNode;
   onAddToCalendar?: () => void;
   eventMetadata?: EventMetadata;
+  visibilityBadge?: React.ReactNode;
 }) {
   const {
     eventImage,
@@ -52,6 +53,7 @@ export default function EventCard(props: {
     deleteButton,
     onAddToCalendar,
     eventMetadata,
+    visibilityBadge,
   } = props;
 
   const displayName = userDisplayName || (userName ? userName : "");
@@ -135,20 +137,25 @@ export default function EventCard(props: {
               )}
 
               {/* Location */}
-              {eventLocation.trim() && getGoogleMapsUrl(eventLocation) && (
-                <a
-                  href={getGoogleMapsUrl(eventLocation)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center justify-start gap-2 text-lg font-medium leading-none text-interactive-1 transition-colors hover:underline"
-                  aria-label={`Open ${eventLocation} in maps`}
-                >
-                  <MapPinned
-                    className="size-4 flex-shrink-0 text-interactive-1"
-                    aria-hidden="true"
-                  />
-                  <span className="min-w-0">{eventLocation}</span>
-                </a>
+              {(eventLocation.trim() || visibilityBadge) && (
+                <div className="flex flex-wrap items-center gap-2">
+                  {eventLocation.trim() && getGoogleMapsUrl(eventLocation) && (
+                    <a
+                      href={getGoogleMapsUrl(eventLocation)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group flex items-center justify-start gap-2 text-lg font-medium leading-none text-interactive-1 transition-colors hover:underline"
+                      aria-label={`Open ${eventLocation} in maps`}
+                    >
+                      <MapPinned
+                        className="size-4 flex-shrink-0 text-interactive-1"
+                        aria-hidden="true"
+                      />
+                      <span className="min-w-0">{eventLocation}</span>
+                    </a>
+                  )}
+                  {visibilityBadge}
+                </div>
               )}
             </div>
 

--- a/apps/web/components/EventDisplays.tsx
+++ b/apps/web/components/EventDisplays.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useUser } from "@clerk/nextjs";
 import { atcb_action } from "add-to-calendar-button-react";
-import { Copy, Earth, EyeOff, Instagram, MapPin } from "lucide-react";
+import { Copy, Instagram, MapPin } from "lucide-react";
 
 import type { DateInfo, EventMetadata, SimilarityDetails } from "@soonlist/cal";
 import type {
@@ -32,6 +32,7 @@ import { EditButton } from "./EditButton";
 import EventCard from "./EventCard";
 import { FollowEventButton } from "./FollowButtons";
 import { buildDefaultUrl } from "./ImageUpload";
+import { PrivateVisibilityBadge } from "./PrivateVisibilityBadge";
 import { SaveButton } from "./SaveButton";
 import { ShareButton } from "./ShareButton";
 import { UserAvatarMini } from "./UserAvatarMini";
@@ -279,6 +280,7 @@ function EventDetailsCard({
   timezone,
   location,
   description,
+  visibility,
   noLinks = false,
 }: {
   id: string;
@@ -291,6 +293,7 @@ function EventDetailsCard({
   timezone: string;
   description?: string;
   location?: string;
+  visibility: "public" | "private";
   noLinks?: boolean;
 }) {
   const { timezone: userTimezone } = useContext(TimezoneContext);
@@ -363,7 +366,7 @@ function EventDetailsCard({
             {name}
           </Link>
         )}
-        <div className="flex-start flex gap-2 pr-12 text-lg font-medium leading-none">
+        <div className="flex-start flex flex-wrap gap-2 pr-12 text-lg font-medium leading-none">
           {location && (
             <>
               {noLinks ? (
@@ -382,6 +385,7 @@ function EventDetailsCard({
               )}
             </>
           )}
+          {visibility === "private" ? <PrivateVisibilityBadge /> : null}
         </div>
       </div>
     </div>
@@ -462,11 +466,6 @@ function EventDetails({
   return (
     <div className="relative">
       <div className="mb-2 flex items-center">
-        {visibility === "private" ? (
-          <EyeOff className="mr-2 size-4 text-neutral-2" />
-        ) : (
-          <Earth className="mr-2 size-4 text-neutral-2" />
-        )}
         <DateAndTimeDisplay
           endDateInfo={endDateInfo}
           endTime={endTime}
@@ -490,7 +489,7 @@ function EventDetails({
         >
           {name}
         </Link>
-        <div className="text-xs">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
           {location && (
             <Link
               href={getGoogleMapsUrl(location)}
@@ -500,6 +499,7 @@ function EventDetails({
               <span className="inline">{location}</span>
             </Link>
           )}
+          {visibility === "private" ? <PrivateVisibilityBadge /> : null}
         </div>
 
         {/* TODO: 
@@ -628,8 +628,8 @@ function EventActionButtons({
           </Link>
         )}
         {visibility === "private" && (
-          <div className="text-lg font-medium leading-none text-neutral-1">
-            <EyeOff className="mr-2 inline size-4" /> Not discoverable
+          <div>
+            <PrivateVisibilityBadge className="text-sm" />
           </div>
         )}
         <Link
@@ -677,6 +677,7 @@ export function EventListItem(props: EventListItemProps) {
   const isFollowing = !!eventFollows.find(
     (item) => item.userId === clerkUser?.id,
   );
+  const isPrivate = visibility === "private";
   const image =
     event.images?.[3] ||
     (filePath ? buildDefaultUrl(props.filePath || "") : undefined);
@@ -928,18 +929,26 @@ export function EventListItem(props: EventListItemProps) {
               <div className="flex items-center gap-1">
                 <p className="text-xs font-medium text-neutral-2">{dateText}</p>
               </div>
-              {isOwner &&
+              {isPrivate ||
+              (isOwner &&
                 props.similarEvents &&
-                props.similarEvents.length > 0 && (
-                  <div className="flex items-center gap-1 opacity-60">
-                    <div className="flex items-center gap-1 rounded-full bg-neutral-4/70 px-2 py-0.5">
-                      <Copy className="size-3.5" />
-                      <span className="text-xs text-neutral-2">
-                        {props.similarEvents.length}
-                      </span>
-                    </div>
-                  </div>
-                )}
+                props.similarEvents.length > 0) ? (
+                <div className="flex items-center gap-1">
+                  {isPrivate ? <PrivateVisibilityBadge /> : null}
+                  {isOwner &&
+                    props.similarEvents &&
+                    props.similarEvents.length > 0 && (
+                      <div className="flex items-center gap-1 opacity-60">
+                        <div className="flex items-center gap-1 rounded-full bg-neutral-4/70 px-2 py-0.5">
+                          <Copy className="size-3.5" />
+                          <span className="text-xs text-neutral-2">
+                            {props.similarEvents.length}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                </div>
+              ) : null}
             </div>
 
             <h3 className="mb-1 truncate text-base font-bold text-neutral-1">
@@ -1086,6 +1095,7 @@ export function EventListItem(props: EventListItemProps) {
                 timezone={event.timeZone || DEFAULT_TIMEZONE}
                 location={event.location}
                 description={event.description}
+                visibility={visibility}
                 noLinks={true}
               />
             )}
@@ -1448,6 +1458,9 @@ export function EventPage(props: EventPageProps) {
       eventImage={image || null}
       onAddToCalendar={handleAddToCalendar}
       eventMetadata={props.eventMetadata}
+      visibilityBadge={
+        props.visibility === "private" ? <PrivateVisibilityBadge /> : null
+      }
       calendarButton={
         <CalendarButton
           event={event as ATCBActionEventConfig}

--- a/apps/web/components/PrivateVisibilityBadge.tsx
+++ b/apps/web/components/PrivateVisibilityBadge.tsx
@@ -1,0 +1,17 @@
+import { EyeOff } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+export function PrivateVisibilityBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full bg-neutral-4/70 px-2 py-0.5 text-xs font-medium text-neutral-2",
+        className,
+      )}
+    >
+      <EyeOff className="size-3" aria-hidden="true" />
+      Private
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
Language and UI indicators only: **Public** / **Private** model on feed cards, event detail, and overflow menu. Behavior unchanged (unlisted-style private events).

## Changes
- **Feed (Expo):** private events show eye-off + "Private" chip after action buttons; public shows nothing extra.
- **Event detail (Expo):** public has no visibility line; private shows gray row below location, matched spacing to location row, extra gap between location and private.
- **Menu (Expo):** `Make Private` (eye-off) / `Make public` (globe); same toggle mutation as before.
- **Web:** `PrivateVisibilityBadge` on list/detail where private; event detail page passes badge next to location when needed.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — copy and presentational UI only; visibility API unchanged.

## Testing
- `pnpm -F @soonlist/expo typecheck`
- `pnpm -F @soonlist/web typecheck`
- Targeted eslint on touched files (warnings only, pre-existing patterns in large files).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear Public/Private visibility indicators across Expo and Web. UI-only change; visibility behavior is unchanged (private = unlisted).

- **New Features**
  - Expo feed: private events show an eye-off “Private” chip after action buttons; public shows nothing extra.
  - Expo detail: adds a “Private” row below location for private events; removes “discoverable” wording/icons; visible to all viewers.
  - Expo menu: toggle now shows eye-off/globe icons; same mutation.
  - Web: adds `PrivateVisibilityBadge` to cards, lists, and event detail; rendered next to location/metadata when private. `EventCard` accepts a new `visibilityBadge` prop; `EventDetailsCard` now requires a `visibility` prop.

- **Bug Fixes**
  - Expo menu labels use consistent sentence case: “Make private” / “Make public”.

<sup>Written for commit b94c7e67df907230ba7c3f15bb39e4927555c99a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds UI-only Public/Private visibility indicators across Expo (feed cards, event detail, overflow menu) and Web (EventCard, EventListItem, EventDetailsCard, EventDetails). No visibility API or mutation logic is changed — the only behavioral shift is that the \"Private\" label is now shown to all viewers of a private event, not just the owner, which is consistent with the PR's stated intent.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely presentational changes with one minor capitalisation inconsistency.

All findings are P2 (style). The single note is inconsistent casing in the Expo menu labels ("Make Private" vs "Make public"), which has no functional impact. Logic, mutations, and data flow are unchanged.

apps/expo/src/components/EventMenu.tsx — capitalisation of toggle labels.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/app/event/[id]/index.tsx | Removes showDiscover/getPlanStatusFromUser guard; now shows "Private" label to any viewer of a private event (not just owner) — intentional per PR spec. |
| apps/expo/src/components/EventMenu.tsx | Renames toggle labels to "Make Private"/"Make public" with inconsistent capitalisation; switch-case logic is correct and functional. |
| apps/expo/src/components/PrivateVisibilityBadge.tsx | New Expo badge component — clean, minimal, correctly styled. |
| apps/expo/src/components/UserEventsList.tsx | Adds PrivateVisibilityBadge after action buttons for private events; similar-events count restructured into a sibling flex row. |
| apps/web/components/EventCard.tsx | Adds optional visibilityBadge prop rendered alongside location in a flex-wrap row; backward-compatible addition. |
| apps/web/components/EventDisplays.tsx | Integrates PrivateVisibilityBadge across EventListItem, EventDetailsCard, EventDetails, and EventActionButtons; removes old Earth/EyeOff inline icons; visibility prop made required on EventDetailsCard. |
| apps/web/components/PrivateVisibilityBadge.tsx | New web badge component — uses lucide EyeOff, cn utility, and semantic span tag; clean implementation. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Event visibility = private?] -->|Yes| B[Show PrivateVisibilityBadge]
    A -->|No| C[Show nothing extra]

    B --> D{Platform}
    D -->|Expo feed| E[Badge after action buttons\nUserEventsList]
    D -->|Expo detail| F[Badge below location row\nevent/id/index.tsx]
    D -->|Expo menu| G[Menu item: Make Public\nEventMenu]
    D -->|Web card| H[Badge next to location\nEventCard visibilityBadge prop]
    D -->|Web list item| I[Badge in metadata row\nEventDisplays EventListItem]
    D -->|Web detail| J[Badge next to location\nEventDisplays EventDetailsCard]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/expo/src/components/EventMenu.tsx:151
**Inconsistent capitalisation in toggle labels**

`"Make Private"` capitalises "Private" but `"Make public"` lowercases "public". The two labels should follow the same casing convention — either sentence-case for both or title-case for both. As written, the menu is visually inconsistent.

```suggestion
          title: event.visibility === "public" ? "Make Private" : "Make Public",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): Public/Private visibility labe..."](https://github.com/jaronheard/soonlist-turbo/commit/158b1b9a2b7b78ea8eece08c7b936747fb4035d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30569324)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->