### PR TITLE
Add event visibility settings with public/private defaults

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -364,6 +364,18 @@ const InitialLayout = () => {
             headerBackTitle: "Account",
           }}
         />
+        <Stack.Screen
+          name="settings/visibility"
+          options={{
+            title: "Default Visibility",
+            headerShown: true,
+            headerTransparent: false,
+            headerBackground: undefined,
+            headerStyle: { backgroundColor: "#F4F1FF" },
+            headerTintColor: "#5A32FB",
+            headerBackTitle: "Account",
+          }}
+        />
       </Stack.Protected>
     </Stack>
   );

--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -39,6 +39,7 @@ import {
   User,
 } from "~/components/icons";
 import { SettingsGroup, SettingsRow } from "~/components/settings/SettingsList";
+import { useToast } from "~/components/Toast";
 import { useCalendar } from "~/hooks/useCalendar";
 import { useShareMyList } from "~/hooks/useShareMyList";
 import { useSignOut } from "~/hooks/useSignOut";
@@ -93,7 +94,7 @@ function Hero({
       style={{
         backgroundColor: PURPLE_WASH,
         paddingTop: 4,
-        paddingBottom: 28,
+        paddingBottom: 14,
         paddingHorizontal: 20,
         alignItems: "center",
       }}
@@ -186,10 +187,7 @@ function Hero({
               }}
               numberOfLines={1}
             >
-              {shareHost}/
-              <Text style={{ fontWeight: "700", color: INK_0 }}>
-                {username}
-              </Text>
+              {shareHost}/{username}
             </Text>
             <Copy
               size={14}
@@ -242,6 +240,7 @@ export default function AccountScreen() {
   const { customerInfo, showProPaywallIfNeeded } = useRevenueCat();
   const signOut = useSignOut();
   const { requestShare } = useShareMyList();
+  const inAppToast = useToast();
 
   const userData = useQuery(
     api.users.getByUsername,
@@ -289,13 +288,13 @@ export default function AccountScreen() {
       try {
         await Clipboard.setStringAsync(url);
         void hapticSuccess();
-        toast.success("Link copied");
+        inAppToast.show({ message: "Link copied" });
       } catch (error) {
         logError("Error copying share link", error);
         toast.error("Failed to copy link");
       }
     })();
-  }, [username]);
+  }, [username, inAppToast]);
 
   const handleOpenVisibility = useCallback(() => {
     router.navigate("/settings/visibility");
@@ -537,7 +536,7 @@ export default function AccountScreen() {
           onEdit={handleOpenEdit}
         />
 
-        <View style={{ height: 14 }} />
+        <View style={{ height: 7 }} />
 
         <SettingsGroup
           header="EVENT DEFAULTS"

--- a/apps/expo/src/app/settings/account.tsx
+++ b/apps/expo/src/app/settings/account.tsx
@@ -11,6 +11,7 @@ import {
   View,
 } from "react-native";
 import * as Application from "expo-application";
+import * as Clipboard from "expo-clipboard";
 import { Redirect, router } from "expo-router";
 import * as StoreReview from "expo-store-review";
 import { useUser } from "@clerk/clerk-expo";
@@ -23,7 +24,9 @@ import {
   Bell,
   Calendar as CalendarIcon,
   Clock,
+  Copy,
   Eye,
+  Globe,
   HelpCircle,
   Instagram,
   Link as LinkIcon,
@@ -42,9 +45,11 @@ import { useSignOut } from "~/hooks/useSignOut";
 import { useRevenueCat } from "~/providers/RevenueCatProvider";
 import {
   useAppStore,
+  useDefaultEventVisibility,
   usePreferredCalendarApp,
   useSetPreferredCalendarApp,
 } from "~/store";
+import Config from "~/utils/config";
 import { hapticSuccess, toast } from "~/utils/feedback";
 import { logError } from "../../utils/errorLogging";
 import { getPlanStatusFromUser } from "../../utils/plan";
@@ -69,13 +74,17 @@ const TILE_COLORS = {
 function Hero({
   avatarUrl,
   displayName,
-  handle,
+  shareHost,
+  username,
+  onCopyLink,
   emoji,
   onEdit,
 }: {
   avatarUrl?: string;
   displayName: string;
-  handle: string;
+  shareHost: string;
+  username: string;
+  onCopyLink: () => void;
   emoji: string | null;
   onEdit: () => void;
 }) {
@@ -145,35 +154,67 @@ function Hero({
       >
         {displayName}
       </Text>
-      <Text
-        style={{
-          fontSize: 14,
-          color: INK_2,
-          marginTop: -2,
-        }}
-      >
-        {handle}
-      </Text>
+
+      {username ? (
+        <Pressable
+          onPress={onCopyLink}
+          accessibilityRole="button"
+          accessibilityLabel={`Copy ${shareHost}/${username} to clipboard`}
+          style={({ pressed }) => ({
+            marginTop: 8,
+            borderRadius: 999,
+            backgroundColor: "#FFFFFF",
+            shadowColor: "#162135",
+            shadowOpacity: 0.06,
+            shadowRadius: 2,
+            shadowOffset: { width: 0, height: 1 },
+            opacity: pressed ? 0.7 : 1,
+          })}
+        >
+          <View
+            style={{
+              height: 32,
+              paddingHorizontal: 14,
+              flexDirection: "row",
+              alignItems: "center",
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 14,
+                color: INK_2,
+              }}
+              numberOfLines={1}
+            >
+              {shareHost}/
+              <Text style={{ fontWeight: "700", color: INK_0 }}>
+                {username}
+              </Text>
+            </Text>
+            <Copy
+              size={14}
+              color={INK_2}
+              strokeWidth={2}
+              style={{ marginLeft: 8 }}
+            />
+          </View>
+        </Pressable>
+      ) : null}
 
       <Pressable
         onPress={onEdit}
         accessibilityRole="button"
         accessibilityLabel="Edit profile"
         style={({ pressed }) => ({
-          marginTop: 14,
+          marginTop: 12,
           borderRadius: 999,
-          backgroundColor: "#FFFFFF",
-          shadowColor: "#162135",
-          shadowOpacity: 0.06,
-          shadowRadius: 2,
-          shadowOffset: { width: 0, height: 1 },
           opacity: pressed ? 0.7 : 1,
         })}
       >
         <View
           style={{
-            height: 34,
-            paddingHorizontal: 16,
+            height: 28,
+            paddingHorizontal: 4,
             flexDirection: "row",
             alignItems: "center",
           }}
@@ -210,6 +251,7 @@ export default function AccountScreen() {
   const userTimezone = useAppStore((s) => s.userTimezone);
   const preferredCalendarApp = usePreferredCalendarApp();
   const setPreferredCalendarApp = useSetPreferredCalendarApp();
+  const defaultEventVisibility = useDefaultEventVisibility();
   const { calendarApps } = useCalendar();
 
   const resetOnboardingMutation = useMutation(api.users.resetOnboarding);
@@ -224,11 +266,39 @@ export default function AccountScreen() {
 
   const displayName =
     userData?.displayName || user?.username || user?.firstName || "Your name";
-  const handle = user?.username ? `@${user.username}` : "";
+  const username = user?.username ?? "";
   const emoji = userData?.emoji ?? null;
+
+  const shareHost = React.useMemo(() => {
+    try {
+      const { hostname } = new URL(Config.apiBaseUrl);
+      return hostname.replace(/^www\./, "");
+    } catch {
+      return "soonlist.com";
+    }
+  }, []);
 
   const handleOpenEdit = useCallback(() => {
     router.navigate("/settings/profile-edit");
+  }, []);
+
+  const handleCopyShareLink = useCallback(() => {
+    if (!username) return;
+    const url = `${Config.apiBaseUrl}/${username}`;
+    void (async () => {
+      try {
+        await Clipboard.setStringAsync(url);
+        void hapticSuccess();
+        toast.success("Link copied");
+      } catch (error) {
+        logError("Error copying share link", error);
+        toast.error("Failed to copy link");
+      }
+    })();
+  }, [username]);
+
+  const handleOpenVisibility = useCallback(() => {
+    router.navigate("/settings/visibility");
   }, []);
 
   const handleTogglePublicList = useCallback(
@@ -460,12 +530,27 @@ export default function AccountScreen() {
         <Hero
           avatarUrl={user?.imageUrl ?? undefined}
           displayName={displayName}
-          handle={handle}
+          shareHost={shareHost}
+          username={username}
+          onCopyLink={handleCopyShareLink}
           emoji={emoji}
           onEdit={handleOpenEdit}
         />
 
         <View style={{ height: 14 }} />
+
+        <SettingsGroup
+          header="EVENT DEFAULTS"
+          footer="Edit any event to override."
+        >
+          <SettingsRow
+            icon={Globe}
+            iconBg={TILE_COLORS.purple}
+            label="Visibility"
+            value={defaultEventVisibility === "public" ? "Public" : "Private"}
+            onPress={handleOpenVisibility}
+          />
+        </SettingsGroup>
 
         <SettingsGroup
           header="YOUR PUBLIC PROFILE"

--- a/apps/expo/src/app/settings/visibility.tsx
+++ b/apps/expo/src/app/settings/visibility.tsx
@@ -27,13 +27,13 @@ const OPTIONS: VisibilityOption[] = [
   {
     value: "public",
     label: "Public",
-    description: "Events appear on your public Soonlist by default.",
+    description: "Shown on your public Soonlist.",
     icon: Globe,
   },
   {
     value: "private",
     label: "Private",
-    description: "Events are only visible to you by default.",
+    description: "Hidden unless you share it.",
     icon: EyeOff,
   },
 ];

--- a/apps/expo/src/app/settings/visibility.tsx
+++ b/apps/expo/src/app/settings/visibility.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback } from "react";
+import { ScrollView, Text, TouchableHighlight, View } from "react-native";
+
+import type { EventVisibility } from "~/constants";
+import { Check, EyeOff, Globe } from "~/components/icons";
+import { SettingsGroup } from "~/components/settings/SettingsList";
+import {
+  useDefaultEventVisibility,
+  useSetDefaultEventVisibility,
+} from "~/store";
+import { hapticSelection } from "~/utils/feedback";
+
+const PAGE_BG = "#F2F2F7";
+const PURPLE = "#5A32FB";
+const INK_0 = "#162135";
+const SECONDARY_LABEL = "rgba(60,60,67,0.6)";
+const ROW_HIGHLIGHT = "rgba(60,60,67,0.08)";
+
+interface VisibilityOption {
+  value: EventVisibility;
+  label: string;
+  description: string;
+  icon: typeof Globe;
+}
+
+const OPTIONS: VisibilityOption[] = [
+  {
+    value: "public",
+    label: "Public",
+    description: "Events appear on your public Soonlist by default.",
+    icon: Globe,
+  },
+  {
+    value: "private",
+    label: "Private",
+    description: "Events are only visible to you by default.",
+    icon: EyeOff,
+  },
+];
+
+function VisibilityRow({
+  option,
+  selected,
+  onSelect,
+}: {
+  option: VisibilityOption;
+  selected: boolean;
+  onSelect: (value: EventVisibility) => void;
+}) {
+  const Icon = option.icon;
+  return (
+    <TouchableHighlight
+      onPress={() => onSelect(option.value)}
+      underlayColor={ROW_HIGHLIGHT}
+      accessibilityRole="button"
+      accessibilityLabel={option.label}
+      accessibilityState={{ selected }}
+    >
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          paddingVertical: 12,
+          paddingHorizontal: 16,
+          minHeight: 56,
+          gap: 12,
+          backgroundColor: "#FFFFFF",
+        }}
+      >
+        <Icon size={20} color={INK_0} strokeWidth={2} />
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{
+              fontSize: 17,
+              letterSpacing: -0.17,
+              color: INK_0,
+            }}
+          >
+            {option.label}
+          </Text>
+          <Text
+            style={{
+              fontSize: 13,
+              lineHeight: 18,
+              color: SECONDARY_LABEL,
+              marginTop: 2,
+            }}
+          >
+            {option.description}
+          </Text>
+        </View>
+        {selected ? <Check size={20} color={PURPLE} strokeWidth={2.5} /> : null}
+      </View>
+    </TouchableHighlight>
+  );
+}
+
+export default function VisibilityScreen() {
+  const visibility = useDefaultEventVisibility();
+  const setVisibility = useSetDefaultEventVisibility();
+
+  const handleSelect = useCallback(
+    (next: EventVisibility) => {
+      if (next !== visibility) {
+        setVisibility(next);
+        void hapticSelection();
+      }
+    },
+    [visibility, setVisibility],
+  );
+
+  return (
+    <View style={{ flex: 1, backgroundColor: PAGE_BG }}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingTop: 14, paddingBottom: 40 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <SettingsGroup footer="Edit any event to override.">
+          {OPTIONS.map((option) => (
+            <VisibilityRow
+              key={option.value}
+              option={option}
+              selected={visibility === option.value}
+              onSelect={handleSelect}
+            />
+          ))}
+        </SettingsGroup>
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/expo/src/constants.ts
+++ b/apps/expo/src/constants.ts
@@ -6,7 +6,7 @@
 export const DEFAULT_TIMEZONE = "America/Los_Angeles";
 
 // Default visibility setting for new events
-export const DEFAULT_VISIBILITY = "private" as const;
+export const DEFAULT_VISIBILITY = "public" as const;
 
 export type EventVisibility = "public" | "private";
 

--- a/apps/expo/src/constants.ts
+++ b/apps/expo/src/constants.ts
@@ -8,5 +8,7 @@ export const DEFAULT_TIMEZONE = "America/Los_Angeles";
 // Default visibility setting for new events
 export const DEFAULT_VISIBILITY = "private" as const;
 
+export type EventVisibility = "public" | "private";
+
 // Storage keys
 export const DISCOVER_CODE_KEY = "soonlist_discover_code";

--- a/apps/expo/src/hooks/useCreateEvent.ts
+++ b/apps/expo/src/hooks/useCreateEvent.ts
@@ -4,9 +4,12 @@ import { useMutation } from "convex/react";
 
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { DEFAULT_VISIBILITY } from "~/constants";
 import { useOneSignal } from "~/providers/OneSignalProvider";
-import { useAppStore, useUserTimezone } from "~/store";
+import {
+  useAppStore,
+  useDefaultEventVisibility,
+  useUserTimezone,
+} from "~/store";
 import { useInFlightEventStore } from "~/store/useInFlightEventStore";
 import { logError } from "~/utils/errorLogging";
 import { hapticError } from "~/utils/feedback";
@@ -58,6 +61,7 @@ export function useCreateEvent() {
   const addPendingBatchId = useInFlightEventStore((s) => s.addPendingBatchId);
   const { hasNotificationPermission } = useOneSignal();
   const userTimezone = useUserTimezone();
+  const defaultVisibility = useDefaultEventVisibility();
 
   // Batch mutations for all image events (single and multiple)
   const createEventBatch = useMutation(api.ai.createEventBatch);
@@ -107,7 +111,7 @@ export function useCreateEvent() {
             username,
             lists: [],
             timezone: userTimezone,
-            visibility: DEFAULT_VISIBILITY,
+            visibility: defaultVisibility,
             sendNotification,
           });
 
@@ -137,7 +141,7 @@ export function useCreateEvent() {
             username,
             lists: [],
             timezone: userTimezone,
-            visibility: DEFAULT_VISIBILITY,
+            visibility: defaultVisibility,
             sendNotification,
           });
 
@@ -155,7 +159,7 @@ export function useCreateEvent() {
             username,
             lists: [],
             timezone: userTimezone,
-            visibility: DEFAULT_VISIBILITY,
+            visibility: defaultVisibility,
             sendNotification,
           });
 
@@ -188,6 +192,7 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       userTimezone,
+      defaultVisibility,
       addWorkflowId,
       eventFromUrl,
       eventFromText,
@@ -222,7 +227,7 @@ export function useCreateEvent() {
           username,
           lists: [],
           timezone: userTimezone,
-          visibility: "private",
+          visibility: defaultVisibility,
           sendNotification,
         });
 
@@ -281,6 +286,7 @@ export function useCreateEvent() {
       hasNotificationPermission,
       addPendingBatchId,
       userTimezone,
+      defaultVisibility,
       setIsCapturing,
       setIsImageLoading,
     ],

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -505,12 +505,31 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: "app-storage",
+      version: 1,
       storage: createJSONStorage(() => AsyncStorage),
       // Do not persist ephemeral flags like discoverAccessOverride
       partialize: (state) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { discoverAccessOverride, ...rest } = state;
         return rest;
+      },
+      // v0 → v1: existing installs predate the EVENT_DEFAULTS picker, so we
+      // pin them to the legacy "private" default. Only truly-new installs
+      // (no persisted state) fall through to the initial value, which is now
+      // "public".
+      migrate: (persistedState, version) => {
+        if (
+          version < 1 &&
+          persistedState &&
+          typeof persistedState === "object" &&
+          !("defaultEventVisibility" in persistedState)
+        ) {
+          return {
+            ...(persistedState as Record<string, unknown>),
+            defaultEventVisibility: "private",
+          } as AppState;
+        }
+        return persistedState as AppState;
       },
     },
   ),

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -3,8 +3,10 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import type { EventVisibility } from "~/constants";
 import type { OnboardingData, OnboardingStep } from "~/types/onboarding";
 import type { CalendarApp } from "~/utils/calendarAppDetection";
+import { DEFAULT_VISIBILITY } from "~/constants";
 import { getUserTimeZone } from "./utils/dates";
 
 // Helper function to create a stable timestamp (rounded to 15-minute intervals)
@@ -77,6 +79,10 @@ interface AppState {
   // Calendar preferences
   preferredCalendarApp: CalendarApp | null;
   setPreferredCalendarApp: (app: CalendarApp | null) => void;
+
+  // Event default preferences
+  defaultEventVisibility: EventVisibility;
+  setDefaultEventVisibility: (visibility: EventVisibility) => void;
 
   // Stable timestamp for query filtering
   stableTimestamp: string;
@@ -177,6 +183,11 @@ export const useAppStore = create<AppState>()(
       // Calendar preferences
       preferredCalendarApp: null,
       setPreferredCalendarApp: (app) => set({ preferredCalendarApp: app }),
+
+      // Event default preferences
+      defaultEventVisibility: DEFAULT_VISIBILITY,
+      setDefaultEventVisibility: (visibility) =>
+        set({ defaultEventVisibility: visibility }),
 
       // No ephemeral discover flag; UI listens to Clerk user metadata
 
@@ -341,6 +352,7 @@ export const useAppStore = create<AppState>()(
           filter: "upcoming",
           intentParams: null,
           preferredCalendarApp: null,
+          defaultEventVisibility: DEFAULT_VISIBILITY,
           // Ensure discover override never persists across global reset
           discoverAccessOverride: false,
           addEventState: {
@@ -386,6 +398,7 @@ export const useAppStore = create<AppState>()(
           filter: "upcoming",
           intentParams: null,
           preferredCalendarApp: null,
+          defaultEventVisibility: DEFAULT_VISIBILITY,
           // Ensure discover override never persists across logout
           discoverAccessOverride: false,
           addEventState: {
@@ -587,6 +600,12 @@ export const usePreferredCalendarApp = () =>
   useAppStore((state) => state.preferredCalendarApp);
 export const useSetPreferredCalendarApp = () =>
   useAppStore((state) => state.setPreferredCalendarApp);
+
+// Event default visibility selectors
+export const useDefaultEventVisibility = () =>
+  useAppStore((state) => state.defaultEventVisibility);
+export const useSetDefaultEventVisibility = () =>
+  useAppStore((state) => state.setDefaultEventVisibility);
 
 // Pending follow selectors (for deferred deep link follow intent)
 export const usePendingFollowUsername = () =>

--- a/apps/expo/src/store.ts
+++ b/apps/expo/src/store.ts
@@ -398,7 +398,9 @@ export const useAppStore = create<AppState>()(
           filter: "upcoming",
           intentParams: null,
           preferredCalendarApp: null,
-          defaultEventVisibility: DEFAULT_VISIBILITY,
+          // Preserve so the v0→v1 migration's "private" pin (and any
+          // explicit user choice) survives sign-out/sign-in.
+          defaultEventVisibility: state.defaultEventVisibility,
           // Ensure discover override never persists across logout
           discoverAccessOverride: false,
           addEventState: {

--- a/packages/backend/convex/ai.ts
+++ b/packages/backend/convex/ai.ts
@@ -590,6 +590,7 @@ export const createEventBatch = mutation({
       userId: args.userId,
       totalCount: args.totalCount ?? args.images.length,
       timezone: args.timezone,
+      visibility: args.visibility,
     });
 
     // Only schedule processing if we have images
@@ -716,7 +717,7 @@ export const processAdditionalBatchImages = internalAction({
               timezone: timezone,
               comment: undefined,
               lists: [],
-              visibility: "private" as const,
+              visibility: batch.visibility,
               userId: args.userId,
               username: batch.username ?? args.userId,
               batchId: args.batchId,

--- a/packages/backend/convex/eventBatches.ts
+++ b/packages/backend/convex/eventBatches.ts
@@ -27,6 +27,7 @@ export const createBatch = internalMutation({
     userId: v.string(),
     totalCount: v.number(),
     timezone: v.string(),
+    visibility: v.optional(v.union(v.literal("public"), v.literal("private"))),
   },
   handler: async (ctx, args) => {
     // Validate timezone
@@ -51,6 +52,7 @@ export const createBatch = internalMutation({
       userId: args.userId,
       username: user?.username,
       timezone: args.timezone,
+      visibility: args.visibility,
       totalCount: args.totalCount,
       successCount: 0,
       failureCount: 0,
@@ -143,7 +145,7 @@ export const getBatchInfo = internalQuery({
       ...batch,
       comment: undefined, // Events don't store comments
       lists: [], // Events don't store lists directly
-      visibility: DEFAULT_VISIBILITY, // Private by default,
+      visibility: batch.visibility ?? DEFAULT_VISIBILITY,
     };
   },
 });

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -294,6 +294,7 @@ export default defineSchema({
     userId: v.string(),
     username: v.optional(v.string()),
     timezone: v.optional(v.string()), // User's timezone for proper event processing
+    visibility: v.optional(v.union(v.literal("public"), v.literal("private"))),
     totalCount: v.number(),
     successCount: v.number(),
     failureCount: v.number(),


### PR DESCRIPTION
## Summary
This PR adds a new event visibility settings feature that allows users to set a default visibility (public or private) for newly created events. The default has been changed from "private" to "public" for new installations, with a migration path for existing users.

## Key Changes

- **New Visibility Settings Screen** (`apps/expo/src/app/settings/visibility.tsx`)
  - Created a dedicated settings page for managing default event visibility
  - Displays two options: Public (shown on public Soonlist) and Private (hidden unless shared)
  - Includes visual feedback with icons and selection indicators

- **Updated Account Settings** (`apps/expo/src/app/settings/account.tsx`)
  - Added visibility setting to the account screen under "EVENT DEFAULTS" section
  - Enhanced profile hero section with copyable share link functionality
  - Integrated clipboard support for sharing profile URLs

- **State Management** (`apps/expo/src/store.ts`)
  - Added `defaultEventVisibility` and `setDefaultEventVisibility` to app store
  - Implemented store persistence with migration logic (v0 → v1)
  - Migration ensures existing users default to "private" while new installs use "public"
  - Added selector hooks for accessing visibility state

- **Event Creation Integration** (`apps/expo/src/hooks/useCreateEvent.ts`)
  - Updated event creation to use the user's default visibility setting instead of hardcoded value
  - Applies default visibility across all event creation paths (text, URL, image, batch)

- **Constants Update** (`apps/expo/src/constants.ts`)
  - Changed `DEFAULT_VISIBILITY` from "private" to "public"
  - Added `EventVisibility` type definition for type safety

- **Backend Schema Updates** (`packages/backend/convex/`)
  - Added optional `visibility` field to event batch schema
  - Updated batch creation and AI processing to handle visibility parameter

- **Navigation** (`apps/expo/src/app/_layout.tsx`)
  - Added new route for visibility settings screen with appropriate styling

## Notable Implementation Details

- The migration strategy preserves backward compatibility by pinning existing installations to "private" visibility while allowing new users to benefit from the new "public" default
- Share link copying includes haptic feedback and toast notifications for user confirmation
- The visibility setting is optional in the backend schema to maintain compatibility during rollout

https://claude.ai/code/session_01VzWYzqf1QFLmh54rSVXirf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a default event visibility setting with a simple Public/Private picker. New installs default to public; existing installs stay private. Event creation and batch processing now honor this default, and the account screen adds a copyable public profile link.

- **New Features**
  - Visibility settings screen and “Event Defaults → Visibility” in Account; persisted as `defaultEventVisibility` with selectors; new installs use "public".
  - All event creation paths (text, URL, image, batch) use the stored default; backend accepts optional `visibility` on batches and threads it through processing.
  - Account hero shows a tappable `soonlist.com/<username>` pill that copies the link with haptics and toast.

- **Bug Fixes**
  - Persist `visibility` on `eventBatches` and use it in image processing so the chosen default isn’t dropped.
  - Preserve `defaultEventVisibility` across logout so migrated or chosen defaults stay intact.

<sup>Written for commit 159a2c30b6a8dfe78f09b1cdf35bebfd00afa256. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a user-configurable default event visibility (public/private) stored in the Zustand persisted store, surfaced via a new settings screen and an "EVENT DEFAULTS" section on the account page. The migration strategy correctly pins existing users (v0 store) to "private" while new installs receive the new "public" default, and visibility is threaded end-to-end from the frontend store through Convex batch creation and async processing.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only a minor P2 finding around URL construction.

All P0/P1 paths are clean — the migration logic is correct, visibility flows end-to-end through the stack, and the backend schema is backward-compatible. The single P2 finding (potential double-slash in clipboard URL) caps the score at 4.

apps/expo/src/app/settings/account.tsx — clipboard URL construction.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/store.ts | Adds defaultEventVisibility to persisted state with a correct v0→v1 migration that pins existing users to 'private' while new installs get the 'public' default. |
| apps/expo/src/app/settings/account.tsx | Adds copy-share-link functionality and an EVENT DEFAULTS section; minor risk of double-slash in clipboard URL if apiBaseUrl has a trailing slash. |
| apps/expo/src/app/settings/visibility.tsx | New settings screen for default event visibility; clean implementation with accessible TouchableHighlight rows and haptic feedback on selection. |
| apps/expo/src/hooks/useCreateEvent.ts | Replaces all hardcoded DEFAULT_VISIBILITY/'private' references with the store-sourced defaultVisibility, consistently applied across all creation paths. |
| packages/backend/convex/eventBatches.ts | Adds optional visibility to batch creation and correctly falls back to backend DEFAULT_VISIBILITY ('private') in getBatchInfo for batches without an explicit value. |
| packages/backend/convex/ai.ts | Threads args.visibility through to createBatch and replaces the hardcoded 'private' in processAdditionalBatchImages with batch.visibility (non-null via getBatchInfo's fallback). |
| packages/backend/convex/schema.ts | Adds optional visibility union field to the eventBatches table; backward-compatible with existing records. |
| apps/expo/src/constants.ts | Changes DEFAULT_VISIBILITY from 'private' to 'public' and extracts an EventVisibility type; backend constant remains 'private' as a conservative server-side fallback. |
| apps/expo/src/app/_layout.tsx | Registers the new settings/visibility route with consistent header styling matching the rest of the settings stack. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VisibilityScreen
    participant AppStore
    participant useCreateEvent
    participant ConvexMutation as Convex: createEventBatch
    participant createBatch as Convex: createBatch (internal)
    participant processImages as Convex: processAdditionalBatchImages

    User->>VisibilityScreen: Select Public or Private
    VisibilityScreen->>AppStore: setDefaultEventVisibility(value)
    AppStore-->>AppStore: persist to AsyncStorage (v1)

    User->>useCreateEvent: Create event (text/URL/image)
    useCreateEvent->>AppStore: useDefaultEventVisibility()
    AppStore-->>useCreateEvent: defaultVisibility
    useCreateEvent->>ConvexMutation: createEventBatch({ visibility })
    ConvexMutation->>createBatch: createBatch({ visibility })
    createBatch-->>createBatch: store visibility in eventBatches table
    ConvexMutation->>processImages: schedule processBatchImages({ visibility })
    processImages->>processImages: getBatchInfo visibility ?? DEFAULT_VISIBILITY
    processImages-->>processImages: createEvent with resolved visibility
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/expo/src/app/settings/account.tsx:299
**Potential double-slash in copied URL**

If `Config.apiBaseUrl` (from `EXPO_PUBLIC_API_BASE_URL`) has a trailing slash, the constructed URL becomes `https://soonlist.com//username`. The displayed label uses only the hostname so it won't show the issue, but the clipboard value would be malformed.

```suggestion
const url = `${Config.apiBaseUrl.replace(/\/$/, "")}/${username}`;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(expo): pin existing installs to priv..."](https://github.com/jaronheard/soonlist-turbo/commit/21aae40104badd415f58da57905b0fc32be3dec3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30572015)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->