### PR TITLE
feat(expo): consistent close + icon buttons across modal routes

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -31,6 +31,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import AuthAndTokenSync from "~/components/AuthAndTokenSync";
 import { ForceUpdateScreen } from "~/components/ForceUpdateScreen";
+import { HeaderCloseButton } from "~/components/HeaderIconButton";
 import { PostHogIdentityTracker } from "~/components/PostHogIdentityTracker";
 import { ToastProvider } from "~/components/Toast";
 import { useAppsFlyerDeepLink } from "~/hooks/useAppsFlyerDeepLink";
@@ -262,6 +263,7 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "Event Details",
             headerShown: true,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen
@@ -270,6 +272,7 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "List Details",
             headerShown: true,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen
@@ -278,6 +281,7 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "",
             headerShown: true,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen
@@ -296,6 +300,7 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#FFFFFF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen
@@ -307,6 +312,7 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#FFFFFF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen
@@ -318,6 +324,7 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#F4F1FF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
+            headerLeft: () => <HeaderCloseButton />,
           }}
         />
         <Stack.Screen

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -263,7 +263,9 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "Event Details",
             headerShown: true,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen
@@ -272,7 +274,9 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "List Details",
             headerShown: true,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen
@@ -281,7 +285,9 @@ const InitialLayout = () => {
             presentation: "modal",
             title: "",
             headerShown: true,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen
@@ -300,7 +306,9 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#FFFFFF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen
@@ -312,7 +320,9 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#FFFFFF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen
@@ -324,7 +334,9 @@ const InitialLayout = () => {
             headerStyle: { backgroundColor: "#F4F1FF" },
             headerTintColor: "#5A32FB",
             headerShadowVisible: false,
-            headerLeft: () => <HeaderCloseButton />,
+            headerLeft: ({ tintColor }) => (
+              <HeaderCloseButton tintColor={tintColor} />
+            ),
           }}
         />
         <Stack.Screen

--- a/apps/expo/src/app/event/[id]/edit.tsx
+++ b/apps/expo/src/app/event/[id]/edit.tsx
@@ -26,12 +26,10 @@ import { api } from "@soonlist/backend/convex/_generated/api";
 import { Button } from "~/components/Button";
 import { DatePickerField, TimePickerField } from "~/components/date-picker";
 import {
-  Check,
-  EyeOff,
-  Globe2,
-  Image as ImageIcon,
-  X,
-} from "~/components/icons";
+  HeaderCloseButton,
+  HeaderIconButton,
+} from "~/components/HeaderIconButton";
+import { Check, EyeOff, Globe2, Image as ImageIcon } from "~/components/icons";
 import ImageUploadSpinner from "~/components/ImageUploadSpinner";
 import { InputTags } from "~/components/InputTags";
 import LoadingSpinner from "~/components/LoadingSpinner";
@@ -423,25 +421,16 @@ export default function EditEventScreen() {
                 selectedImage === originalImage) ||
               !isValid;
             return (
-              <TouchableOpacity
+              <HeaderIconButton
+                accessibilityLabel="Save event"
                 onPress={() => void handleSubmit(onSubmit)()}
                 disabled={isDisabled}
-                activeOpacity={0.6}
-                style={{ opacity: isDisabled ? 0.4 : 1 }}
               >
-                <View className="rounded-full p-1">
-                  <Check size={20} color="#5A32FB" strokeWidth={2.5} />
-                </View>
-              </TouchableOpacity>
+                <Check size={18} color="#5A32FB" strokeWidth={2.5} />
+              </HeaderIconButton>
             );
           },
-          headerLeft: () => (
-            <TouchableOpacity onPress={() => router.back()} activeOpacity={0.6}>
-              <View className="rounded-full p-1">
-                <X size={20} color="#5A32FB" strokeWidth={2.5} />
-              </View>
-            </TouchableOpacity>
-          ),
+          headerLeft: () => <HeaderCloseButton />,
         }}
       />
       <KeyboardAvoidingView

--- a/apps/expo/src/app/event/[id]/edit.tsx
+++ b/apps/expo/src/app/event/[id]/edit.tsx
@@ -430,7 +430,9 @@ export default function EditEventScreen() {
               </HeaderIconButton>
             );
           },
-          headerLeft: () => <HeaderCloseButton />,
+          headerLeft: ({ tintColor }) => (
+            <HeaderCloseButton tintColor={tintColor} />
+          ),
         }}
       />
       <KeyboardAvoidingView

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -16,13 +16,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Image as ExpoImage } from "expo-image";
-import {
-  Link,
-  router,
-  Stack,
-  useLocalSearchParams,
-  useNavigation,
-} from "expo-router";
+import { Link, router, Stack, useLocalSearchParams } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 import { useQuery } from "convex/react";
 
@@ -33,7 +27,10 @@ import { getTimezoneAbbreviation } from "@soonlist/cal";
 
 import { AttributionGrid } from "~/components/AttributionGrid";
 import { EventMenu } from "~/components/EventMenu";
-import { HeaderLogo } from "~/components/HeaderLogo";
+import {
+  HeaderCloseButton,
+  HeaderIconButton,
+} from "~/components/HeaderIconButton";
 import {
   CalendarPlus,
   EyeOff,
@@ -94,23 +91,6 @@ function getPlatformUrl(
   }
 }
 
-// Sized to match Apple's observed iOS 26 Liquid Glass nav-bar buttons
-// (Mail, Safari, Music): ~36pt visible capsule, ~18pt SF Symbol, ≥44pt hit
-// area via hitSlop. Apple has not published exact point values; these match
-// stock-app appearance per design research.
-const headerButtonStyle = {
-  width: 36,
-  height: 36,
-  borderRadius: 18,
-  alignItems: "center" as const,
-  justifyContent: "center" as const,
-  backgroundColor: "#FFFFFF",
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 1 },
-  shadowOpacity: 0.06,
-  shadowRadius: 2,
-};
-
 export default function Page() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
@@ -123,10 +103,6 @@ function EventDetail({ id }: { id: string }) {
   const { width } = Dimensions.get("window");
   const insets = useSafeAreaInsets();
   const { user: currentUser } = useUser();
-  const navigation = useNavigation();
-
-  // Check if we can go back in the navigation stack
-  const canGoBack = navigation.canGoBack();
 
   // Store the aspect ratio for the main event image
   const [imageAspectRatio, setImageAspectRatio] = useState<number | null>(null);
@@ -221,14 +197,6 @@ function EventDetail({ id }: { id: string }) {
     return `${eventImage}?w=160&h=160&fit=cover&f=webp&q=80`;
   }, [event?.event?.images]);
 
-  // Build the header-left UI if we can't go back
-  const HeaderLeft = useCallback(() => {
-    if (!canGoBack) {
-      return <HeaderLogo />;
-    }
-    return null;
-  }, [canGoBack]);
-
   // Build the header-right UI if we have data
   const HeaderRight = useCallback(() => {
     if (!event) return null;
@@ -237,15 +205,12 @@ function EventDetail({ id }: { id: string }) {
 
     return (
       <View className="flex-row items-center gap-4">
-        <TouchableOpacity
-          onPress={() => void openShareSheet("event_detail")}
+        <HeaderIconButton
           accessibilityLabel="Share event"
-          accessibilityRole="button"
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          style={headerButtonStyle}
+          onPress={() => void openShareSheet("event_detail")}
         >
           <ShareIcon size={18} color="#5A32FB" />
-        </TouchableOpacity>
+        </HeaderIconButton>
         <EventMenu
           event={event}
           isOwner={isOwner}
@@ -254,15 +219,9 @@ function EventDetail({ id }: { id: string }) {
           onDelete={handleDeleteAndRedirect}
           iconColor="#5A32FB"
         >
-          <TouchableOpacity
-            activeOpacity={0.6}
-            accessibilityLabel="Event menu"
-            accessibilityRole="button"
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            style={headerButtonStyle}
-          >
+          <HeaderIconButton accessibilityLabel="Event menu">
             <MoreVertical size={18} color="#5A32FB" />
-          </TouchableOpacity>
+          </HeaderIconButton>
         </EventMenu>
       </View>
     );
@@ -384,7 +343,7 @@ function EventDetail({ id }: { id: string }) {
       <Stack.Screen
         options={{
           headerRight: HeaderRight,
-          headerLeft: !canGoBack ? HeaderLeft : undefined,
+          headerLeft: () => <HeaderCloseButton />,
           headerTransparent: true,
           headerTintColor: "#5A32FB",
           headerTitleStyle: { color: "#5A32FB" },

--- a/apps/expo/src/app/event/[id]/index.tsx
+++ b/apps/expo/src/app/event/[id]/index.tsx
@@ -343,7 +343,9 @@ function EventDetail({ id }: { id: string }) {
       <Stack.Screen
         options={{
           headerRight: HeaderRight,
-          headerLeft: () => <HeaderCloseButton />,
+          headerLeft: ({ tintColor }) => (
+            <HeaderCloseButton tintColor={tintColor} />
+          ),
           headerTransparent: true,
           headerTintColor: "#5A32FB",
           headerTitleStyle: { color: "#5A32FB" },

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -1,13 +1,14 @@
-import { Text, TouchableOpacity, View } from "react-native";
+import { Text, View } from "react-native";
 import QRCode from "react-native-qrcode-svg";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Image as ExpoImage } from "expo-image";
-import { router, useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams } from "expo-router";
 import { useQuery } from "convex/react";
 
 import type { AddToCalendarButtonProps } from "@soonlist/cal/types";
 import { api } from "@soonlist/backend/convex/_generated/api";
 
-import { X } from "~/components/icons";
+import { HeaderCloseButton } from "~/components/HeaderIconButton";
 import { Logo } from "~/components/Logo";
 import Config from "~/utils/config";
 
@@ -17,6 +18,7 @@ function appendImageParams(url: string, params: string) {
 }
 
 export default function QRModal() {
+  const insets = useSafeAreaInsets();
   const { id } = useLocalSearchParams<{ id: string }>();
 
   const event = useQuery(api.events.get, { eventId: id });
@@ -52,14 +54,9 @@ export default function QRModal() {
       )}
 
       <View className="flex-1 items-center justify-center p-4">
-        <TouchableOpacity
-          className="absolute right-4 top-12 z-10 rounded-full bg-interactive-1 p-2"
-          onPress={() =>
-            router.canGoBack() ? router.back() : router.navigate("/feed")
-          }
-        >
-          <X size={24} color="white" />
-        </TouchableOpacity>
+        <View className="absolute left-4 z-10" style={{ top: insets.top + 8 }}>
+          <HeaderCloseButton />
+        </View>
 
         <View className="items-center rounded-3xl bg-white/95 p-8 shadow-sm">
           <View>

--- a/apps/expo/src/app/event/[id]/qr.tsx
+++ b/apps/expo/src/app/event/[id]/qr.tsx
@@ -55,7 +55,7 @@ export default function QRModal() {
 
       <View className="flex-1 items-center justify-center p-4">
         <View className="absolute left-4 z-10" style={{ top: insets.top + 8 }}>
-          <HeaderCloseButton />
+          <HeaderCloseButton tintColor="#fff" />
         </View>
 
         <View className="items-center rounded-3xl bg-white/95 p-8 shadow-sm">

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { InteractionManager, Pressable, View } from "react-native";
+import { InteractionManager, View } from "react-native";
 import Animated from "react-native-reanimated";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import { useUser } from "@clerk/clerk-expo";
 
 import { CaptureEventButton } from "~/components/CaptureEventButton";
 import { EventPreview } from "~/components/EventPreview";
-import { X } from "~/components/icons";
+import { HeaderCloseButton } from "~/components/HeaderIconButton";
 import { NewEventHeader } from "~/components/NewEventHeader";
 import { useCreateEvent } from "~/hooks/useCreateEvent";
 import { useInitializeInput } from "~/hooks/useInitializeInput";
@@ -142,14 +142,7 @@ export default function NewShareScreen() {
               handleDescribePress={() => setActiveInput("describe")}
             />
           ),
-          headerRight: () => (
-            <Pressable
-              onPress={() => router.back()}
-              className="rounded-full bg-transparent py-4"
-            >
-              <X size={24} color="#fff" />
-            </Pressable>
-          ),
+          headerLeft: () => <HeaderCloseButton />,
         }}
       />
 

--- a/apps/expo/src/app/new.tsx
+++ b/apps/expo/src/app/new.tsx
@@ -142,7 +142,9 @@ export default function NewShareScreen() {
               handleDescribePress={() => setActiveInput("describe")}
             />
           ),
-          headerLeft: () => <HeaderCloseButton />,
+          headerLeft: ({ tintColor }) => (
+            <HeaderCloseButton tintColor={tintColor} />
+          ),
         }}
       />
 

--- a/apps/expo/src/components/HeaderIconButton.tsx
+++ b/apps/expo/src/components/HeaderIconButton.tsx
@@ -1,0 +1,86 @@
+import type { Href } from "expo-router";
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { router } from "expo-router";
+
+import { X } from "~/components/icons";
+
+// iOS 26 Liquid Glass headers wrap nav-bar items in their own shared
+// backdrop capsule, so we don't paint our own background/shadow here —
+// just give the icon a 36pt centered hit area to match SF-Symbol sizing.
+const HEADER_ICON_BUTTON_STYLE = {
+  width: 36,
+  height: 36,
+  alignItems: "center" as const,
+  justifyContent: "center" as const,
+};
+
+const HEADER_BUTTON_HIT_SLOP = {
+  top: 8,
+  bottom: 8,
+  left: 8,
+  right: 8,
+};
+
+interface HeaderIconButtonProps {
+  onPress?: () => void;
+  accessibilityLabel: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  style?: React.ComponentProps<typeof TouchableOpacity>["style"];
+}
+
+export function HeaderIconButton({
+  onPress,
+  accessibilityLabel,
+  children,
+  disabled,
+  style,
+}: HeaderIconButtonProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      hitSlop={HEADER_BUTTON_HIT_SLOP}
+      activeOpacity={0.6}
+      style={[
+        HEADER_ICON_BUTTON_STYLE,
+        disabled ? { opacity: 0.4 } : null,
+        style,
+      ]}
+    >
+      {children}
+    </TouchableOpacity>
+  );
+}
+
+interface HeaderCloseButtonProps {
+  tintColor?: string;
+  fallbackHref?: Href;
+  accessibilityLabel?: string;
+}
+
+export function HeaderCloseButton({
+  tintColor = "#5A32FB",
+  fallbackHref = "/feed",
+  accessibilityLabel = "Close",
+}: HeaderCloseButtonProps) {
+  const handlePress = () => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(fallbackHref);
+    }
+  };
+
+  return (
+    <HeaderIconButton
+      accessibilityLabel={accessibilityLabel}
+      onPress={handlePress}
+    >
+      <X size={18} color={tintColor} strokeWidth={2.5} />
+    </HeaderIconButton>
+  );
+}

--- a/apps/expo/src/components/HeaderIconButton.tsx
+++ b/apps/expo/src/components/HeaderIconButton.tsx
@@ -57,13 +57,16 @@ export function HeaderIconButton({
 }
 
 interface HeaderCloseButtonProps {
+  // Accept undefined so callers can forward React Navigation's
+  // `headerLeft: ({ tintColor }) => ...` arg directly. When unset, falls
+  // back to the screen's `headerTintColor` value (purple by default).
   tintColor?: string;
   fallbackHref?: Href;
   accessibilityLabel?: string;
 }
 
 export function HeaderCloseButton({
-  tintColor = "#5A32FB",
+  tintColor,
   fallbackHref = "/feed",
   accessibilityLabel = "Close",
 }: HeaderCloseButtonProps) {
@@ -80,7 +83,7 @@ export function HeaderCloseButton({
       accessibilityLabel={accessibilityLabel}
       onPress={handlePress}
     >
-      <X size={18} color={tintColor} strokeWidth={2.5} />
+      <X size={18} color={tintColor ?? "#5A32FB"} strokeWidth={2.5} />
     </HeaderIconButton>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a top-left close button to every modal route for consistency.
- Routes all icon header buttons through a new shared `HeaderIconButton` so the styling lives in one place.
- Buttons render naked (no white background or shadow) — iOS 26's Liquid Glass nav-bar wraps them in its own backdrop capsule, so painting our own circle was creating a "button-in-a-button" look.

## Why

Modal routes had inconsistent header treatments: some had a custom close button (QR), some had none (most), and the share/menu buttons on event details lived as inline styles that no other screen shared. This unifies the pattern.

## What changed

**New** — `apps/expo/src/components/HeaderIconButton.tsx`
- `HeaderIconButton` — 36×36 hit area, accessibility-wired, disabled state.
- `HeaderCloseButton` — wraps it with an `X`. `canGoBack()`-aware with a `/feed` fallback for deep-link entries.

**Modal screens — close button on top-left, icon buttons via shared component**

| Screen | Change |
|---|---|
| `event/[id]/index.tsx` | Removed inline `headerButtonStyle`; share/menu now use `HeaderIconButton`. Replaced the conditional `HeaderLogo` (when `!canGoBack`) with always-visible `HeaderCloseButton`. |
| `event/[id]/qr.tsx` | Replaced custom purple X (top-right, absolute) with `HeaderCloseButton` at top-left over the safe area. |
| `event/[id]/edit.tsx` | `headerLeft` X → `HeaderCloseButton`; `headerRight` Check → `HeaderIconButton`. |
| `new.tsx` | Moved close from `headerRight` to `headerLeft` via `HeaderCloseButton`. |
| `_layout.tsx` | Added `headerLeft: () => <HeaderCloseButton />` to: `event/[id]/index`, `list/[slug]`, `[username]/index`, `event/[id]/saved-by`, `lists/subscribed`, `lists/discover`. |

## Intentionally not changed

- **Settings screens** (`settings/account` and friends) — not declared as modals; they're pushed routes with a system Back chevron, so a close X would be doubled-up.
- **`share-setup`** — formSheet with a drag grabber, different dismissal model.

## Test plan

- [ ] Open event details from the feed → close button appears top-left, share + menu top-right; tapping close dismisses the modal.
- [ ] Open event details from a deep link (no back stack) → close still works (falls back to `/feed`).
- [ ] Open list, user profile, saved-by, subscribed lists, discover lists, edit event, new event, QR code → all show a close button top-left, all dismiss correctly.
- [ ] Verify close + share/menu buttons sit inside the iOS nav-bar backdrop capsule (no double-circle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consistent top-left close button to all modal routes and unifies header icon buttons via a shared component. Also forwards navigator `tintColor` so icons always have correct contrast.

- **New Features**
  - Added `HeaderIconButton` and `HeaderCloseButton` (36×36 hit area, a11y, disabled state). Close is `canGoBack()`-aware with a `/feed` fallback.
  - Modal headers now use these buttons and render without custom backgrounds/shadows to avoid the double-capsule look.
  - Applied across event details, list details, profiles, saved-by, subscribed/discover lists, edit event (save check), new event, and the QR modal (safe-area left).

- **Bug Fixes**
  - Forwarded React Navigation’s `tintColor` to `HeaderCloseButton` at all `headerLeft` call sites so the close icon matches each screen’s `headerTintColor`.
  - Fixed the invisible close on `new.tsx` (now white on the purple header); QR modal explicitly uses `tintColor="#fff"` since it hides the system header.

<sup>Written for commit 2ea0b9c3bb891734e94f32dab6385d6f530728a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `HeaderIconButton` / `HeaderCloseButton` component and applies it across all modal routes to give every screen a consistent top-left close button, removing per-screen inline styles.

- **P1 — invisible close button in `new.tsx`**: `HeaderCloseButton` defaults to `tintColor=\"#5A32FB\"`, but `new.tsx` sets `headerStyle: { backgroundColor: \"#5A32FB\" }` — the purple X on a purple background is effectively invisible. The original code explicitly used `color=\"#fff\"`; the fix is to pass `tintColor=\"#fff\"` (or forward the navigator's `tintColor` prop) at this call site.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without fixing the invisible close button in the new-event screen.

One P1 bug: the close button in new.tsx is rendered with a purple icon on a purple background, making it invisible to users. All other screens look correct.

apps/expo/src/app/new.tsx — close button color must be #fff to contrast against the purple header background.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/expo/src/components/HeaderIconButton.tsx | New shared component — well-structured with correct accessibility, hit-slop, and canGoBack fallback; tintColor not auto-forwarded from navigator which causes a contrast bug in new.tsx |
| apps/expo/src/app/new.tsx | Purple close button rendered on a purple header background — effectively invisible; original used white (#fff); needs tintColor="#fff" passed explicitly |
| apps/expo/src/app/_layout.tsx | Adds HeaderCloseButton as headerLeft to six modal screens; all use matching tintColor defaults, no conflicts |
| apps/expo/src/app/event/[id]/index.tsx | Replaces inline headerButtonStyle + canGoBack-conditional HeaderLogo with shared HeaderIconButton/HeaderCloseButton; logic is correct |
| apps/expo/src/app/event/[id]/edit.tsx | Swaps custom X/Check TouchableOpacity buttons for shared HeaderIconButton/HeaderCloseButton; disabled opacity logic preserved |
| apps/expo/src/app/event/[id]/qr.tsx | Moves close button from top-right absolute to top-left via HeaderCloseButton in content layer; uses insets.top correctly; purple tint on image-backed background may have contrast issues depending on event photo |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Modal Screen headerLeft] --> B[HeaderCloseButton]
    B -->|canGoBack = true| C[router.back]
    B -->|canGoBack = false| D["router.replace(fallbackHref)"]
    D -->|default fallback| E["/feed"]

    F[HeaderIconButton] --> G["TouchableOpacity 36x36 + hitSlop 8pt"]
    G --> H{disabled?}
    H -->|yes| I[opacity 0.4]
    H -->|no| J["full opacity, activeOpacity 0.6"]

    subgraph "new.tsx contrast bug"
      K["headerStyle bg #5A32FB"] -.->|same color| L["HeaderCloseButton tintColor #5A32FB default"]
      L --> M["X invisible on purple background"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/expo/src/app/new.tsx:145
**Invisible close button on purple header**

`HeaderCloseButton` defaults to `tintColor="#5A32FB"`, but this screen sets `headerStyle: { backgroundColor: "#5A32FB" }` — a purple icon on a purple background is effectively invisible. The original button used `color="#fff"` for precisely this reason. Pass `tintColor="#fff"` (or forward the navigator's `tintColor` prop) to restore visibility.

```suggestion
          headerLeft: ({ tintColor }) => <HeaderCloseButton tintColor={tintColor ?? "#fff"} />,
```

### Issue 2 of 2
apps/expo/src/components/HeaderIconButton.tsx:63-85
**`tintColor` from navigator not forwarded at call sites**

React Navigation passes `{ tintColor, canGoBack }` as props to any `headerLeft` render function. All usages in this PR use `() => <HeaderCloseButton />`, silently dropping the navigator-provided tint. This is the root cause of the `new.tsx` contrast bug and will silently break again for any future screen that sets a non-default `headerTintColor`. Consider documenting or enforcing the forwarding pattern:

```tsx
// at every headerLeft call site
headerLeft: ({ tintColor }) => <HeaderCloseButton tintColor={tintColor} />,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(expo): consistent close + icon butt..."](https://github.com/jaronheard/soonlist-turbo/commit/b6db8f22677ac54b2e6a6b75978d1eb2019bcdd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30586797)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->